### PR TITLE
add guard for old package removal

### DIFF
--- a/recipes/_install-linux.rb
+++ b/recipes/_install-linux.rb
@@ -35,6 +35,8 @@ else
   # default behavior, remove the `base` package as it is no longer needed
   package 'datadog-agent-base' do
     action :remove
+    not_if 'rpm -q datadog-agent-base' if %w(rhel fedora).include?(node['platform_family'])
+    not_if 'apt-cache policy datadog-agent-base | grep "Installed: (none)"' if node['platform_family'] == 'debian'
   end
   # Install the regular package
   package 'datadog-agent' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,11 @@ RSpec.configure do |config|
   # Supress deprecation warnings from `yum` cookbook.
   # @see https://github.com/chef-cookbooks/yum/issues/140
   config.log_level = :error
+
+  config.before do
+    stub_command('rpm -q datadog-agent-base')
+    stub_command('apt-cache policy datadog-agent-base | grep "Installed: (none)"')
+  end
 end
 
 ChefSpec::Coverage.start!


### PR DESCRIPTION
This will skip the removal of the `datadog-agent-base` package if it is not installed.
Due to how chef [checks to see if a package is installed](https://github.com/chef/chef/blob/8bf1304da739d4be94edb101ad9e46c96b1d4ccd/lib/chef/provider/package/apt.rb#L79-L97), and the fact that this package is a virtual package, chef always tries to uninstall the package even if it is not installed.