### PR TITLE
Update Kafka configuration to 0.8.2 format

### DIFF
--- a/spec/integrations/kafka_spec.rb
+++ b/spec/integrations/kafka_spec.rb
@@ -1,0 +1,93 @@
+describe 'datadog::kafka' do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+      node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
+
+      node.set['datadog'] = {
+        'api_key' => 'someapikey',
+        'kafka' => {
+          'instances' => [
+            {
+              'host' => 'localhost',
+              'port' => 1234
+            }
+          ]
+        }
+      }
+    end.converge(described_recipe)
+  end
+
+  subject { chef_run }
+
+  it_behaves_like 'datadog-agent'
+
+  it { is_expected.to include_recipe('datadog::dd-agent') }
+
+  it { is_expected.to add_datadog_monitor('kafka') }
+
+  it 'renders expected YAML config file' do
+    expect(chef_run).to render_file('/etc/dd-agent/conf.d/kafka.yaml').with_content { |actual_yaml|
+      actual = YAML.load(actual_yaml)
+      expect(actual['instances']).to eq(
+        [
+          {
+            'host' => 'localhost',
+            'port' => 1234
+          }
+        ]
+      )
+    }
+  end
+
+  describe 'with optional values specified' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+        node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
+
+        node.set['datadog'] = {
+          'api_key' => 'someapikey',
+          'kafka' => {
+            'instances' => [
+              {
+                'host' => 'localhost',
+                'port' => 1234,
+                'name' => 'chef_spec_name',
+                'user' => 'chef_spec_user',
+                'password' => 'chef_spec_password',
+                'process_name_regex' => 'chef_spec.*',
+                'tools_jar_path' => '/chef/spec/tools.jar',
+                'java_bin_path' => '/chef/spec/java/bin',
+                'trust_store_path' => '/chef/spec/trusts',
+                'trust_store_password' => 'chef_spec_ts_password',
+                'tags' => {'key' => 'value'}
+              }
+            ]
+          }
+        }
+      end.converge(described_recipe)
+    end
+
+    it 'renders optional values into the config file' do
+      expect(chef_run).to render_file('/etc/dd-agent/conf.d/kafka.yaml').with_content { |actual_yaml|
+        actual = YAML.load(actual_yaml)
+        expect(actual['instances']).to eq(
+          [
+            {
+              'host' => 'localhost',
+              'port' => 1234,
+              'name' => 'chef_spec_name',
+              'user' => 'chef_spec_user',
+              'password' => 'chef_spec_password',
+              'process_name_regex' => 'chef_spec.*',
+              'tools_jar_path' => '/chef/spec/tools.jar',
+              'java_bin_path' => '/chef/spec/java/bin',
+              'trust_store_path' => '/chef/spec/trusts',
+              'trust_store_password' => 'chef_spec_ts_password',
+              'tags' => {'key' => 'value'}
+            }
+          ]
+        )
+      }
+    end
+  end
+end

--- a/templates/default/kafka.yaml.erb
+++ b/templates/default/kafka.yaml.erb
@@ -43,47 +43,61 @@ init_config:
     # Aggregate cluster stats
     #
     - include:
-        domain: '"kafka.server"'
-        bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsBytesOutPerSec"'
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec'
         attribute:
-          MeanRate:
-            metric_type: gauge
-            alias: kafka.net.bytes_out
+          Count:
+            metric_type: rate
+            alias: kafka.net.bytes_out.rate
     - include:
-        domain: '"kafka.server"'
-        bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsBytesInPerSec"'
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec'
         attribute:
-          MeanRate:
-            metric_type: gauge
-            alias: kafka.net.bytes_in
+          Count:
+            metric_type: rate
+            alias: kafka.net.bytes_in.rate
     - include:
-        domain: '"kafka.server"'
-        bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsMessagesInPerSec"'
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec'
         attribute:
-          MeanRate:
-            metric_type: gauge
-            alias: kafka.messages_in
+          Count:
+            metric_type: rate
+            alias: kafka.messages_in.rate
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=BrokerTopicMetrics,name=BytesRejectedPerSec'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.net.bytes_rejected.rate
 
     #
     # Request timings
     #
     - include:
