### PR TITLE
Fix Provider `updated_by_last_action` return value

### DIFF
--- a/providers/monitor.rb
+++ b/providers/monitor.rb
@@ -6,25 +6,29 @@ end
 
 action :add do
   Chef::Log.debug "Adding monitoring for #{new_resource.name}"
-  template "/etc/dd-agent/conf.d/#{new_resource.name}.yaml" do
+
+  t = template "/etc/dd-agent/conf.d/#{new_resource.name}.yaml" do
     owner 'dd-agent'
-    mode 00600
+    mode '0600'
     variables(
-      :init_config => new_resource.init_config,
-      :instances   => new_resource.instances
+      init_config: new_resource.init_config,
+      instances: new_resource.instances
     )
-    notifies :restart, 'service[datadog-agent]', :delayed
+    notifies :restart, 'service[datadog-agent]'
   end
-  new_resource.updated_by_last_action(false)
+
+  new_resource.updated_by_last_action(t.updated_by_last_action?)
 end
 
 action :remove do
-  if ::File.exist?("/etc/dd-agent/conf.d/#{new_resource.name}.yaml")
-    Chef::Log.debug "Removing #{new_resource.name} from /etc/dd-agent/conf.d/"
-    file "/etc/dd-agent/conf.d/#{new_resource.name}.yaml" do
-      action :delete
-      notifies :restart, 'service[datadog-agent]', :delayed
-    end
-    new_resource.updated_by_last_action(true)
+  return unless ::File.exist?("/etc/dd-agent/conf.d/#{new_resource.name}.yaml")
+
+  Chef::Log.debug "Removing #{new_resource.name} from /etc/dd-agent/conf.d/"
+
+  f = file "/etc/dd-agent/conf.d/#{new_resource.name}.yaml" do
+    action :delete
+    notifies :restart, 'service[datadog-agent]'
   end
+
+  new_resource.updated_by_last_action(f.updated_by_last_action?)
 end


### PR DESCRIPTION
This PR uses the return value from the executed resource vs. hard-coding a `true`/`false` return.