### PR TITLE
Additionally catch ArgumentError; Fixes #79

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,6 +47,8 @@ begin
   default['datadog']['install_base'] = Gem::Version.new(node['languages']['python']['version']) < Gem::Version.new('2.6.0')
 rescue NoMethodError # nodes['languages']['python'] == nil
   Chef::Log.warn 'no version of python found'
+rescue ArgumentError
+  Chef::Log.warn "could not parse python version string: #{node['languages']['python']['version']}"
 end
 
 # Chef handler version


### PR DESCRIPTION
This ensures the cookbook is still usable even if the Python version 
string is not parsable by `Gem::Version`. This occurs with certain 
Debian/Ubuntu Python version strings like `2.7.1+`.
