### PR TITLE
[why-run] Skip dd-handler recipe in why-run mode

### DIFF
--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -17,6 +17,14 @@
 # limitations under the License.
 #
 
+if Chef::Config[:why_run]
+  # chef_handler 1.1 needs us to require datadog handler's file,
+  # which makes why-run runs fail when chef-handler-datadog is not installed,
+  # so skip the recipe when in why-run mode until we can use chef_handler 1.2
+  Chef::Log.warn('Running in why-run mode, skipping dd-handler')
+  return
+end
+
 include_recipe 'chef_handler'
 ENV['DATADOG_HOST'] = node['datadog']['url']
 


### PR DESCRIPTION
Running in why-run mode fails when the chef-handler-datadog gem is not
installed because of the `require 'chef/handler/datadog'` line, so we
skip the entire recipe in why-run mode.

Upgrading chef_handler to v1.2 (Chef>=12)  will allow us to remove that
`require` and unskip the recipe in why-run mode.

See #118