### PR TITLE
Remove support of debug mode and add support of custom log levels

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -78,9 +78,8 @@ default['datadog']['chef_handler_version'] = nil
 # Enable the Chef handler to report to datadog
 default['datadog']['chef_handler_enable'] = true
 
-# Boolean to enable debug_mode, which outputs massive amounts of log messages
-# to the /tmp/ directory.
-default['datadog']['debug'] = false
+# Log level. Should be a valid python log level https://docs.python.org/2/library/logging.html#logging-levels
+default['datadog']['log_level'] = 'INFO'
 
 # Default to false to non_local_traffic
 # See: https://github.com/DataDog/dd-agent/wiki/Network-Traffic-and-Proxy-Configuration

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -3,7 +3,6 @@
 [Main]
 dd_url: <%= @dd_url %>
 api_key: <%= @api_key %>
-debug_mode: <%= node['datadog']['debug'] %>
 check_freq: <%= node['datadog']['check_freq'] %>
 hostname: <%= node['datadog']['hostname'] %>
 use_mount: <%= node['datadog']['use_mount'] ? "yes" : "no"  %>
@@ -72,7 +71,7 @@ statsd_forward_port: <%= node['datadog']['statsd_forward_port'] %>
 # Logging
 # ========================================================================== #
 
-log_level: INFO
+log_level: <%= node['datadog']['log_level'] %>
 
 # collector_log_file: /var/log/datadog/collector.log
 # forwarder_log_file: /var/log/datadog/forwarder.log


### PR DESCRIPTION
debug_mode has been removed more than 2 years ago in the Agent code:
https://github.com/DataDog/dd-agent/commit/2302ad9479124e96253e5776c5b37e755e6ece67

The proper way to be in "debug mode" is to set the log level accordingly, so this PR is adding this possibilty.