### PR TITLE
Add source & issues URLs for Supermarket

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,8 @@ license          'Apache 2.0'
 description      'Installs/Configures datadog components'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.1.0'
+source_url       'https://github.com/DataDog/chef-datadog' if respond_to? :source_url
+issues_url       'https://github.com/DataDog/chef-datadog/issues' if respond_to? :issues_url
 
 %w(
   amazon


### PR DESCRIPTION
Sets the URLs for the Supermarket in code, allowing visitors arriving at the Supermarket page to find their way easily to the GitHub project.