### PR TITLE
Fix tags template in kafka check

### DIFF
--- a/templates/default/kafka.yaml.erb
+++ b/templates/default/kafka.yaml.erb
@@ -27,7 +27,7 @@ instances:
     <% end -%>
     <% if i.key?('tags') -%>
     tags:
-      <% @tags.each do |k, v| -%>
+      <% i['tags'].each do |k, v| -%>
       <%= k %>: <%= v %>
       <% end -%>
     <% end -%>


### PR DESCRIPTION
`@tags` is never defined so if a `tags` key is present in the instance,
chef will throw:

```
undefined method `each' for nil:NilClass
```