### PR TITLE
Update keyserver url for debian OS

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -22,7 +22,7 @@ when "debian"
   include_recipe "apt"
 
   apt_repository 'datadog' do
-    keyserver 'keyserver.ubuntu.com'
+    keyserver 'hkp://keyserver.ubuntu.com:80'
     key 'C7A7DA52'
     uri node['datadog']['aptrepo']
     distribution "unstable"


### PR DESCRIPTION
We were seeing timeouts connecting to this url for our VPC instance builds, and the issue was resolved by doing explicit port settings with the hkp protocol. Hopefully you will consider this change!

http://superuser.com/questions/64922/how-to-work-around-blocked-outbound-hkp-port-for-apt-keys