### PR TITLE
simplify fluentd template, add tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -132,6 +132,22 @@ suites:
               - kitchen
               - sink
 
+- name: datadog_fluentd
+  run_list:
+    - recipe[datadog::fluentd]
+  attributes:
+    datadog:
+      <<: *DATADOG
+      fluentd:
+        instances:
+          - monitor_agent_url: http://localhost.com:24220/api/plugins.json
+            plugin_ids:
+              - api
+              - plugin
+            tags:
+              - kitchen
+              - sink
+
 - name: datadog_haproxy
   run_list:
     - recipe[datadog::haproxy]

--- a/templates/default/fluentd.yaml.erb
+++ b/templates/default/fluentd.yaml.erb
@@ -1,19 +1,4 @@
-instances:
-<% @instances.each do |i| -%>
-  - monitor_agent_url: <%= i['monitor_agent_url'] %>
-  <% if i.key?('plugin_ids') -%>
-    plugin_ids:
-    <% i['plugin_ids'].each do |p| -%>
-    - <%= p %>
-    <% end -%>
-  <% end -%>
-  <% if i.key?('tags') -%>
-    tags:
-    <% i['tags'].each do |t| -%>
-    - <%= t %>
-    <% end -%>
-  <% end -%>
-<% end -%>
+<%= JSON.parse(({ 'instances' => @instances }).to_json).to_yaml %>
 
 # Nothing to configure here
 init_config:

--- a/test/integration/datadog_fluentd/serverspec/Gemfile
+++ b/test/integration/datadog_fluentd/serverspec/Gemfile
@@ -1,0 +1,1 @@
+../../helpers/serverspec/Gemfile

--- a/test/integration/datadog_fluentd/serverspec/fluentd_spec.rb
+++ b/test/integration/datadog_fluentd/serverspec/fluentd_spec.rb
@@ -1,0 +1,34 @@
+# Encoding: utf-8
+require 'json_spec'
+require 'serverspec'
+require 'yaml'
+
+set :backend, :exec
+set :path, '/sbin:/usr/local/sbin:$PATH'
+
+AGENT_CONFIG = '/etc/dd-agent/conf.d/fluentd.yaml'
+
+describe service('datadog-agent') do
+  it { should be_running }
+end
+
+describe file(AGENT_CONFIG) do
+  it { should be_a_file }
+
+  it 'is valid yaml matching input values' do
+    generated = YAML.load_file(AGENT_CONFIG)
+
+    expected = {
+      'instances' => [
+        {
+          'monitor_agent_url' => 'http://localhost.com:24220/api/plugins.json',
+          'plugin_ids' => ['api', 'plugin'],
+          'tags' => ['kitchen', 'sink']
+        }
+      ],
+      'init_config' => nil
+    }
+
+    expect(generated.to_json).to be_json_eql expected.to_json
+  end
+end


### PR DESCRIPTION
Refs #191

/cc @alq666 - this is the preferred style of adding new templates, as they leave the attribute implementation open to future additions with no update to the template file.