### PR TITLE
Update kafka.yaml: proper spacing & recent changes

### DIFF
--- a/templates/default/kafka.yaml.erb
+++ b/templates/default/kafka.yaml.erb
@@ -11,6 +11,11 @@ instances:
     <% if i['password'] -%>
     password: <%= i['password'] %>
     <% end -%>
+    <% if i['process_name_regex'] and i['tools_jar_path'] -%>
+    process_name_regex: <%= i['process_name_regex'] %> # Instead of specifying a host, and port. The agent can connect using the attach api.
+                                                       # This requires the JDK to be installed and the path to tools.jar to be set below.
+    tools_jar_path: <%= i['tools_jar_path'] %>
+    <% end -%>
     <% if i['java_bin_path'] -%>
     java_bin_path: <%= i['java_bin_path'] %> #Optional, should be set if the agent cannot find your java executable
     <% end -%>
@@ -20,7 +25,14 @@ instances:
     <% if i['trust_store_password'] -%>
     trust_store_password: <%= i['trust_store_password'] %>
     <% end -%>
+    <% if i.key?('tags') -%>
+    tags:
+      <% @tags.each do |k, v| -%>
+      <%= k %>: <%= v %>
+      <% end -%>
+    <% end -%>
   <% end -%>
+
 
 init_config:
   is_jmx: true
@@ -31,134 +43,134 @@ init_config:
     # Aggregate cluster stats
     #
     - include:
-      domain: '"kafka.server"'
-      bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsBytesOutPerSec"'
-      attribute:
-        MeanRate:
-          metric_type: counter
-          alias: kafka.net.bytes_out
+        domain: '"kafka.server"'
+        bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsBytesOutPerSec"'
+        attribute:
+          MeanRate:
+            metric_type: gauge
+            alias: kafka.net.bytes_out
     - include:
-      domain: '"kafka.server"'
-      bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsBytesInPerSec"'
-      attribute:
-        MeanRate:
-          metric_type: counter
-          alias: kafka.net.bytes_in
+        domain: '"kafka.server"'
+        bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsBytesInPerSec"'
+        attribute:
+          MeanRate:
+            metric_type: gauge
+            alias: kafka.net.bytes_in
     - include:
-      domain: '"kafka.server"'
-      bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsMessagesInPerSec"'
-      attribute:
-        MeanRate:
-          metric_type: gauge
-          alias: kafka.messages_in
+        domain: '"kafka.server"'
+        bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsMessagesInPerSec"'
+        attribute:
+          MeanRate:
+            metric_type: gauge
+            alias: kafka.messages_in
 
     #
     # Request timings
     #
     - include:
-      domain: '"kafka.server"'
-      bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsFailedFetchRequestsPerSec"'
-      attribute:
-        MeanRate:
-          metric_type: gauge
-          alias: kafka.request.fetch.failed
+        domain: '"kafka.server"'
+        bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsFailedFetchRequestsPerSec"'
+        attribute:
+          MeanRate:
+            metric_type: gauge
+            alias: kafka.request.fetch.failed
     - include:
-      domain: '"kafka.server"'
-      bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsFailedProduceRequestsPerSec"'
-      attribute:
-        MeanRate:
-          metric_type: gauge
-          alias: kafka.request.produce.failed
+        domain: '"kafka.server"'
+        bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsFailedProduceRequestsPerSec"'
+        attribute:
+          MeanRate:
+            metric_type: gauge
+            alias: kafka.request.produce.failed
     - include:
-      domain: '"kafka.network"'
-      bean: '"kafka.network":type="RequestMetrics",name="Produce-TotalTimeMs"'
-      attribute:
-        Mean:
-          metric_type: counter
-          alias: kafka.request.produce.time.avg
-        99thPercentile:
-          metric_type: counter
-          alias: kafka.request.produce.time.99percentile
+        domain: '"kafka.network"'
+        bean: '"kafka.network":type="RequestMetrics",name="Produce-TotalTimeMs"'
+        attribute:
+          Mean:
+            metric_type: gauge
+            alias: kafka.request.produce.time.avg
+          99thPercentile:
+            metric_type: gauge
+            alias: kafka.request.produce.time.99percentile
     - include:
-      domain: '"kafka.network"'
-      bean: '"kafka.network":type="RequestMetrics",name="Fetch-TotalTimeMs"'
-      attribute:
-        Mean:
-          metric_type: counter
-          alias: kafka.request.fetch.time.avg
-        99thPercentile:
-          metric_type: counter
-          alias: kafka.request.fetch.time.99percentile
+        domain: '"kafka.network"'
+        bean: '"kafka.network":type="RequestMetrics",name="Fetch-TotalTimeMs"'
+        attribute:
+          Mean:
+            metric_type: gauge
+            alias: kafka.request.fetch.time.avg
+          99thPercentile:
+            metric_type: gauge
+            alias: kafka.request.fetch.time.99percentile
     - include:
