### PR TITLE
Enable ability to match with epoch version numbers

### DIFF
--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -23,7 +23,7 @@ include_recipe 'datadog::repository' if node['datadog']['installrepo']
 dd_agent_version = node['datadog']['agent_version']
 
 # If version specified and lower than 5.x
-if !dd_agent_version.nil? && dd_agent_version.split('.')[0].to_i < 5
+if !dd_agent_version.nil? && dd_agent_version.match(/(\d{1,})\.\d{1,}\.\d\.*/)[1].to_i < 5
   # Select correct package name based on attribute
   dd_pkg_name = node['datadog']['install_base'] ? 'datadog-agent-base' : 'datadog-agent'
 


### PR DESCRIPTION
This fixes the version match if people are running their own repo and have an epoch on the version number. While rare this will keep it compatible with that.

EG:
5.3.2-1
1:5.3.2-1
2:5.3.2-1

All the above will match and find the correct major release version number. 

**NOTE:**
It appears that there are epoch versions on the packages in the ```apt.datadoghq.com``` repository, causing the if statement in its current form to never match correctly.