### PR TITLE
Support config deployment on Windows

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -70,7 +70,7 @@ default['datadog']['yumrepo'] = "http://yum.datadoghq.com/rpm/#{architecture_map
 begin
   default['datadog']['install_base'] = Gem::Version.new(node['languages']['python']['version'].gsub(/(\d\.\d\.\d).+/, '\\1')) < Gem::Version.new('2.6.0')
 rescue NoMethodError # nodes['languages']['python'] == nil
-  Chef::Log.warn 'no version of python found, please install Agent version 5.x or higher.'
+  Chef::Log.warn 'no version of python found, please install Agent version 5.x or higher.' unless platform_family?("windows")
 rescue ArgumentError
   Chef::Log.warn "could not parse python version string: #{node['languages']['python']['version']}"
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,6 +30,20 @@ default['datadog']['application_key'] = nil
 # The host of the Datadog intake server to send agent data to
 default['datadog']['url'] = 'https://app.datadoghq.com'
 
+# Values that differ on Windows
+# The location of the config folder (containing conf.d)
+# The location of the dd agent folder (containing checks.d)
+# The name of the DD agent service
+if platform_family?("windows")
+	default['datadog']['configDir'] = "#{ENV['ProgramData']}/Datadog"
+	default['datadog']['agentDir'] = "#{ENV['ProgramFiles(x86)']}/Datadog/Datadog Agent"
+	default['datadog']['agent_name'] = 'DatadogAgent'
+else
+	default['datadog']['configDir'] = '/etc/dd-agent'
+	default['datadog']['agentDir'] = '/etc/dd-agent'
+	default['datadog']['agent_name'] = 'datadog-agent'
+end
+
 # Add tags as override attributes in your role
 default['datadog']['tags'] = ''
 

--- a/providers/monitor.rb
+++ b/providers/monitor.rb
@@ -5,26 +5,28 @@ def whyrun_supported?
 end
 
 action :add do
-  Chef::Log.debug "Adding monitoring for #{new_resource.name}"
-  template "/etc/dd-agent/conf.d/#{new_resource.name}.yaml" do
-    owner 'dd-agent'
-    mode 00600
-    variables(
-      :init_config => new_resource.init_config,
-      :instances   => new_resource.instances
-    )
-    notifies :restart, 'service[datadog-agent]', :delayed
-  end
-  new_resource.updated_by_last_action(false)
+	converge_by("Adding monitoring for #{new_resource.name}") do
+		template "#{node['datadog']['configDir']}/conf.d/#{new_resource.name}.yaml" do
+			owner 'dd-agent' if !platform_family?('windows')
+			mode 00600 if !platform_family?('windows')
+			variables(
+			  :init_config => new_resource.init_config,
+			  :instances   => new_resource.instances
+			)
+			notifies :restart, 'service[datadog-agent]', :delayed
+			new_resource.updated_by_last_action(true)
+		end
+	end	
 end
 
 action :remove do
-  if ::File.exist?("/etc/dd-agent/conf.d/#{new_resource.name}.yaml")
-    Chef::Log.debug "Removing #{new_resource.name} from /etc/dd-agent/conf.d/"
-    file "/etc/dd-agent/conf.d/#{new_resource.name}.yaml" do
-      action :delete
-      notifies :restart, 'service[datadog-agent]', :delayed
-    end
-    new_resource.updated_by_last_action(true)
-  end
+	if ::File.exist?("#{node['datadog']['configDir']}/conf.d/#{new_resource.name}.yaml")
+		converge_by("Removing #{node['datadog']['configDir']}/conf.d/#{new_resource.name}.yaml") do
+			resource = file "#{node['datadog']['configDir']}/conf.d/#{new_resource.name}.yaml" do
+				action :delete
+				notifies :restart, 'service[datadog-agent]', :delayed
+				new_resource.updated_by_last_action(true)
+			end
+		end
+	end
 end

--- a/recipes/dd-agent-config.rb
+++ b/recipes/dd-agent-config.rb
@@ -1,0 +1,62 @@
+#
+# Cookbook Name:: datadog
+# Recipe:: dd-agent-config
+#
+# Copyright 2011-2014, Datadog
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This recipe is a temporary work around as the dd-agent recipe doesn't support windows
+# it ensures the agent service is running and provides the link for restarting it when monitors are changed
+
+# Set the correct Agent startup action
+agent_action = node['datadog']['agent_start'] ? :start : :stop
+
+# Make sure the config directory exists
+directory "#{node['datadog']['configDir']}" do
+  owner 'root' if !platform_family?('windows')
+  group 'root' if !platform_family?('windows')
+  mode 0755 if !platform_family?('windows')
+end
+directory "#{node['datadog']['configDir']}/conf.d" do
+  owner 'root' if !platform_family?('windows')
+  group 'root' if !platform_family?('windows')
+  mode 0755 if !platform_family?('windows')
+end
+
+#
+# Configures a basic agent
+# To add integration-specific configurations, add 'datadog::config_name' to
+# the node's run_list and set the relevant attributes
+#
+raise "Add a ['datadog']['api_key'] attribute to configure this node's Datadog Agent." if node['datadog'] && node['datadog']['api_key'].nil?
+
+template '/etc/dd-agent/datadog.conf' do
+  path "#{node['datadog']['configDir']}/datadog.conf"
+  owner 'root' if !platform_family?('windows')
+  group 'root' if !platform_family?('windows')
+  mode 0644 if !platform_family?('windows')
+  variables(
+    :api_key => node['datadog']['api_key'],
+    :dd_url => node['datadog']['url']
+  )
+end
+
+# Common configuration
+service 'datadog-agent' do
+  service_name "#{node['datadog']['agent_name']}"
+  action [:enable, agent_action]
+  supports :restart => true, :status => true, :start => true, :stop => true
+  subscribes :restart, 'template[/etc/dd-agent/datadog.conf]', :delayed unless node['datadog']['agent_start'] == false
+end

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -41,36 +41,5 @@ else
   end
 end
 
