### PR TITLE
Fix `updated_by_last_action` value of `monitor` provider

### DIFF
--- a/providers/monitor.rb
+++ b/providers/monitor.rb
@@ -1,5 +1,8 @@
 # Creates the proper yaml file in /etc/dd-agent/conf.d/
 
+# Defined since Chef 11
+use_inline_resources if defined?(use_inline_resources)
+
 def whyrun_supported?
   true
 end
@@ -15,16 +18,16 @@ action :add do
     )
     notifies :restart, 'service[datadog-agent]', :delayed
   end
-  new_resource.updated_by_last_action(false)
+
+  service 'datadog-agent'
 end
 
 action :remove do
-  if ::File.exist?("/etc/dd-agent/conf.d/#{new_resource.name}.yaml")
-    Chef::Log.debug "Removing #{new_resource.name} from /etc/dd-agent/conf.d/"
-    file "/etc/dd-agent/conf.d/#{new_resource.name}.yaml" do
-      action :delete
-      notifies :restart, 'service[datadog-agent]', :delayed
-    end
-    new_resource.updated_by_last_action(true)
+  Chef::Log.debug "Removing #{new_resource.name} from /etc/dd-agent/conf.d/"
+  file "/etc/dd-agent/conf.d/#{new_resource.name}.yaml" do
+    action :delete
+    notifies :restart, 'service[datadog-agent]', :delayed
   end
+
+  service 'datadog-agent'
 end


### PR DESCRIPTION
Replaces #168 (see discussion there for more context on this issue)

`use_inline_resources` is the way to go to ensure that `updated_by_last_action` is correct.

It makes the provider actions run in their own run context, so we need to redefine the `datadog-agent` service in each action.

The behavior of the provider is preserved, except that the `datadog-agent` service gets restarted every time a config file is updated (instead of only being restarted once) when multiple files are updated in the same run.