### PR TITLE
Corrected sample postgres config

### DIFF
--- a/recipes/postgres.rb
+++ b/recipes/postgres.rb
@@ -7,13 +7,13 @@ include_recipe 'datadog::dd-agent'
 #
 # node['datadog']['postgres']['instances'] = [
 #   {
-#     'host' => "localhost",
+#     'server' => "localhost",
 #     'port' => "5432",
 #     'username' => "datadog",
 #     'tags' => ["test"]
 #   },
 #   {
-#     'host' => "remote",
+#     'server' => "remote",
 #     'port' => "5432",
 #     'username' => "datadog",
 #     'tags' => ["prod"],


### PR DESCRIPTION
In the postgres.rb cookbook, the sample `node['datadog']['postgres']['instances']`attribute does not match the keys in the postgres.yaml.erb. 
