### PR TITLE
add flexible configuration through node attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Attributes
 * `node['datadog']['use_ec2_instance_id']` = Whether to use the instance-id in lieu of hostname when running on EC2. No effect on non-EC2 servers.
 * `node['datadog']['use_mount']`           = Whether to use the mount point instead of the device name for all I/O metrics.
 * `node['datadog']['tags']`                = List of Datadog tags you want to apply to this host
-* `node[:datadog][:conf_lines]`            = A hash of extra lines to specify in datadog.conf.
+* `node['datadog']['conf_lines']`            = A hash of extra lines to specify in datadog.conf.
 
 apache
 -------

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -15,7 +15,7 @@ use_mount: <%= node['datadog']['use_mount'] ? "yes" : "no"  %>
 listen_port: <%= node['datadog']['agent_port'] %>
 tags: <%= node['datadog']['tags'] %>
 
-<% node[:datadog][:conf_lines].each do |key, value| -%>
+<% node['datadog']['conf_lines'].each do |key, value| -%>
 <%= key %>: <%= value %>
 <% end -%>
 


### PR DESCRIPTION
you would use this to specify configurations through chef that are not
currently achievable through chef configuration, for example, in a role:

```
default_attributes(
  "datadog" => {
    "conf_lines" => {
      "memcache_instance_1" => "localhost:1234:my_tag"
    }
  }
)
```

Caveat emptor: this makes it possible to specify invalid, possibly unparseable configuration.