-# Set the correct Agent startup action
-agent_action = node['datadog']['agent_start'] ? :start : :stop
-
-# Make sure the config directory exists
-directory '/etc/dd-agent' do
-  owner 'root'
-  group 'root'
-  mode 0755
-end
-
-#
-# Configures a basic agent
-# To add integration-specific configurations, add 'datadog::config_name' to
-# the node's run_list and set the relevant attributes
-#
-raise "Add a ['datadog']['api_key'] attribute to configure this node's Datadog Agent." if node['datadog'] && node['datadog']['api_key'].nil?
-
-template '/etc/dd-agent/datadog.conf' do
-  owner 'root'
-  group 'root'
-  mode 0644
-  variables(
-    :api_key => node['datadog']['api_key'],
-    :dd_url => node['datadog']['url']
-  )
-end
-
 # Common configuration
-service 'datadog-agent' do
-  action [:enable, agent_action]
-  supports :restart => true, :status => true, :start => true, :stop => true
-  subscribes :restart, 'template[/etc/dd-agent/datadog.conf]', :delayed unless node['datadog']['agent_start'] == false
-end
+include-recipe 'datadog::dd-agent-config'

--- a/recipes/iis.rb
+++ b/recipes/iis.rb
@@ -1,11 +1,11 @@
-include_recipe 'datadog::dd-agent'
+include_recipe 'datadog::dd-agent-config'
 
 # Integrate IIS metrics
 #
 # Simply declare the following attributes
 # One instance per server.
 #
-# node.datadog.iis.instances = [
+# node['datadog']['iis']['instances'] = [
 #                               {
 #                                 "host" => "localhost",
 #                                 "tags" => ["prod", "other_tag"]
@@ -14,6 +14,7 @@ include_recipe 'datadog::dd-agent'
 #                                 "host" => "other.server.com",
 #                                 "username" => "myuser",
 #                                 "password" => "password",
+#                                 "sites" => ["Default", "Site2"]
 #                                 "tags" => ["prod", "other_tag"]
 #                               }
 #                              ]

--- a/recipes/sqlserver.rb
+++ b/recipes/sqlserver.rb
@@ -1,0 +1,30 @@
+include_recipe 'datadog::dd-agent-config'
+
+# Integrate SQL Server metrics
+#
+# Simply declare the following attributes
+# One instance per server.
+#
+# node['datadog']['sqlserver']['custom_metrics'] = [
+#                               {
+#                                 "name" => "sqlserver.db.commit_table_entries",
+#                                 "type" => "gauge",
+#                                 "counter_name" => "Log Flushes/sec",
+#                                 "instance_name" => "ALL",
+#                                 "tag_by" => "db"
+#                               }
+#                              ]
+# node['datadog']['sqlserver']['instances'] = [
+#                               {
+#                                 "host" => "other.server.com",
+#                                 "port" => 12345,
+#                                 "username" => "myuser",
+#                                 "password" => "password"
+#                               }
+#                              ]
+
+config = { 'custom_metrics' => node['datadog']['sqlserver']['custom_metrics'] } if node['datadog']['sqlserver'].key?('custom_metrics')
+datadog_monitor 'sqlserver' do
+  instances 	node['datadog']['sqlserver']['instances']
+  init_config 	config
+end

--- a/recipes/wmi_check.rb
+++ b/recipes/wmi_check.rb
@@ -1,0 +1,23 @@
+include_recipe 'datadog::dd-agent-config'
+
+# Integrate IIS metrics
+#
+# Simply declare the following attributes
+# One instance per server.
+#
+# node['datadog']['wmi_check']['instances'] = [
+#                               {
+#                                 "class" => "Win32_OperatingSystem",
+#                                 "metrics" => ["[NumberOfProcesses, system.proc.count, gauge]", "[NumberOfUsers, system.users.count, gauge]"]
+#                               },
+#                               {
+#                                 "class" => "Win32_PerfFormattedData_PerfProc_Process",
+#                                 "metrics" => ["[PercentProcessorTime, proc.cpu_pct, gauge]"],
+#                                 "filters" => ["Name: app1", "Name: app2"],
+#                                 "tag_by" => "Name"
+#                               }
+#                              ]
+
+datadog_monitor 'wmi_check' do
+  instances node['datadog']['wmi_check']['instances']
+end

