### PR TITLE
do not ignore attributes

### DIFF
--- a/templates/default/jmx.yaml.erb
+++ b/templates/default/jmx.yaml.erb
@@ -7,40 +7,40 @@ instances:
     password: <%= i["password"] %>
   <% if i.key?("include") || i.key?("exclude") -%>
     conf:
-    <% i["include"].each do |c| -%>
-    - include:
-      <% if c.key?("domain") -%>
-      domain: <%= c["domain"] %>
+      <% i["include"].each do |c| -%>
+      - include:
+          <% if c.key?("domain") -%>
+          domain: <%= c["domain"] %>
+          <% end -%>
+          <% if c.key?("bean") -%>
+          bean: <%= c["bean"] %>
+          <% end -%>
+          <% if c.key?("attributes") -%>
+          attribute:
+            <% c["attributes"].each do |a| -%>
+            attribute<%= c["attributes"].index(a) %>:
+              metric_type: <%= a["metric_type"] %>
+              alias: <%= a["alias"] %>
+            <% end -%>
+          <% end -%>
       <% end -%>
-      <% if c.key?("bean") -%>
-      bean: <%= c["bean"] %>
+      <% i["exclude"].each do |c| -%>
+      - exclude:
+          <% if c.key?("domain") -%>
+          domain: <%= c["domain"] %>
+          <% end -%>
+          <% if c.key?("bean") -%>
+          bean: <%= c["bean"] %>
+          <% end -%>
+          <% if c.key?("attributes") -%>
+          attribute:
+            <% c["attributes"].each do |a| -%>
+            attribute<%= c["attributes"].index(a) %>:
+              metric_type: <%= a["metric_type"] %>
+              alias: <%= a["alias"] %>
+            <% end -%>
+          <% end -%>
       <% end -%>
-      <% if c.key?("attributes") -%>
-      attribute:
-        <% c["attributes"].each do |a| -%>
-        attribute<%= c["attributes"].index(a) %>:
-          metric_type: <%= a["metric_type"] %>
-          alias: <%= a["alias"] %>
-        <% end -%>
-      <% end -%>
-    <% end -%>
-    <% i["exclude"].each do |c| -%>
-    - exclude:
-      <% if c.key?("domain") -%>
-      domain: <%= c["domain"] %>
-      <% end -%>
-      <% if c.key?("bean") -%>
-      bean: <%= c["bean"] %>
-      <% end -%>
-      <% if c.key?("attributes") -%>
-      attribute:
-        <% c["attributes"].each do |a| -%>
-        attribute<%= c["attributes"].index(a) %>:
-          metric_type: <%= a["metric_type"] %>
-          alias: <%= a["alias"] %>
-        <% end -%>
-      <% end -%>
-    <% end -%>
   <% end -%>
 <% end -%>
 


### PR DESCRIPTION
The jmx.yaml.erb file has a small typo which causes it to ignore attributes. This fixes that issue. I didn't notice any tests for the jmx.yaml file...

I also realized that the structure of the yaml file doesn't appear to fully support both invocations of the attributes referenced [here](http://docs.datadoghq.com/integrations/java/).

I was thinking it would be helpful if the attributes key could be an array or a hash. The array would be a list of strings, naming attributes. The hash would be a hash of hashes, the key would define the attribute, and the hash would define the metric type and alias. If that's agreeable, I could add that to this PR or make a separate one (and update the Vagrantfile).
