### PR TITLE
add cleanup rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@
 require 'emeril/rake' unless ENV['CI']
 require 'fileutils'
 require 'foodcritic'
+require 'rake/clean'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 
@@ -10,6 +11,9 @@ task :default => [
   :style,
   :spec
 ]
+
+CLEAN.include %w(.kitchen/ .yardoc/ coverage/)
+CLOBBER.include %w(doc/ Berksfile.lock Gemfile.lock)
 
 # Style tests. Rubocop and Foodcritic
 namespace :style do


### PR DESCRIPTION
Nothing changing in behavior, allows operator to run `rake clean` to
remove any logs, and `rake clobber` to remove .lock files