### PR TITLE
`pkgs` should be an array, not a string 

### DIFF
--- a/datadog/recipes/dd-handler.rb
+++ b/datadog/recipes/dd-handler.rb
@@ -23,10 +23,10 @@ ENV["DATADOG_HOST"] = node[:datadog][:url]
 # Install dependency library
 pkgs = value_for_platform(
     ["redhat","centos","fedora","scientific"] =>
-        {"default" => "ruby-devel" },
+        {"default" => ["ruby-devel"] },
     [ "debian", "ubuntu" ] =>
-        {"default" => "ruby-dev" },
-    "default" => "ruby-dev"
+        {"default" => ["ruby-dev"] },
+    "default" => ["ruby-dev"]
   )
 
 pkgs.each do |pkg|


### PR DESCRIPTION
Ruby 1.9 does not define `each` for strings
