### PR TITLE
Need to force-yes on version updates

### DIFF
--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -43,13 +43,11 @@ if node['datadog']['install_base']
   package "datadog-agent-base" do
     options "--force-yes" if node['datadog']['agent_version']
     version node['datadog']['agent_version']
-    action node['datadog']['agent_version'] ? :upgrade : :install
   end
 else
   package "datadog-agent" do
     options "--force-yes" if node['datadog']['agent_version']
     version node['datadog']['agent_version']
-    action node['datadog']['agent_version'] ? :upgrade : :install
   end
 end
 


### PR DESCRIPTION
apt package resource does not handle update installs without a force-yes, at least on ubuntu.
