### PR TITLE
Use provider action upgrade if pinning to a version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "package@datadoghq.com"
 license          "Apache 2.0"
 description      "Installs/Configures datadog components"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.2.0'
+version          '1.2.1'
 
 %w{
   amazon

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -41,11 +41,13 @@ end
 
 if node['datadog']['install_base']
   package "datadog-agent-base" do
+    options "--force-yes" if node['datadog']['agent_version']
     version node['datadog']['agent_version']
     action node['datadog']['agent_version'] ? :upgrade : :install
   end
 else
   package "datadog-agent" do
+    options "--force-yes" if node['datadog']['agent_version']
     version node['datadog']['agent_version']
     action node['datadog']['agent_version'] ? :upgrade : :install
   end


### PR DESCRIPTION
We had not had agent version set.  When trying to set it, ran into an apt-get install error wanting --force-yes.  I think the :upgrade action will take care of this. 

We're on ubuntu 10.04 and 12.04.  Have no way to test other debian.
