### PR TITLE
don't set tags for the host in recipe[datadog::dd-agent]

### DIFF
--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -88,6 +88,10 @@ end
 #
 raise "Add a ['datadog']['api_key'] attribute to configure this node's Datadog Agent." if node['datadog'] && node['datadog']['api_key'].nil?
 
+if not node.run_list.recipes.include?("datadog::dd-handler")
+  Chef::Log.warn "To set host tags, you must use recipe[datadog::dd-handler]"
+end
+
 template "/etc/dd-agent/datadog.conf" do
   owner "root"
   group "root"

--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -25,13 +25,17 @@ if(Gem::Version.new(Chef::VERSION) < Gem::Version.new('0.10.9'))
   # This method ensures that the gem will be available for loading on the first run
   # TODO: Remove once 0.10.8 is fully end-of-life
   r = gem_package "chef-handler-datadog" do
+    version ">= 0.2.0"
     action :nothing
   end
-  r.run_action(:install)
+  r.run_action(:upgrade)
   Gem.clear_paths
 else
   # The chef_gem provider was introduced in Chef 0.10.10
-  chef_gem "chef-handler-datadog"
+  chef_gem "chef-handler-datadog" do
+    version ">= 0.2.0"
+    action :upgrade
+  end
 end
 require 'chef/handler/datadog'
 

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -13,7 +13,6 @@ hostname: <%= node.name %>
 use_ec2_instance_id: <%= node['datadog']['use_ec2_instance_id'] ? "yes": "no" %>
 use_mount: <%= node['datadog']['use_mount'] ? "yes" : "no"  %>
 listen_port: <%= node['datadog']['agent_port'] %>
-tags: <%= node['datadog']['tags'] %>
 
 <% if !node['datadog']['dogstreams'].empty? %>
 dogstreams: <%= node['datadog']['dogstreams'].join(', ') %>


### PR DESCRIPTION
a new version of the chef datadog handler will set tags from this
attribute instead. in case the user doesn't have
recipe[datadog::dd-handler] installed, issue a warning

Reissue of #33, as requested.
