### PR TITLE
[zk] Make `timeout` attribute optional

### DIFF
--- a/templates/default/zk.yaml.erb
+++ b/templates/default/zk.yaml.erb
@@ -3,7 +3,9 @@ instances:
   <% @instances.each do |instance| -%>
   - host: <%= instance["host"] %>
     port: <%= instance["port"] %>
+    <% if instance.key?("timeout") -%>
     timeout: <%= instance["timeout"] %>
+    <% end -%>
     <% if instance.key?("tags") -%>
     tags:
       <% instance["tags"].each do |tag| -%>


### PR DESCRIPTION
Consistent with the check config in the agent.

Fixes #211