### PR TITLE
introduce chef_handler_enable to control the chef reporting

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -52,6 +52,9 @@ end
 # Chef handler version
 default['datadog']['chef_handler_version'] = nil
 
+# Enable the Chef handler to report to datadog
+default['datadog']['chef_handler_enable'] = true
+
 # Boolean to enable debug_mode, which outputs massive amounts of log messages
 # to the /tmp/ directory.
 default['datadog']['debug'] = false

--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -40,13 +40,15 @@ end
 require 'chef/handler/datadog'
 
 # Create the handler to run at the end of the Chef execution
-chef_handler "Chef::Handler::Datadog" do
-  source "chef/handler/datadog"
-  arguments [
-    :api_key => node['datadog']['api_key'],
-    :application_key => node['datadog']['application_key'],
-    :use_ec2_instance_id => node['datadog']['use_ec2_instance_id']
-  ]
-  supports :report => true, :exception => true
-  action :nothing
-end.run_action(:enable)
+if node['datadog']['chef_handler_enable']
+  chef_handler "Chef::Handler::Datadog" do
+    source "chef/handler/datadog"
+    arguments [
+      :api_key => node['datadog']['api_key'],
+      :application_key => node['datadog']['application_key'],
+      :use_ec2_instance_id => node['datadog']['use_ec2_instance_id']
+    ]
+    supports :report => true, :exception => true
+    action :nothing
+  end.run_action(:enable)
+end


### PR DESCRIPTION
Controlling the agent stop and start is not enough to prevent data to be send from a host to datadog.
The chef handler reports directly via the gem, so we need another flag : `node[:datadog][:chef_handler_enable]` 
