### PR TITLE
Add missing options for rabbitmq collector

### DIFF
--- a/templates/default/rabbitmq.yaml.erb
+++ b/templates/default/rabbitmq.yaml.erb
@@ -6,10 +6,40 @@ instances:
   - rabbitmq_api_url: <%= i['api_url'] %>
     rabbitmq_user: <%= i['user'] || 'guest' %>
     rabbitmq_pass: <%= i['pass'] || 'guest' %>
-    tags:
   <% if i.key?('tags') -%>
-    <% i['tags'].each do |t| -%>
-    - <%= t %>
+    tags:
+    <% i['tags'].each do |x| -%>
+    - <%= x %>
+    <% end -%>
+  <% end -%>
+  <% if i.key?('nodes') -%>
+    nodes:
+    <% i['nodes'].each do |x| -%>
+    - <%= x %>
+    <% end -%>
+  <% end -%>
+  <% if i.key?('nodes_regexes') -%>
+    nodes_regexes:
+    <% i['nodes_regexes'].each do |x| -%>
+    - <%= x %>
+    <% end -%>
+  <% end -%>
+  <% if i.key?('queues') -%>
+    queues:
+    <% i['queues'].each do |x| -%>
+    - <%= x %>
+    <% end -%>
+  <% end -%>
+  <% if i.key?('queues_regexes') -%>
+    queues_regexes:
+    <% i['queues_regexes'].each do |x| -%>
+    - <%= x %>
+    <% end -%>
+  <% end -%>
+  <% if i.key?('vhosts') -%>
+    vhosts:
+    <% i['vhosts'].each do |x| -%>
+    - <%= x %>
     <% end -%>
   <% end -%>
 <% end -%>


### PR DESCRIPTION
Adds the following: nodes, nodes_regexes, queues, queues_regexes, and vhosts