### PR TITLE
add `node['datadog']['agent_version']` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Attributes
 * `node['datadog']['use_mount']`           = Whether to use the mount point instead of the device name for all I/O metrics.
 * `node['datadog']['tags']`                = List of Datadog tags you want to apply to this host
 * `node['datadog']['dogstreams']`          = List of Dogstreams (see [Guide to Log Parsing](http://docs.datadoghq.com/guides/logs/) for details).
+* `node['datadog']['agent_version']        = Sets the datadog agent version to install (default: latest available version)
 
 apache
 -------
@@ -167,6 +168,9 @@ We are not making use of data_bags in this recipe at this time, as it is unlikel
 
 Changes/Roadmap
 ===============
+## v0.2.0
+* Added `node['datadog']['agent_version']` attribute
+
 ## v0.1.3
 * Work-around for COOK-2171
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,6 +37,9 @@ default['datadog']['tags'] = ""
 default['datadog']['aptrepo'] = "http://apt.datadoghq.com"
 default['datadog']['yumrepo'] = "http://yum.datadoghq.com/rpm"
 
+# Agent Version
+default['datadog']['agent_version'] = nil
+
 # Boolean to enable debug_mode, which outputs massive amounts of log messages 
 # to the /tmp/ directory.
 default['datadog']['debug'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "package@datadoghq.com"
 license          "Apache 2.0"
 description      "Installs/Configures datadog components"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.3"
+version          "0.2.0"
 
 depends          "apt"
 depends          "chef_handler", "~> 1.0.6"

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -47,9 +47,13 @@ when "debian", "ubuntu"
 
   # datadog-agent requires python2.6, not available on LTS till 10.04
   if (node['platform'] == "ubuntu") and (node['platform_version'].to_f <= 8.04)
-    package "datadog-agent-base"
+    package "datadog-agent-base" do
+      version node['datadog']['agent_version']
+    end
   else
-    package "datadog-agent"
+    package "datadog-agent" do
+      version node['datadog']['agent_version']
+    end
   end
 
 when "redhat", "centos", "scientific", "amazon"
@@ -65,9 +69,13 @@ when "redhat", "centos", "scientific", "amazon"
 
   # datadog-agent requires python2.6, not available on RH5 by default
   if node['platform_version'].to_i <= 5
-    package "datadog-agent-base"
+    package "datadog-agent-base" do
+      version node['datadog']['agent_version']
+    end
   elsif node['platform_version'].to_i >= 6
-    package "datadog-agent"
+    package "datadog-agent" do
+      version node['datadog']['agent_version']
+    end
   end
 end
 


### PR DESCRIPTION
if this attribute is left unset, the existing behavior of "install the
latest version the first time the recipe is run, then never change it
again" is maintained.
