### PR TITLE
Don't clobber other cookbook's attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -79,7 +79,7 @@ default['datadog']['graphite_port'] = 17124
 #default['haproxy']['stats_password'] = nil
 
 # mysql
-#default['mysql']['server'] = nil        # localhost
+default['datadog']['mysql']['server'] = nil        # localhost
 #default['mysql']['user'] = "readonly"
 #default['mysql']['pass'] = "readonly"
 

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -44,9 +44,9 @@ haproxy_password: <%= node['haproxy']['stats_password'] %>
   <% end %>
 <% end %>
 
-<% if node['mysql'] && node['mysql']['server'] %>
+<% if node['datadog']['mysql']['server'] %>
 # mysql
-mysql_server: <%= node['mysql']['server'] %>
+mysql_server: <%= node['datadog']['mysql']['server'] %>
 mysql_user: <%= node['mysql']['user'] %>
 mysql_pass: <%= node['mysql']['pass'] %>
 <% end %>


### PR DESCRIPTION
Fixes #23

comment out default values in attributes/default.rb.  Instead of setting default values (which can override the real cookbooks' default values), be more paranoid about checking for existence of those nodes in the template.

Btw, there is another way to handle this:

If you prefer the template code to be simple and clean, without all the 'if' checks, you can create a new recipe in your cookbook which sets the value of these attributes to default values only if the attribute is not already set.  Then include that recipe before you run the template.

The advantage of this approach (which is advocated by opscode: http://community.opscode.com/questions/77) is that it can be run either at recipe compilation or recipe convergence time, rather than during attribute compilation.  This ensures that all cookbooks have set their up their attributes.  Also, if cookbooks set attributes during the recipe convergence phase, this honors the run-list order: your recipe will see any attributes set by recipes executed before this one, which is the intuitive behavior.
