### PR TITLE
support Nagios log file integration

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -84,6 +84,9 @@ default['datadog']['syslog']['udp'] = false
 default['datadog']['syslog']['host'] = nil
 default['datadog']['syslog']['port'] = nil
 
+# Nagios log file integration
+default['datadog']['nagios_log'] = nil
+
 # For service-specific configuration, use the integration recipes included
 # in this cookbook, and apply them to the appropirate node's run list.
 # Read more at http://docs.datadoghq.com/

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -52,3 +52,8 @@ log_to_syslog: <%= node['datadog']['syslog']['active'] ? 'yes' : 'no' %>
 syslog_host: <%= node['datadog']['syslog']['host'] %>
 syslog_port: <%= node['datadog']['syslog']['port'] %>
 <% end -%>
+
+<% if node['datadog']['nagios_log'] -%>
+# Nagios log file integration
+nagios_log: <%= node['datadog']['nagios_log'] %>
+<% end -%>


### PR DESCRIPTION
This is necessary because the Nagios integration requires modifying the `datadog.conf`, but the file is reset by the provided template on the next chef run.
