### PR TITLE
Add notify on failure of chef-client run

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -81,7 +81,7 @@ default['datadog']['chef_handler_version'] = nil
 default['datadog']['chef_handler_enable'] = true
 
 # List to notify in case of chef failures
-default['datadog']['handler']['notify_on_failure'] = []
+default['datadog']['handler']['notify_on_failure'] = nil
 
 # Log level. Should be a valid python log level https://docs.python.org/2/library/logging.html#logging-levels
 default['datadog']['log_level'] = 'INFO'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -80,6 +80,9 @@ default['datadog']['chef_handler_version'] = nil
 # Enable the Chef handler to report to datadog
 default['datadog']['chef_handler_enable'] = true
 
+# List to notify in case of chef failures
+default['datadog']['handler']['notify_on_failure'] = []
+
 # Log level. Should be a valid python log level https://docs.python.org/2/library/logging.html#logging-levels
 default['datadog']['log_level'] = 'INFO'
 

--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -34,8 +34,8 @@ chef_handler 'Chef::Handler::Datadog' do
   arguments [
     :api_key => node['datadog']['api_key'],
     :application_key => node['datadog']['application_key'],
-    :use_ec2_instance_id => node['datadog']['use_ec2_instance_id'],
-    :notify_on_failure => node['datadog']['handler']['notify_on_failure']
+    :notify_on_failure => node['datadog']['handler']['notify_on_failure'],
+    :use_ec2_instance_id => node['datadog']['use_ec2_instance_id']
   ]
   supports :report => true, :exception => true
   action :nothing

--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -34,7 +34,8 @@ chef_handler 'Chef::Handler::Datadog' do
   arguments [
     :api_key => node['datadog']['api_key'],
     :application_key => node['datadog']['application_key'],
-    :use_ec2_instance_id => node['datadog']['use_ec2_instance_id']
+    :use_ec2_instance_id => node['datadog']['use_ec2_instance_id'],
+    :notify_on_failure => node['datadog']['handler']['notify_on_failure']
   ]
   supports :report => true, :exception => true
   action :nothing


### PR DESCRIPTION
The dd-handler does not currently support notifications when chef fails.