### PR TITLE
Changing version constraint slightly, making pessimistic instead

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.1.1"
 
 depends          "apt"
-depends          "chef_handler", ">= 1.0.6"
+depends          "chef_handler", "~> 1.0.6"
 depends          "yum"
 
 recipe "datadog::default", "Default"


### PR DESCRIPTION
The affect of this should be that version 1.0.8 and 1.0.10 will be allowed, while 1.1.0 will not.
