### PR TITLE
[yum] Add RPM signature check

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -37,7 +37,7 @@ when 'rhel', 'fedora'
     name 'datadog'
     description 'datadog'
     url node['datadog']['yumrepo']
-    gpgcheck false if respond_to? :gpgcheck
+    gpgkey 'https://yum.datadoghq.com/DATADOG_RPM_KEY.public'
     action :add
   end
 end


### PR DESCRIPTION
FIXME: Use HTTPs URL for both the key and the YUM repository as soon as
we're ready with that.