### PR TITLE
Fixes for dealing with ddagent.exe under windows service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The code is licensed under the Apache License 2.0 (see  LICENSE for details).
 Datadog Cookbook
 ================
 
+RCSAVAGE'S CRUDE FIX FOR DEALING WITH WINDOWS AGENTS.
 Chef recipes to deploy Datadog's components and configuration automatically.
 
 Requirements

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,10 +1,10 @@
 name             'datadog'
 maintainer       'Datadog'
-maintainer_email 'package@datadoghq.com'
+maintainer_email 'rsavage@aptos.com'
 license          'Apache 2.0'
 description      'Installs/Configures datadog components'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.2.0'
+version          '2.2.1'
 source_url       'https://github.com/DataDog/chef-datadog' if respond_to? :source_url
 issues_url       'https://github.com/DataDog/chef-datadog/issues' if respond_to? :issues_url
 

--- a/recipes/_install-linux.rb
+++ b/recipes/_install-linux.rb
@@ -37,10 +37,12 @@ else
     action :remove
     not_if 'rpm -q datadog-agent-base' if %w(rhel fedora).include?(node['platform_family'])
     not_if 'apt-cache policy datadog-agent-base | grep "Installed: (none)"' if node['platform_family'] == 'debian'
+    options '-y'
   end
   # Install the regular package
   package 'datadog-agent' do
     version dd_agent_version
     action node['datadog']['agent_package_action'] # default is :install
+    options '-y'
   end
 end

--- a/test/integration/datadog_activemq/serverspec/Gemfile
+++ b/test/integration/datadog_activemq/serverspec/Gemfile
@@ -1,1 +1,3 @@
-../../helpers/serverspec/Gemfile
+source 'https://rubygems.org'
+
+gem 'json_spec', '~> 1.1'

--- a/test/integration/datadog_apache/serverspec/Gemfile
+++ b/test/integration/datadog_apache/serverspec/Gemfile
@@ -1,1 +1,3 @@
-../../helpers/serverspec/Gemfile
+source 'https://rubygems.org'
+
+gem 'json_spec', '~> 1.1'

--- a/test/integration/datadog_cacti/serverspec/Gemfile
+++ b/test/integration/datadog_cacti/serverspec/Gemfile
@@ -1,1 +1,3 @@
-../../helpers/serverspec/Gemfile
+source 'https://rubygems.org'
+
+gem 'json_spec', '~> 1.1'

--- a/test/integration/datadog_cassandra/serverspec/Gemfile
+++ b/test/integration/datadog_cassandra/serverspec/Gemfile
@@ -1,1 +1,3 @@
-../../helpers/serverspec/Gemfile
+source 'https://rubygems.org'
+
+gem 'json_spec', '~> 1.1'

--- a/test/integration/datadog_consul/serverspec/Gemfile
+++ b/test/integration/datadog_consul/serverspec/Gemfile
@@ -1,1 +1,3 @@
-../../helpers/serverspec/Gemfile
+source 'https://rubygems.org'
+
+gem 'json_spec', '~> 1.1'

--- a/test/integration/datadog_couchdb/serverspec/Gemfile
+++ b/test/integration/datadog_couchdb/serverspec/Gemfile
@@ -1,1 +1,3 @@
-../../helpers/serverspec/Gemfile
+source 'https://rubygems.org'
+
+gem 'json_spec', '~> 1.1'

--- a/test/integration/datadog_docker/serverspec/Gemfile
+++ b/test/integration/datadog_docker/serverspec/Gemfile
@@ -1,1 +1,3 @@
-../../helpers/serverspec/Gemfile
+source 'https://rubygems.org'
+
+gem 'json_spec', '~> 1.1'

--- a/test/integration/datadog_elasticsearch/serverspec/Gemfile
+++ b/test/integration/datadog_elasticsearch/serverspec/Gemfile
@@ -1,1 +1,3 @@
-../../helpers/serverspec/Gemfile
+source 'https://rubygems.org'
+
+gem 'json_spec', '~> 1.1'

