### PR TITLE
Set compile_time when using chef_gem resource

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -44,6 +44,14 @@ suites:
       api_key: somethingnotnil
       application_key: alsonotnil
 
+- name: dd-handler
+  run_list:
+    - recipe[datadog::dd-handler]
+  attributes:
+    datadog: &DATADOG
+      api_key: somethingnotnil
+      application_key: alsonotnil
+
 - name: datadog_activemq
   run_list:
     - recipe[datadog::activemq]

--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -23,6 +23,8 @@ ENV['DATADOG_HOST'] = node['datadog']['url']
 chef_gem 'chef-handler-datadog' do
   action :install
   version node['datadog']['chef_handler_version']
+  # Chef 12 introduced `compile_time` - remove when Chef 11 is EOL.
+  compile_time true if respond_to?(:compile_time)
 end
 require 'chef/handler/datadog'
 

--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -20,7 +20,7 @@
 include_recipe 'chef_handler'
 ENV['DATADOG_HOST'] = node['datadog']['url']
 
-chef_gem 'chef-handler-datadog' do
+chef_gem 'chef-handler-datadog' do # ~FC009
   action :install
   version node['datadog']['chef_handler_version']
   # Chef 12 introduced `compile_time` - remove when Chef 11 is EOL.

--- a/test/integration/dd-handler/serverspec/dd-handler_spec.rb
+++ b/test/integration/dd-handler/serverspec/dd-handler_spec.rb
@@ -1,0 +1,8 @@
+require 'serverspec'
+
+set :backend, :exec
+set :path, '/sbin:/usr/local/sbin:$PATH'
+
+describe package('chef-handler-datadog') do
+  it { should be_installed.by('gem') }
+end


### PR DESCRIPTION
In Chef 12, the compile_time behavior flag was added, leading to WARN
messages showing up in the Chef Client execution.

Since the current method to invoke a handler is via a recipe, we need to
install the gem during compile time to allow loading the handler to
caputer execution items.

See https://www.chef.io/blog/2015/02/17/chef-12-1-0-chef_gem-resource-warnings/
for more details on the new flag.

Fixes #189