### PR TITLE
add flexible configuration through node attributes

### DIFF
--- a/datadog/README.md
+++ b/datadog/README.md
@@ -37,6 +37,7 @@ Attributes
 * `node[:datadog][:debug]` 			= Will trigger heavy logging to /tmp/dd-agent.log
 * `node[:datadog][:use_ec2_instance_id]` = Whether to use the instance-id in lieu of hostname when running on EC2. No effect on non-EC2 servers.
 * `node[:datadog][:use_mount]`      = Whether to use the mount point instead of the device name for all I/O metrics.
+* `node[:datadog][:conf_lines]`     = A hash of extra lines to specify in datadog.conf.
 
 apache
 -------

--- a/datadog/templates/default/datadog.conf.erb
+++ b/datadog/templates/default/datadog.conf.erb
@@ -14,6 +14,10 @@ use_ec2_instance_id: <%= node[:datadog][:use_ec2_instance_id] ? "yes": "no" %>
 use_mount: <%= node[:datadog][:use_mount] ? "yes" : "no"  %>
 listen_port: <%= node[:datadog][:agent_port] %>
 
+<% node[:datadog][:conf_lines].each do |key, value| -%>
+<%= key %>: <%= value %>
+<% end -%>
+
 <% if node[:datadog][:graphite] %>
 graphite_listen_port: <%= node[:datadog][:graphite_port] %>
 <% end %>


### PR DESCRIPTION
you would use this to specify configurations through chef that are not
currently achievable through chef configuration, for example, in a role:

```
default_attributes(
  "datadog" => {
    "conf_lines" => {
      "memcache_instance_1" => "localhost:1234:my_tag"
    }
  }
)
```

Caveat emptor: this makes it possible to specify invalid, possibly unparseable configuration.
