### PR TITLE
Updates to manage LWRP

### DIFF
--- a/providers/monitor.rb
+++ b/providers/monitor.rb
@@ -14,7 +14,7 @@ action :add do
       :instances   => new_resource.instances
     )
     cookbook new_resource.cookbook
-    notifies :restart, 'service[datadog-agent]', :delayed
+    notifies :restart, 'service[datadog-agent]', :delayed if node['datadog']['agent_start']
   end
   new_resource.updated_by_last_action(false)
 end
@@ -24,7 +24,7 @@ action :remove do
     Chef::Log.debug "Removing #{new_resource.name} from /etc/dd-agent/conf.d/"
     file "/etc/dd-agent/conf.d/#{new_resource.name}.yaml" do
       action :delete
-      notifies :restart, 'service[datadog-agent]', :delayed
+      notifies :restart, 'service[datadog-agent]', :delayed if node['datadog']['agent_start']
     end
     new_resource.updated_by_last_action(true)
   end

--- a/providers/monitor.rb
+++ b/providers/monitor.rb
@@ -13,6 +13,7 @@ action :add do
       :init_config => new_resource.init_config,
       :instances   => new_resource.instances
     )
+    cookbook new_resource.cookbook
     notifies :restart, 'service[datadog-agent]', :delayed
   end
   new_resource.updated_by_last_action(false)

--- a/resources/monitor.rb
+++ b/resources/monitor.rb
@@ -9,3 +9,10 @@ attribute :name, :kind_of => String, :name_attribute => true
 # is evaluated.
 attribute :init_config, :kind_of => Hash, :required => false, :default => {}
 attribute :instances, :kind_of => Array, :required => false, :default => []
+
+## We need access to `cookbook_name` from the instantiated Resource
+def cookbook(arg = nil)
+  set_or_return(:cookbook, arg,
+                :kind_of => String,
+                :default => cookbook_name)
+end

--- a/resources/monitor.rb
+++ b/resources/monitor.rb
@@ -4,15 +4,10 @@ actions :add, :remove
 default_action :add if defined?(default_action)
 
 attribute :name, :kind_of => String, :name_attribute => true
+attribute :cookbook, :kind_of => String, :default => 'datadog'
+
 # checks have 2 sections: init_config and instances
 # we mimic these here, no validation is performed until the template
 # is evaluated.
 attribute :init_config, :kind_of => Hash, :required => false, :default => {}
 attribute :instances, :kind_of => Array, :required => false, :default => []
-
-## We need access to `cookbook_name` from the instantiated Resource
-def cookbook(arg = nil)
-  set_or_return(:cookbook, arg,
-                :kind_of => String,
-                :default => cookbook_name)
-end


### PR DESCRIPTION
### Set cookbook attribute for template in manage provider
If the `cookbook` attribute is not defined for a template in an LWRP, the resource will search in the instantiating cookbook, not the defining (`datadog` in this case) cookbook, for its source.

### Restart notifications in manage provider
The manage resource issued restart notifications to the `datadog-agent` service regardless of the `node['datadog']['agent_start']` attribute. This could cause the service to start even though the desired state was stopped.