### PR TITLE
Support for multiple tags in datadog.conf

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,7 +30,7 @@ default['datadog']['application_key'] = nil
 # The host of the Datadog intake server to send agent data to
 default['datadog']['url'] = 'https://app.datadoghq.com'
 
-# Add tags as override attributes in your role
+# Add tags as override attributes in your role, string or key/value
 default['datadog']['tags'] = ''
 
 # Collect EC2 tags, set to 'yes' to collect

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'package@datadoghq.com'
 license          'Apache 2.0'
 description      'Installs/Configures datadog components'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0.0'
+version          '2.1.0'
 
 %w(
   amazon

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -13,7 +13,11 @@ bind_host: <%= node['datadog']['bind_host'] %>
 autorestart: <%= node['datadog']['autorestart'] %>
 <% end -%>
 
+<% if node['datadog']['tags'].respond_to?("map") %>
+tags: <%= node['datadog']['tags'].select{|k,v| not v.nil?}.map{|k,v| "#{k}:#{v}"}.join(",") %>
+<% else %>
 tags: <%= node['datadog']['tags'] %>
+<% end %>
 <% if node['datadog']['collect_ec2_tags'] -%>
 collect_ec2_tags: <%= node['datadog']['collect_ec2_tags'] %>
 <% end -%>


### PR DESCRIPTION
Enables setting tags from different attribute levels, backward compatible.

Suppose you have role A which acts on two environments B and C.
This patch enables setting this on the role:

    {
      "datadog": {
        "tags": {
          "cluster": "A"
         }
       }
    }

And these on the different environments:

    {
      "datadog": {
        "tags": {
          "environment": "B"
         }
       }
    }

    {
      "datadog": {
        "tags": {
          "environment": "C"
         }
       }
    }

Will result in datadog.conf having `tags: cluster:A,environment:B` and `tags: cluster:A,environment:C` respectively. String version of the tags should still work.