### PR TITLE
Add support for multiple tags via key/value

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,6 +31,8 @@ default['datadog']['application_key'] = nil
 default['datadog']['url'] = 'https://app.datadoghq.com'
 
 # Add tags as override attributes in your role, string or key/value
+# When using the Datadog Chef Handler, tags are set on the node with preset prefixes:
+# `env:node.chef_environment`, `role:node.node.run_list.role`, `tag:somecheftag`
 default['datadog']['tags'] = ''
 
 # Collect EC2 tags, set to 'yes' to collect

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,7 +30,7 @@ default['datadog']['application_key'] = nil
 # The host of the Datadog intake server to send agent data to
 default['datadog']['url'] = 'https://app.datadoghq.com'
 
-# Add tags as override attributes in your role
+# Add tags as override attributes in your role, string or key/value
 default['datadog']['tags'] = ''
 
 # Collect EC2 tags, set to 'yes' to collect

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -243,5 +243,28 @@ describe 'datadog::dd-agent' do
 
       it_behaves_like 'debianoids'
     end
+
+    context 'use key/value for tags' do
+      before(:all) do
+        @chef_run = ChefSpec::SoloRunner.new(
+          platform: 'ubuntu',
+          version: '14.04'
+        ) do |node|
+          node.set['datadog'] = {
+            'api_key' => 'somethingnotnil',
+            'tags' => {'env' => 'foo', 'cluster' => 'bar'},
+            'languages' => {'python' => {'version' => '2.6.2'}}
+          }
+        end
+        @chef_run.converge described_recipe
+      end
+
+      it_behaves_like 'common resources'
+
+      it 'sets tags properly' do
+        expect(@chef_run).to render_file('/etc/dd-agent/datadog.conf').
+          with_content(/^tags: env:foo,cluster:bar$/)
+      end
+    end
   end
 end

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -13,7 +13,11 @@ bind_host: <%= node['datadog']['bind_host'] %>
 autorestart: <%= node['datadog']['autorestart'] %>
 <% end -%>
 
+<% if node['datadog']['tags'].respond_to?("each_pair") %>
+tags: <%= node['datadog']['tags'].select{|k,v| not v.empty?}.map{|k,v| "#{k}:#{v}"}.join(",") %>
+<% else %>
 tags: <%= node['datadog']['tags'] %>
+<% end %>
 <% if node['datadog']['collect_ec2_tags'] -%>
 collect_ec2_tags: <%= node['datadog']['collect_ec2_tags'] %>
 <% end -%>


### PR DESCRIPTION
A new pull request (previous is #183) without a version change and with a more strict test for Hash implementation.

---

Enables setting tags from different attribute levels, backward compatible.

Suppose you have role A which acts on two environments B and C.
This patch enables setting this on the role:

    {
      "datadog": {
        "tags": {
          "cluster": "A"
        }
      }
    }

And these on the different environments:

    {
      "datadog": {
        "tags": {
          "environment": "B"
        }
      }
    }

    {
      "datadog": {
        "tags": {
          "environment": "C"
        }
      }
    }

Will result in datadog.conf having `tags: cluster:A,environment:B` and `tags: cluster:A,environment:C` respectively. String version of the tags should still work. To remove a tag in a higher precedence level, set it to an empty string.

This is also reported in #170.