### PR TITLE
Add trailing slash to yum repo attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -39,7 +39,7 @@ default['datadog']['autorestart'] = false
 # Repository configuration
 default['datadog']['installrepo'] = true
 default['datadog']['aptrepo'] = "http://apt.datadoghq.com"
-default['datadog']['yumrepo'] = "http://yum.datadoghq.com/rpm"
+default['datadog']['yumrepo'] = "http://yum.datadoghq.com/rpm/"
 
 # Agent Version
 default['datadog']['agent_version'] = nil


### PR DESCRIPTION
The lack of a trailing slash results in yum.datadoghq.com/rpm redirect to localhost/rpm.  With the trailing slash it works fine.
