### PR TITLE
datadog::repository is not compatible withm yum 3.0.0

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -38,5 +38,7 @@ when "rhel"
     description "datadog"
     url node['datadog']['yumrepo']
     action :add
+    # see https://github.com/DataDog/chef-datadog/issues/89
+    gpgcheck false if respond_to? :gpgcheck
   end
 end


### PR DESCRIPTION
The default value for `gpgkey` has changed in the yum cookbook 3.0.0. It is now set to `true` by default. 

This will generate the following yum config:

```
[datadog]
name=datadog
baseurl=http://yum.datadoghq.com/rpm
enabled=1
gpgcheck=1
sslverify=1
```

With `gpgcheck=1`, `datadog::repository` fails with:
`Package meld3-0.6.5-1.noarch.rpm is not signed`

I opened a ticket and submitted a pull request to change the default value back to the previous behavior:
- https://tickets.opscode.com/browse/COOK-4266
- https://github.com/opscode-cookbooks/yum/pull/66

Another alternative would be to set `gpgcheck` to `false` in `datadog::repository`. See my commit in this pull-request.

Meanwhile a workaround is to rewind the `yum_repository[datadog]` resource by adding this in your recipe:

``` ruby

include_recipe 'datadog::dd-agent'

chef_gem 'chef-rewind'
require 'chef/rewind'

rewind 'yum_repository[datadog]' do
  gpgcheck false
end
```