-        domain: '"kafka.server"'
-        bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsFailedFetchRequestsPerSec"'
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=BrokerTopicMetrics,name=FailedFetchRequestsPerSec'
         attribute:
-          MeanRate:
-            metric_type: gauge
-            alias: kafka.request.fetch.failed
+          Count:
+            metric_type: rate
+            alias: kafka.request.fetch.failed.rate
     - include:
-        domain: '"kafka.server"'
-        bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsFailedProduceRequestsPerSec"'
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=BrokerTopicMetrics,name=FailedProduceRequestsPerSec'
         attribute:
-          MeanRate:
-            metric_type: gauge
-            alias: kafka.request.produce.failed
+          Count:
+            metric_type: rate
+            alias: kafka.request.produce.failed.rate
     - include:
-        domain: '"kafka.network"'
-        bean: '"kafka.network":type="RequestMetrics",name="Produce-TotalTimeMs"'
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestMetrics,name=RequestsPerSec,request=Produce'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.request.produce.rate
+    - include:
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestMetrics,name=TotalTimeMs,request=Produce'
         attribute:
           Mean:
             metric_type: gauge
@@ -92,18 +106,42 @@ init_config:
             metric_type: gauge
             alias: kafka.request.produce.time.99percentile
     - include:
-        domain: '"kafka.network"'
-        bean: '"kafka.network":type="RequestMetrics",name="Fetch-TotalTimeMs"'
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestMetrics,name=RequestsPerSec,request=FetchConsumer'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.request.fetch_consumer.rate
+    - include:
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestMetrics,name=RequestsPerSec,request=FetchFollower'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.request.fetch_follower.rate
+    - include:
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestMetrics,name=TotalTimeMs,request=FetchConsumer'
         attribute:
           Mean:
             metric_type: gauge
-            alias: kafka.request.fetch.time.avg
+            alias: kafka.request.fetch_consumer.time.avg
           99thPercentile:
             metric_type: gauge
-            alias: kafka.request.fetch.time.99percentile
+            alias: kafka.request.fetch_consumer.time.99percentile
     - include:
-        domain: '"kafka.network"'
-        bean: '"kafka.network":type="RequestMetrics",name="UpdateMetadata-TotalTimeMs"'
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestMetrics,name=TotalTimeMs,request=FetchFollower'
+        attribute:
+          Mean:
+            metric_type: gauge
+            alias: kafka.request.fetch_follower.time.avg
+          99thPercentile:
+            metric_type: gauge
+            alias: kafka.request.fetch_follower.time.99percentile
+    - include:
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestMetrics,name=TotalTimeMs,request=UpdateMetadata'
         attribute:
           Mean:
             metric_type: gauge
@@ -112,8 +150,8 @@ init_config:
             metric_type: gauge
             alias: kafka.request.update_metadata.time.99percentile
     - include:
-        domain: '"kafka.network"'
-        bean: '"kafka.network":type="RequestMetrics",name="Metadata-TotalTimeMs"'
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestMetrics,name=TotalTimeMs,request=Metadata'
         attribute:
           Mean:
             metric_type: gauge
@@ -122,8 +160,8 @@ init_config:
             metric_type: gauge
             alias: kafka.request.metadata.time.99percentile
     - include:
-        domain: '"kafka.network"'
-        bean: '"kafka.network":type="RequestMetrics",name="Offsets-TotalTimeMs"'
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestMetrics,name=TotalTimeMs,request=Offsets'
         attribute:
           Mean:
             metric_type: gauge
@@ -131,46 +169,109 @@ init_config:
           99thPercentile:
             metric_type: gauge
             alias: kafka.request.offsets.time.99percentile
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=KafkaRequestHandlerPool,name=RequestHandlerAvgIdlePercent'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.request.handler.avg.idle.pct.rate
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=ProducerRequestPurgatory,name=PurgatorySize'
+        attribute:
+          Value:
+            metric_type: gauge
+            alias: kafka.request.producer_request_purgatory.size
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=FetchRequestPurgatory,name=PurgatorySize'
+        attribute:
+          Value:
+            metric_type: gauge
+            alias: kafka.request.fetch_request_purgatory.size
 
     #
     # Replication stats
     #
     - include:
