### PR TITLE
Let the agent set the default hostname

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -100,7 +100,7 @@ default['datadog']['check_freq'] = 15
 
 # Specify agent hostname
 # More information available here: http://docs.datadoghq.com/hostnames/#agent
-default['datadog']['hostname'] = node.name
+default['datadog']['hostname'] = nil
 
 # If running on ec2, if true, use the instance-id as the host identifier
 # rather than the hostname for chef-handler.

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -4,7 +4,9 @@
 dd_url: <%= @dd_url %>
 api_key: <%= @api_key %>
 check_freq: <%= node['datadog']['check_freq'] %>
+<% if node['datadog']['hostname'] -%>
 hostname: <%= node['datadog']['hostname'] %>
+<% end -%>
 use_mount: <%= node['datadog']['use_mount'] ? "yes" : "no"  %>
 listen_port: <%= node['datadog']['agent_port'] %>
 bind_host: <%= node['datadog']['bind_host'] %>


### PR DESCRIPTION
The hostname logic in the agent is more reliable

Defaulting to the node name can create some issues as the chef node
name can be based on the ip of the machine that could get recycled.
