### PR TITLE
Support optional datadog events for haproxy check

### DIFF
--- a/recipes/haproxy.rb
+++ b/recipes/haproxy.rb
@@ -7,7 +7,8 @@ include_recipe "datadog::dd-agent"
 #                                     {
 #                                       :url => "http://localhost/stats_url",
 #                                       :username => "username",
-#                                       :password => "secret"
+#                                       :password => "secret",
+#                                       :status_check => true
 #                                     }
 #                                    ]
 

--- a/templates/default/haproxy.yaml.erb
+++ b/templates/default/haproxy.yaml.erb
@@ -5,6 +5,9 @@ instances:
     username: <%= i['username'] %>
     password: <%= i['password'] %>
     <% end -%>
+    <% if i.key?('status_check') -%>
+    status_check: True
+    <% end -%>
   <% end -%>
 
 # Nothing to configure below


### PR DESCRIPTION
The haproxy check that ships with datadog agent can optionally create events. That option is not currently supported in the yaml config shipped by chef-datadog; let's make it so.
