### PR TITLE
Fix inconsistency in elasticsearch config file template

### DIFF
--- a/templates/default/elastic.yaml.erb
+++ b/templates/default/elastic.yaml.erb
@@ -1,6 +1,6 @@
 instances:
   <% @instances.each do |i| -%>
-  - url: <%= i.url %>
+  - url: <%= i["url"] %>
   <% end %>
 
 # Nothing to configure below


### PR DESCRIPTION
With this change you can use the ruby 1.9 syntax for declaring
hash {a: "b"}.
Using this syntax would trigger this kind of error during chef
run :
## Chef::Mixin::Template::TemplateError

undefined method `url' for
{"url"=>"http://localhost:9200"}:Mash
