### PR TITLE
set gpgcheck to false for yum repository - packages are not signed

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -37,6 +37,7 @@ when "rhel"
     name "datadog"
     description "datadog"
     url node['datadog']['yumrepo']
+    gpgcheck false
     action :add
   end
 end


### PR DESCRIPTION
Packages are not signed in yum repo, so they fail to install.

Example: recipe[datadog::dd-agent] fails to install.
