### PR TITLE
Use non-deprecated python datadog library

### DIFF
--- a/recipes/dogstatsd-python.rb
+++ b/recipes/dogstatsd-python.rb
@@ -17,4 +17,4 @@
 # limitations under the License.
 #
 
-easy_install_package 'dogstatsd-python'
+easy_install_package 'datadog'


### PR DESCRIPTION
The current python package (https://github.com/DataDog/dogstatsd-python) is deprecated in favour of the 'datadog' package (https://github.com/DataDog/datadogpy)