--- a/test/integration/datadog_fluentd/serverspec/Gemfile
+++ b/test/integration/datadog_fluentd/serverspec/Gemfile
@@ -1,1 +1,3 @@
-../../helpers/serverspec/Gemfile
+source 'https://rubygems.org'
+
+gem 'json_spec', '~> 1.1'

--- a/test/integration/datadog_haproxy/serverspec/Gemfile
+++ b/test/integration/datadog_haproxy/serverspec/Gemfile
@@ -1,1 +1,3 @@
-../../helpers/serverspec/Gemfile
+source 'https://rubygems.org'
+
+gem 'json_spec', '~> 1.1'

--- a/test/integration/datadog_http_check/serverspec/Gemfile
+++ b/test/integration/datadog_http_check/serverspec/Gemfile
@@ -1,1 +1,3 @@
-../../helpers/serverspec/Gemfile
+source 'https://rubygems.org'
+
+gem 'json_spec', '~> 1.1'

--- a/test/integration/datadog_jmx/serverspec/Gemfile
+++ b/test/integration/datadog_jmx/serverspec/Gemfile
@@ -1,1 +1,3 @@
-../../helpers/serverspec/Gemfile
+source 'https://rubygems.org'
+
+gem 'json_spec', '~> 1.1'

--- a/test/integration/datadog_kafka/serverspec/Gemfile
+++ b/test/integration/datadog_kafka/serverspec/Gemfile
@@ -1,1 +1,3 @@
-../../helpers/serverspec/Gemfile
+source 'https://rubygems.org'
+
+gem 'json_spec', '~> 1.1'

--- a/test/integration/datadog_mesos/serverspec/Gemfile
+++ b/test/integration/datadog_mesos/serverspec/Gemfile
@@ -1,1 +1,3 @@
-../../helpers/serverspec/Gemfile
+source 'https://rubygems.org'
+
+gem 'json_spec', '~> 1.1'

--- a/test/integration/datadog_ntp/serverspec/Gemfile
+++ b/test/integration/datadog_ntp/serverspec/Gemfile
@@ -1,1 +1,3 @@
-../../helpers/serverspec/Gemfile
+source 'https://rubygems.org'
+
+gem 'json_spec', '~> 1.1'

--- a/test/integration/datadog_pgbouncer/serverspec/Gemfile
+++ b/test/integration/datadog_pgbouncer/serverspec/Gemfile
@@ -1,1 +1,3 @@
-../../helpers/serverspec/Gemfile
+source 'https://rubygems.org'
+
+gem 'json_spec', '~> 1.1'

--- a/test/integration/datadog_postfix/serverspec/Gemfile
+++ b/test/integration/datadog_postfix/serverspec/Gemfile
@@ -1,1 +1,3 @@
-../../helpers/serverspec/Gemfile
+source 'https://rubygems.org'
+
+gem 'json_spec', '~> 1.1'

--- a/test/integration/datadog_process/serverspec/Gemfile
+++ b/test/integration/datadog_process/serverspec/Gemfile
@@ -1,1 +1,3 @@
-../../helpers/serverspec/Gemfile
+source 'https://rubygems.org'
+
+gem 'json_spec', '~> 1.1'

--- a/test/integration/datadog_supervisord/serverspec/Gemfile
+++ b/test/integration/datadog_supervisord/serverspec/Gemfile
@@ -1,1 +1,3 @@
-../../helpers/serverspec/Gemfile
+source 'https://rubygems.org'
+
+gem 'json_spec', '~> 1.1'

--- a/test/integration/datadog_tcp_check/serverspec/Gemfile
+++ b/test/integration/datadog_tcp_check/serverspec/Gemfile
@@ -1,1 +1,3 @@
-../../helpers/serverspec/Gemfile
+source 'https://rubygems.org'
+
+gem 'json_spec', '~> 1.1'


### PR DESCRIPTION
The current datadog dd-agent recipe does not restart the Windows Service 'DatadogAgent' well.  It seems to be that the ddagent.exe (executable) is not responsive to SC commands.   So, I have put in a crude fix to taskkill the service.   I understand it's not the best approach but my changes actually work.
