### PR TITLE
allow yum repo to be modified via attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -39,7 +39,8 @@ default['datadog']['autorestart'] = false
 # Repository configuration
 default['datadog']['installrepo'] = true
 default['datadog']['aptrepo'] = "http://apt.datadoghq.com"
-default['datadog']['yumrepo'] = "http://yum.datadoghq.com/rpm/"
+default['yum']['datadog']['description'] = "datadog"
+default['yum']['datadog']['baseurl'] = "http://yum.datadoghq.com/rpm/"
 
 # Agent Version
 default['datadog']['agent_version'] = nil

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -34,10 +34,9 @@ when "rhel"
   include_recipe "yum"
 
   yum_repository "datadog" do
-    name "datadog"
-    description "datadog"
-    url node['datadog']['yumrepo']
+    description node['yum']['datadog']['description']
+    baseurl node['yum']['datadog']['baseurl']
     gpgcheck false if respond_to? :gpgcheck
-    action :add
+    action :create
   end
 end


### PR DESCRIPTION
This PR allows a customized baseurl for the datadog yum repo. This may be useful if, eg, you mirror the repo behind a firewall
