### PR TITLE
[doc] Updated Kafka doc for Agent 5.3

### DIFF
--- a/recipes/kafka.rb
+++ b/recipes/kafka.rb
@@ -10,7 +10,7 @@ include_recipe 'datadog::dd-agent'
 #     :host => "localhost",
 #     :port => "9999",
 #     :name => "prod",
-#     :username => "username",
+#     :user => "username",
 #     :password => "secret"
 #   },
 #   {


### PR DESCRIPTION
Username is now user, just like in dd-agent/conf.d/kafka.yaml.example.