### PR TITLE
add recipe for removing the agent.

### DIFF
--- a/recipes/remove-dd-agent.rb
+++ b/recipes/remove-dd-agent.rb
@@ -1,0 +1,5 @@
+
+package 'datadog-agent' do
+  action :purge
+end
+


### PR DESCRIPTION
Some people may use the cookbook during their evaluation period, and it's best for everyone, including DataDog, if they can easily remove the agent if they decide not to continue use of the service after the trial.