-      domain: '"kafka.network"'
-      bean: '"kafka.network":type="RequestMetrics",name="UpdateMetadata-TotalTimeMs"'
-      attribute:
-        Mean:
-          metric_type: counter
-          alias: kafka.request.update_metadata.time.avg
-        99thPercentile:
-          metric_type: counter
-          alias: kafka.request.update_metadata.time.99percentile
+        domain: '"kafka.network"'
+        bean: '"kafka.network":type="RequestMetrics",name="UpdateMetadata-TotalTimeMs"'
+        attribute:
+          Mean:
+            metric_type: gauge
+            alias: kafka.request.update_metadata.time.avg
+          99thPercentile:
+            metric_type: gauge
+            alias: kafka.request.update_metadata.time.99percentile
     - include:
-      domain: '"kafka.network"'
-      bean: '"kafka.network":type="RequestMetrics",name="Metadata-TotalTimeMs"'
-      attribute:
-        Mean:
-          metric_type: counter
-          alias: kafka.request.metadata.time.avg
-        99thPercentile:
-          metric_type: counter
-          alias: kafka.request.metadata.time.99percentile
+        domain: '"kafka.network"'
+        bean: '"kafka.network":type="RequestMetrics",name="Metadata-TotalTimeMs"'
+        attribute:
+          Mean:
+            metric_type: gauge
+            alias: kafka.request.metadata.time.avg
+          99thPercentile:
+            metric_type: gauge
+            alias: kafka.request.metadata.time.99percentile
     - include:
-      domain: '"kafka.network"'
-      bean: '"kafka.network":type="RequestMetrics",name="Offsets-TotalTimeMs"'
-      attribute:
-        Mean:
-          metric_type: counter
-          alias: kafka.request.offsets.time.avg
-        99thPercentile:
-          metric_type: counter
-          alias: kafka.request.offsets.time.99percentile
+        domain: '"kafka.network"'
+        bean: '"kafka.network":type="RequestMetrics",name="Offsets-TotalTimeMs"'
+        attribute:
+          Mean:
+            metric_type: gauge
+            alias: kafka.request.offsets.time.avg
+          99thPercentile:
+            metric_type: gauge
+            alias: kafka.request.offsets.time.99percentile
 
     #
     # Replication stats
     #
     - include:
-      domain: '"kafka.server"'
-      bean: '"kafka.server":type="ReplicaManager",name="ISRShrinksPerSec"'
-      attribute:
-        MeanRate:
-          metric_type: counter
-          alias: kafka.replication.isr_shrinks
+        domain: '"kafka.server"'
+        bean: '"kafka.server":type="ReplicaManager",name="ISRShrinksPerSec"'
+        attribute:
+          MeanRate:
+            metric_type: gauge
+            alias: kafka.replication.isr_shrinks
     - include:
-      domain: '"kafka.server"'
-      bean: '"kafka.server":type="ReplicaManager",name="ISRExpandsPerSec"'
-      attribute:
-        MeanRate:
-          metric_type: counter
-          alias: kafka.replication.isr_expands
+        domain: '"kafka.server"'
+        bean: '"kafka.server":type="ReplicaManager",name="ISRExpandsPerSec"'
+        attribute:
+          MeanRate:
+            metric_type: gauge
+            alias: kafka.replication.isr_expands
     - include:
-      domain: '"kafka.server"'
-      bean: '"kafka.server":type="ControllerStats",name="LeaderElectionRateAndTimeMs"'
-      attribute:
-        MeanRate:
-          metric_type: counter
-          alias: kafka.replication.leader_elections
+        domain: '"kafka.server"'
+        bean: '"kafka.server":type="ControllerStats",name="LeaderElectionRateAndTimeMs"'
+        attribute:
+          MeanRate:
+            metric_type: gauge
+            alias: kafka.replication.leader_elections
     - include:
-      domain: '"kafka.server"'
-      bean: '"kafka.server":type="ControllerStats",name="UncleanLeaderElectionsPerSec"'
-      attribute:
-        MeanRate:
-          metric_type: counter
-          alias: kafka.replication.unclean_leader_elections
+        domain: '"kafka.server"'
+        bean: '"kafka.server":type="ControllerStats",name="UncleanLeaderElectionsPerSec"'
+        attribute:
+          MeanRate:
+            metric_type: gauge
+            alias: kafka.replication.unclean_leader_elections
 
     #
     # Log flush stats
     #
     - include:
-      domain: '"kafka.log"'
-      bean: '"kafka.log":type="LogFlushStats",name="LogFlushRateAndTimeMs"'
-      attribute:
-        MeanRate:
-          metric_type: counter
-          alias: kafka.log.flush_rate
+        domain: '"kafka.log"'
+        bean: '"kafka.log":type="LogFlushStats",name="LogFlushRateAndTimeMs"'
+        attribute:
+          MeanRate:
+            metric_type: gauge
+            alias: kafka.log.flush_rate


### PR DESCRIPTION
With previous spacing check throws exception:
  InvalidJMXConfiguration("Each configuration must have an 'include' section.")

In particular incorporates
DataDog/dd-agent@75863d82ee2f0cdef3f3e75097fe79cb17f6b5c2 - counters-> guages,
DataDog/dd-agent@5382422d3790be2a9c4f6eccb9bca58547ae8c76 - jmxfetch custom tags
and DataDog/dd-agent@8bac88e23f94d615a90e587ed84c55e4adba683f - support for jmxfetch0.4