--- a/templates/default/iis.yaml.erb
+++ b/templates/default/iis.yaml.erb
@@ -1,3 +1,5 @@
+# This file is built by Chef. Direct modification will be overwritten!
+
 # By default, this check will run against a single instance - the current
 # machine that the Agent is running on. It will check the WMI performance
 # counters for IIS on that machine. 
@@ -16,6 +18,12 @@ instances:
     <% if i.key?('username') -%>
     username: <%= i['username'] %>
     password: <%= i['password'] %>
+    <% end -%>
+    <% if i.key?('sites') -%>
+    sites:
+      <% i['sites'].each do |s| -%>
+      - <%= s %>
+      <% end -%>
     <% end -%>
     <% if i.key?('tags') -%>
     tags:

--- a/templates/default/sqlserver.yaml.erb
+++ b/templates/default/sqlserver.yaml.erb
@@ -1,3 +1,5 @@
+# This file is built by Chef. Direct modification will be overwritten!
+
 init_config:
     #
     # By default, we only capture *some* of the metrics available in the
@@ -32,8 +34,26 @@ init_config:
     #        counter_name: Log Flushes/sec
     #        instance_name: ALL
     #        tag_by: db
+  <% if @init_config.key?('custom_metrics') -%>
+  custom_metrics:
+    <% @init_config['custom_metrics'].each do |i| -%>
+    - name: <%= i['name'] %>
+      type: <%= i['type'] %>
+      counter_name: <%= i['counter_name'] %>
+      <% if i.key?('instance_name') -%>
+      instance_name: <%= i['instance_name'] %>
+      <% end -%>
+      <% if i.key?('tag_by') -%>
+      tag_by: <%= i['tag_by'] %>
+      <% end -%>
+    <% end -%>
+  <% end -%>
 
 instances:
-    -   host: HOST,PORT
-        username: my_username
-        password: my_password
+  <% @instances.each do |i| -%>
+  - host: <%= i['host'] %><% if i.key?('port') -%>,<%= i['port'] %><% end -%>
+    <% if i.key?('username') -%>
+    username: <%= i['username'] %>
+    password: <%= i['password'] %>
+    <% end -%>
+  <% end -%>

--- a/templates/default/wmi_check.yaml.erb
+++ b/templates/default/wmi_check.yaml.erb
@@ -1,3 +1,5 @@
+# This file is built by Chef. Direct modification will be overwritten!
+
 init_config:
 
 instances:
@@ -35,39 +37,21 @@ instances:
     # WMI class you're using. This is only useful when you will have multiple
     # values for your WMI query. The examples below show how you can tag your
     # process metrics with the process name (giving a tag of "name:app_name").
+    #
 
-
-    # Fetch the number of processes and users
-    -   class: Win32_OperatingSystem
-        metrics:
-            -   [NumberOfProcesses, system.proc.count, gauge]
-            -   [NumberOfUsers, system.users.count, gauge]
-
-    # Fetch metrics for a single running application, called myapp
-    -   class: Win32_PerfFormattedData_PerfProc_Process
-        metrics:
-            -   [ThreadCount, my_app.threads.count, gauge]
-            -   [VirtualBytes, my_app.mem.virtual, gauge]
-        filters:
-            -   Name: myapp
-
-    # Fetch process metrics for a set of processes, tagging by app name.
-    -   class: Win32_PerfFormattedData_PerfProc_Process
-        metrics:
-            -   [ThreadCount, proc.threads.count, gauge]
-            -   [VirtualBytes, proc.mem.virtual, gauge]
-            -   [PercentProcessorTime, proc.cpu_pct, gauge]
-        filters:
-            -   Name: app1
-            -   Name: app2
-            -   Name: app3
-        tag_by: Name
-
-    # Fetch process metrics for every available process, tagging by app name.
-    -   class: Win32_PerfFormattedData_PerfProc_Process
-        metrics:
-            -   [IOReadBytesPerSec, proc.io.bytes_read, gauge]
-            -   [IOWriteBytesPerSec, proc.io.bytes_written, gauge]
-        tag_by: Name
-
-
+  <% @instances.each do |i| -%>
+  - class: <%= i['class'] %>
+    metrics:
+      <% i['metrics'].each do |m| -%>
+      - <%= m %>
+      <% end -%>
+    <% if i.key?('filters') -%>
+    filters:
+      <% i['filters'].each do |f| -%>
+      - <%= f %>
+      <% end -%>
+    <% end -%>
+    <% if i.key?('tag_by') -%>
+    tag_by: <%= i['tag_by'] %>
+    <% end -%>
+  <% end -%>


### PR DESCRIPTION
See #161 

Current code has unix paths and package deployment preventing operation on Windows. Now split out and parameterised to allow operation.

Working recipes included to deploy iis, sqlserver and wmi integrations on Windows.