### PR TITLE
Added `Service-specific` configuration to datadog.conf.erb so that the `device_blacklist_re` can be configurable.

### DIFF
--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -50,6 +50,24 @@ dogstatsd_interval: <%= node['datadog']['dogstatsd_interval'] %>
 dogstatsd_normalize: <%= node['datadog']['dogstatsd_normalize'] %>
 <% end -%>
 
+<% if node['datadog']['device_blacklist_re'] -%>
+# ========================================================================== #
+# Service-specific configuration #
+# ========================================================================== #
+
+# -------------------------------------------------------------------------- #
+# Disk #
+# -------------------------------------------------------------------------- #
+
+# Some infrastrucures have many constantly changing virtual devices (e.g. folks
+# running constantly churning linux containers) whose metrics aren't
+# interesting for datadog. To filter out a particular pattern of devices
+# from collection, configure a regex here:
+# device_blacklist_re: .*\/dev\/mapper\/lxc-box.*
+
+device_blacklist_re: <%= node['datadog']['device_blacklist_re'] -%>
+<% end -%>
+
 # ========================================================================== #
 # Logging
 # ========================================================================== #


### PR DESCRIPTION
Modified- templates/default/datadog.conf.erb:
Added Service-specific configuration so that the `device_blacklist_re` can be configurable.
https://github.com/DataDog/dd-agent/pull/615
