### PR TITLE
Add apt-transport-https to the repository install. In preparation for…

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -21,6 +21,10 @@ case node['platform_family']
 when 'debian'
   include_recipe 'apt'
 
+  package 'apt-transport-https' do
+    action :install
+  end
+
   apt_repository 'datadog' do
     keyserver 'hkp://keyserver.ubuntu.com:80'
     key 'C7A7DA52'

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -50,6 +50,10 @@ shared_examples_for 'debianoids' do
   it 'sets up an apt repo' do
     expect(@chef_run).to add_apt_repository('datadog')
   end
+
+  it 'installs apt-transport-https' do
+    expect(@chef_run). to install_package('apt-transport-https')
+  end
 end
 
 shared_examples_for 'rhellions' do


### PR DESCRIPTION
… HTTPS repo.

Without this already installed, when an https repo is added apt fails to update.

With this added it all works properly.

There are no changes needed for the YUM repo.