-        domain: '"kafka.server"'
-        bean: '"kafka.server":type="ReplicaManager",name="ISRShrinksPerSec"'
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=ReplicaManager,name=UnderReplicatedPartitions'
         attribute:
-          MeanRate:
+          Value:
             metric_type: gauge
-            alias: kafka.replication.isr_shrinks
+            alias: kafka.replication.under_replicated_partitions
     - include:
-        domain: '"kafka.server"'
-        bean: '"kafka.server":type="ReplicaManager",name="ISRExpandsPerSec"'
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=ReplicaManager,name=IsrShrinksPerSec'
         attribute:
-          MeanRate:
-            metric_type: gauge
-            alias: kafka.replication.isr_expands
+          Count:
+            metric_type: rate
+            alias: kafka.replication.isr_shrinks.rate
     - include:
-        domain: '"kafka.server"'
-        bean: '"kafka.server":type="ControllerStats",name="LeaderElectionRateAndTimeMs"'
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=ReplicaManager,name=IsrExpandsPerSec'
         attribute:
-          MeanRate:
-            metric_type: gauge
-            alias: kafka.replication.leader_elections
+          Count:
+            metric_type: rate
+            alias: kafka.replication.isr_expands.rate
     - include:
-        domain: '"kafka.server"'
-        bean: '"kafka.server":type="ControllerStats",name="UncleanLeaderElectionsPerSec"'
+        domain: 'kafka.controller'
+        bean: 'kafka.controller:type=ControllerStats,name=LeaderElectionRateAndTimeMs'
         attribute:
-          MeanRate:
+          Count:
+            metric_type: rate
+            alias: kafka.replication.leader_elections.rate
+    - include:
+        domain: 'kafka.controller'
+        bean: 'kafka.controller:type=ControllerStats,name=UncleanLeaderElectionsPerSec'
+        attribute:
+          Count:
+            metric_type: rate
+            alias: kafka.replication.unclean_leader_elections.rate
+    - include:
+        domain: 'kafka.controller'
+        bean: 'kafka.controller:type=KafkaController,name=OfflinePartitionsCount'
+        attribute:
+          Count:
             metric_type: gauge
-            alias: kafka.replication.unclean_leader_elections
+            alias: kafka.replication.offline_partitions_count
+    - include:
+        domain: 'kafka.controller'
+        bean: 'kafka.controller:type=KafkaController,name=ActiveControllerCount'
+        attribute:
+          Count:
+            metric_type: gauge
+            alias: kafka.replication.active_controller_count
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=ReplicaManager,name=PartitionCount'
+        attribute:
+          Count:
+            metric_type: gauge
+            alias: kafka.replication.partition_count
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=ReplicaManager,name=LeaderCount'
+        attribute:
+          Count:
+            metric_type: gauge
+            alias: kafka.replication.leader_count
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=ReplicaFetcherManager,name=MaxLag,clientId=Replica'
+        attribute:
+          Value:
+            metric_type: gauge
+            alias: kafka.replication.max_lag
 
     #
     # Log flush stats
     #
     - include:
-        domain: '"kafka.log"'
-        bean: '"kafka.log":type="LogFlushStats",name="LogFlushRateAndTimeMs"'
+        domain: 'kafka.log'
+        bean: 'kafka.log:type=LogFlushStats,name=LogFlushRateAndTimeMs'
         attribute:
-          MeanRate:
-            metric_type: gauge
-            alias: kafka.log.flush_rate
+          Count:
+            metric_type: rate
+            alias: kafka.log.flush_rate.rate


### PR DESCRIPTION
This changes the Chef template to render a file that closely aligns with the [example configuration](https://github.com/DataDog/dd-agent/pull/2079) provided with the dd-agent code. More details on the changes in the configuration file can be found the dd-agent repository.

With this change, the rendered file will only correctly collect metrics on brokers that are on 0.8.2 or higher.