### PR TITLE
Fix YAML formatting

### DIFF
--- a/templates/default/activemq.yaml.erb
+++ b/templates/default/activemq.yaml.erb
@@ -18,54 +18,54 @@ instances:
 init_config:
   conf:
     - include:
-      Type: Queue
-      attribute:
-        AverageEnqueueTime:
-          alias: activemq.queue.avg_enqueue_time
-          metric_type: gauge
-        ConsumerCount:
-          alias: activemq.queue.consumer_count
-          metric_type: gauge
-        DequeueCount:
-          alias: activemq.queue.dequeue_count
-          metric_type: counter
-        DispatchCount:
-          alias: activemq.queue.dispatch_count
-          metric_type: counter
-        EnqueueCount:
-          alias: activemq.queue.enqueue_count
-          metric_type: counter
-        ExpiredCount:
-          alias: activemq.queue.expired_count
-          type: counter
-        InFlightCount:
-          alias: activemq.queue.in_flight_count
-          metric_type: counter
-        MaxEnqueueTime:
-          alias: activemq.queue.max_enqueue_time
-          metric_type: gauge
-        MemoryPercentUsage:
-          alias: activemq.queue.memory_pct
-          metric_type: gauge
-        MinEnqueueTime:
-          alias: activemq.queue.min_enqueue_time
-          metric_type: gauge
-        ProducerCount:
-          alias: activemq.queue.producer_count
-          metric_type: gauge
-        QueueSize:
-          alias: activemq.queue.size
-          metric_type: gauge
+        Type: Queue
+        attribute:
+          AverageEnqueueTime:
+            alias: activemq.queue.avg_enqueue_time
+            metric_type: gauge
+          ConsumerCount:
+            alias: activemq.queue.consumer_count
+            metric_type: gauge
+          DequeueCount:
+            alias: activemq.queue.dequeue_count
+            metric_type: counter
+          DispatchCount:
+            alias: activemq.queue.dispatch_count
+            metric_type: counter
+          EnqueueCount:
+            alias: activemq.queue.enqueue_count
+            metric_type: counter
+          ExpiredCount:
+            alias: activemq.queue.expired_count
+            type: counter
+          InFlightCount:
+            alias: activemq.queue.in_flight_count
+            metric_type: counter
+          MaxEnqueueTime:
+            alias: activemq.queue.max_enqueue_time
+            metric_type: gauge
+          MemoryPercentUsage:
+            alias: activemq.queue.memory_pct
+            metric_type: gauge
+          MinEnqueueTime:
+            alias: activemq.queue.min_enqueue_time
+            metric_type: gauge
+          ProducerCount:
+            alias: activemq.queue.producer_count
+            metric_type: gauge
+          QueueSize:
+            alias: activemq.queue.size
+            metric_type: gauge
 
     - include:
-      Type: Broker
-      attribute:
-        MemoryPercentUsage:
-          alias: activemq.broker.memory_pct
-          metric_type: gauge
-        StorePercentUsage:
-          alias: activemq.broker.store_pct
-          metric_type: gauge
-        TempPercentUsage:
-          alias: activemq.broker.temp_pct
-          metric_type: gauge
+        Type: Broker
+        attribute:
+          MemoryPercentUsage:
+            alias: activemq.broker.memory_pct
+            metric_type: gauge
+          StorePercentUsage:
+            alias: activemq.broker.store_pct
+            metric_type: gauge
+          TempPercentUsage:
+            alias: activemq.broker.temp_pct
+            metric_type: gauge


### PR DESCRIPTION
YAML had incorrect formatting in the Ruby template, causing the following error after Chef used it to create the `activemq.yaml` config file:

```
    activemq
    --------
      - initialize check class [ERROR]: InvalidJMXConfiguration("Each configuration must have an 'include' section. See http://docs.datadoghq.com/integrations/java/ for more information",)
```