### PR TITLE
Fall back for older versions of Ubuntu that don't have python 2.6

### DIFF
--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -42,7 +42,12 @@ when "debian", "ubuntu"
     end
   end
 
-  package "datadog-agent"
+  # datadog-agent requires python2.6, not available on LTS till 10.04
+  if (node['platform'] == "ubuntu") and (node['platform_version'].to_f <= 8.04)
+    package "datadog-agent-base"
+  else
+    package "datadog-agent"
+  end
 
 when "redhat", "centos", "scientific", "amazon"
   # Depending on the version, deploy a package    


### PR DESCRIPTION
Running this on a Ubuntu 8.04 box, comes with python2.5
