### PR TITLE
Example doesn't work when it is rendered

### DIFF
--- a/recipes/jmx.rb
+++ b/recipes/jmx.rb
@@ -6,7 +6,7 @@ include_recipe 'datadog::dd-agent'
 #   node.override['datadog']['jmx']['instances'] = [
 #     {
 #       'host' => 'localhost',
-#       'port' => '7199',
+#       'port' => 7199,
 #       'name' 'prod_jmx_app',
 #       'conf' => [
 #         'include' => {


### PR DESCRIPTION
When this example is copied the line `'port' => '7199' `will be rendered as '7199'  in the template. Data dog complains about the port value being a non integer and the stats collection won't work. Small change but caused a headache.