### PR TITLE
Added the option for stats metric namespace.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -159,6 +159,7 @@ default['datadog']['dogstatsd_interval'] = 10
 default['datadog']['dogstatsd_normalize'] = 'yes'
 default['datadog']['statsd_forward_host'] = nil
 default['datadog']['statsd_forward_port'] = 8125
+default['datadog']['statsd_metric_namespace'] = nil
 
 # For service-specific configuration, use the integration recipes included
 # in this cookbook, and apply them to the appropirate node's run list.

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -71,6 +71,10 @@ dogstatsd_normalize: <%= node['datadog']['dogstatsd_normalize'] %>
 statsd_forward_host: <%= node['datadog']['statsd_forward_host'] %>
 statsd_forward_port: <%= node['datadog']['statsd_forward_port'] %>
 <% end -%>
+
+<% if node['datadog']['statsd_metric_namespace'] -%>
+statsd_metric_namespace: <%= node['datadog']['statsd_metric_namespace'] %>
+<% end -%>
 <% end -%>
 
 # ========================================================================== #


### PR DESCRIPTION
Seemed like a simple enough change to support [statsd_metric_namespace](https://github.com/DataDog/dd-agent/blob/master/datadog.conf.example#L124).