### PR TITLE
Conditionally use HTTPS based on platform_version

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -41,7 +41,9 @@ when 'rhel', 'fedora'
     name 'datadog'
     description 'datadog'
     url node['datadog']['yumrepo']
-    gpgkey 'https://yum.datadoghq.com/DATADOG_RPM_KEY.public'
+    # Older versions of yum embed M2Crypto with SSL that doesn't support TLS1.2
+    prefix = node['platform_version'].to_i < 6 ? 'http' : 'https'
+    gpgkey "#{prefix}://yum.datadoghq.com/DATADOG_RPM_KEY.public"
     action :add
   end
 end

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -1,0 +1,37 @@
+describe 'datadog::repository' do
+  context 'rhellions' do
+    describe 'on versions 5.x and lower' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(
+          :platform => 'centos',
+          :version => '5.8'
+        ) do |node|
+          node.set['languages'] = { 'python' => { 'version' => '2.4.3' } }
+        end.converge described_recipe
+      end
+
+      it 'sets up a yum repo' do
+        expect(chef_run).to add_yum_repository('datadog').with(
+          gpgkey: 'http://yum.datadoghq.com/DATADOG_RPM_KEY.public'
+        )
+      end
+    end
+
+    describe 'on versions 6.x and higher' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(
+          :platform => 'centos',
+          :version => '6.3'
+        ) do |node|
+          node.set['languages'] = { 'python' => { 'version' => '2.7.3' } }
+        end.converge described_recipe
+      end
+
+      it 'sets up a yum repo' do
+        expect(chef_run).to add_yum_repository('datadog').with(
+          gpgkey: 'https://yum.datadoghq.com/DATADOG_RPM_KEY.public'
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Following #225.

CentOS 5 and earlier use an older version of yum, which embeds an older
version of M2Crypto, that when used against a modern cipher set (i.e. no
sslv3), fails when trying to retrieve the signing key with:

    ...
      File "/usr/lib64/python2.4/site-packages/M2Crypto/SSL/Connection.py",
line 167, in connect_ssl
        return m2.ssl_connect(self.ssl, self._timeout)
    M2Crypto.SSL.SSLError: sslv3 alert handshake failure

There doesn't seem to be any patches to update this behavior, so instead
switch on SSL for any system older than 6.x, continue to use http to
retrieve the key.

/cc @elafarge 