### PR TITLE
[cassandra] YAML configuration template versioning

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -135,6 +135,21 @@ suites:
             password: somepass
             process_name_regex: .*cassandra.*
 
+- name: datadog_cassandra_version
+  run_list:
+    - recipe[datadog::cassandra]
+  attributes:
+    datadog:
+      <<: *DATADOG
+      cassandra:
+        version: 2
+        instances:
+          - host: localhost
+            port: 7199
+            user: someuser
+            password: somepass
+            process_name_regex: .*cassandra.*
+
 - name: datadog_couchdb
   run_list:
     - recipe[datadog::couchdb]

--- a/attributes/cassandra.rb
+++ b/attributes/cassandra.rb
@@ -1,0 +1,1 @@
+default['datadog']['cassandra']['version'] = 1

--- a/providers/monitor.rb
+++ b/providers/monitor.rb
@@ -20,7 +20,8 @@ action :add do
     end
     variables(
       :init_config => new_resource.init_config,
-      :instances   => new_resource.instances
+      :instances => new_resource.instances,
+      :version => new_resource.version
     )
     cookbook new_resource.cookbook
     sensitive true if Chef::Resource.instance_methods(false).include?(:sensitive)

--- a/recipes/cassandra.rb
+++ b/recipes/cassandra.rb
@@ -1,29 +1,41 @@
 include_recipe 'datadog::dd-agent'
 
-# Monitor cassandra
-#
-# Assuming you have 2 clusters "test" and "prod",
-# one with and one without authentication
-# you need to set up the following attributes
-#
-# node['datadog']['cassandra']['instances'] = [
-#   {
-#     host: 'localhost',
-#     port: 7199,
-#     name: 'prod',
-#     user: 'username',
-#     password: 'secret'
-#   },
-#   {
-#     server: 'localhost',
-#     port: 8199,
-#     name: 'test'
-#   }
-# ]
-#
-# See here for more configuration values:
-# https://github.com/DataDog/dd-agent/blob/master/conf.d/cassandra.yaml.example
-#
+# Monitor Cassandra
+
+# Set the following attributes
+# * `instances` (required)
+#   List of Cassandra clusters to monitor. Each cluster is generally a dictionary with a `host`, `port` and a `name`.
+#   More attributes are available. For more information, please refer to : https://github.com/DataDog/dd-agent/blob/master/conf.d/cassandra.yaml.example
+# * `version` (optional)
+#   Select the appropriate configuration file template. Available options are:
+#   * `1` (Default, recommended for Cassandra < 2.2).
+#     Use Cassandra legacy metrics, i.e. https://github.com/DataDog/dd-agent/blob/5.6.x/conf.d/cassandra.yaml.example#L23-L74
+#   * `2` (recommended for Cassandra >= 2.2).
+#     Use Cassandra expanded metrics (CASSANDRA-4009) introduced in 1.2 (https://wiki.apache.org/cassandra/Metrics),
+#     i.e. https://github.com/DataDog/dd-agent/blob/master/conf.d/cassandra.yaml.example#L23-L102
+
+# Example:
+
+# ```
+# node['datadog']['cassandra'] =
+#     instances: [
+#     {
+#         host: 'localhost',
+#         port: 7199,
+#         name: 'prod',
+#         user: 'username',
+#         password: 'secret'
+#     },
+#     {
+#         server: 'localhost',
+#         port: 8199,
+#         name: 'test'
+#     }],
+#     version: 2
+# }
+# ```
+
 datadog_monitor 'cassandra' do
   instances node['datadog']['cassandra']['instances']
+  version node['datadog']['cassandra']['version']
 end

--- a/resources/monitor.rb
+++ b/resources/monitor.rb
@@ -11,3 +11,4 @@ attribute :cookbook, :kind_of => String, :default => 'datadog'
 # is evaluated.
 attribute :init_config, :kind_of => Hash, :required => false, :default => {}
 attribute :instances, :kind_of => Array, :required => false, :default => []
+attribute :version, :kind_of => Integer, :required => false, :default => nil

--- a/spec/integrations/cassandra_spec.rb
+++ b/spec/integrations/cassandra_spec.rb
@@ -1,0 +1,363 @@
+describe 'datadog::cassandra' do
+  context 'version 1 (default)' do
+    expected_yaml = <<-EOF
+      instances:
+        - host: localhost
+          port: 7199
+          cassandra_aliasing: true
+          user: someuser
+          password: somepass
+          process_name_regex: .*cassandra.*
+
+      init_config:
+        conf:
+          - include:
+              domain: org.apache.cassandra.db
+              attribute:
+                - BloomFilterDiskSpaceUsed
+                - BloomFilterFalsePositives
+                - BloomFilterFalseRatio
+                - Capacity
+                - CompletedTasks
+                - CompressionRatio
+                - ExceptionCount
+                - Hits
+                - KeyCacheRecentHitRate
+                - LiveDiskSpaceUsed
+                - LiveSSTableCount
+                - Load
+                - MaxRowSize
+                - MeanRowSize
+                - MemtableColumnsCount
+                - MemtableDataSize
+                - MemtableSwitchCount
+                - MinRowSize
+                - PendingTasks
+                - ReadCount
+                - RecentHitRate
+                - RecentRangeLatencyMicros
+                - RecentReadLatencyMicros
+                - RecentWriteLatencyMicros
+                - Requests
+                - RowCacheRecentHitRate
+                - Size
+                - TotalDiskSpaceUsed
+                - TotalReadLatencyMicros
+                - TotalWriteLatencyMicros
+                - UpdateInterval
+                - WriteCount
+            exclude:
+              keyspace: system
+          - include:
+              domain: org.apache.cassandra.internal
+              attribute:
+                - ActiveCount
+                - CompletedTasks
+                - CurrentlyBlockedTasks
+                - TotalBlockedTasks
+          - include:
+              domain: org.apache.cassandra.net
+              attribute:
+                - TotalTimeouts
+    EOF
+
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+        node.automatic['languages'] = { python: { version: '2.7.2' } }
+
+        node.set['datadog'] = {
+          api_key: 'someapikey',
+          cassandra: {
+            instances: [
+              {
+                host: 'localhost',
+                port: 7199,
+                user: 'someuser',
+                password: 'somepass',
+                process_name_regex: '.*cassandra.*'
+              }
+            ],
+            init_config: {
+              conf: [
+                {
+                  include: {
+                    domain: 'org.apache.cassandra.db',
+                    attribute: %w(
+                      BloomFilterDiskSpaceUsed
+                      BloomFilterFalsePositives
+                      BloomFilterFalseRatio
+                      Capacity
+                      CompletedTasks
+                      CompressionRatio
+                      ExceptionCount
+                      Hits
+                      KeyCacheRecentHitRate
+                      LiveDiskSpaceUsed
+                      LiveSSTableCount
+                      Load
+                      MaxRowSize
+                      MeanRowSize
+                      MemtableColumnsCount
+                      MemtableDataSize
+                      MemtableSwitchCount
+                      MinRowSize
+                      PendingTasks
+                      ReadCount
+                      RecentHitRate
+                      RecentRangeLatencyMicros
+                      RecentReadLatencyMicros
+                      RecentWriteLatencyMicros
+                      Requests
+                      RowCacheRecentHitRate
+                      Size
+                      TotalDiskSpaceUsed
+                      TotalReadLatencyMicros
+                      TotalWriteLatencyMicros
+                      UpdateInterval
+                      WriteCount
+                    )
+                  },
+                  exclude: {
+                    keyspace: 'system'
+                  }
+                },
+                {
+                  include: {
+                    domain: 'org.apache.cassandra.internal',
+                    attribute: [
+                      'ActiveCount',
+                      'CompletedTasks',
+                      'CurrentlyBlockedTasks',
+                      'TotalBlockedTasks'
+                    ]
+                  }
+                },
+                {
+                  include: {
+                    domain: 'org.apache.cassandra.net',
+                    attribute: [
+                      'TotalTimeouts'
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      end.converge(described_recipe)
+    end
+
+    subject { chef_run }
+
+    it_behaves_like 'datadog-agent'
+
+    it { is_expected.to include_recipe('datadog::dd-agent') }
+
+    it { is_expected.to add_datadog_monitor('cassandra') }
+
+    it 'renders expected YAML config file' do
+      expect(chef_run).to render_file('/etc/dd-agent/conf.d/cassandra.yaml').with_content { |content|
+        expect(YAML.load(content).to_json).to be_json_eql(YAML.load(expected_yaml).to_json)
+      }
+    end
+  end
+
+  context 'version 2' do
+    expected_yaml = <<-EOF
+    instances:
+      - host: localhost
+        port: 7199
+        cassandra_aliasing: true
+        user: someuser
+        password: somepass
+        process_name_regex: .*cassandra.*
+
+    init_config:
+      conf:
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: ClientRequest
+            scope:
+              - Read
+              - Write
+            name:
+              - Latency
+              - Timeouts
+              - Unavailables
+            attribute:
+              - Count
+              - OneMinuteRate
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: ClientRequest
+            scope:
+              - Read
+              - Write
+            name:
+              - TotalLatency
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: Storage
+            name:
+              - Load
+              - Exceptions
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: ColumnFamily
+            bean_regex:
+              - .*keyspace=.*
+            name:
+              - TotalDiskSpaceUsed
+              - BloomFilterDiskSpaceUsed
+              - BloomFilterFalsePositives
+              - BloomFilterFalseRatio
+              - CompressionRatio
+              - LiveDiskSpaceUsed
+              - LiveSSTableCount
+              - MaxRowSize
+              - MeanRowSize
+              - MemtableColumnsCount
+              - MemtableLiveDataSize
+              - MemtableSwitchCount
+              - MinRowSize
+          exclude:
+            keyspace:
+              - OpsCenter
+              - system
+              - system_auth
+              - system_distributed
+              - system_schema
+              - system_traces
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: Cache
+            name:
+              - Capacity
+              - Size
+            attribute:
+              - Value
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: Cache
+            name:
+              - Hits
+              - Requests
+            attribute:
+              - Count
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: ThreadPools
+            path: request
+            name:
+              - ActiveTasks
+              - CompletedTasks
+              - PendingTasks
+              - CurrentlyBlockedTasks
+        - include:
+            domain: org.apache.cassandra.db
+            attribute:
+              - UpdateInterval
+    EOF
+
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+        node.automatic['languages'] = { python: { version: '2.7.2' } }
+
+        node.set['datadog'] = {
+          api_key: 'someapikey',
+          cassandra: {
+            version: 2,
+            instances: [
+              {
+                host: 'localhost',
+                port: 7199,
+                user: 'someuser',
+                password: 'somepass',
+                process_name_regex: '.*cassandra.*'
+              }
+            ],
+            init_config: {
+              conf: [
+                {
+                  include: {
+                    domain: 'org.apache.cassandra.db',
+                    attribute: %w(
+                      BloomFilterDiskSpaceUsed
+                      BloomFilterFalsePositives
+                      BloomFilterFalseRatio
+                      Capacity
+                      CompletedTasks
+                      CompressionRatio
+                      ExceptionCount
+                      Hits
+                      KeyCacheRecentHitRate
+                      LiveDiskSpaceUsed
+                      LiveSSTableCount
+                      Load
+                      MaxRowSize
+                      MeanRowSize
+                      MemtableColumnsCount
+                      MemtableDataSize
+                      MemtableSwitchCount
+                      MinRowSize
+                      PendingTasks
+                      ReadCount
+                      RecentHitRate
+                      RecentRangeLatencyMicros
+                      RecentReadLatencyMicros
+                      RecentWriteLatencyMicros
+                      Requests
+                      RowCacheRecentHitRate
+                      Size
+                      TotalDiskSpaceUsed
+                      TotalReadLatencyMicros
+                      TotalWriteLatencyMicros
+                      UpdateInterval
+                      WriteCount
+                    )
+                  },
+                  exclude: {
+                    keyspace: 'system'
+                  }
+                },
+                {
+                  include: {
+                    domain: 'org.apache.cassandra.internal',
+                    attribute: [
+                      'ActiveCount',
+                      'CompletedTasks',
+                      'CurrentlyBlockedTasks',
+                      'TotalBlockedTasks'
+                    ]
+                  }
+                },
+                {
+                  include: {
+                    domain: 'org.apache.cassandra.net',
+                    attribute: [
+                      'TotalTimeouts'
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      end.converge(described_recipe)
+    end
+
+    subject { chef_run }
+
+    it_behaves_like 'datadog-agent'
+
+    it { is_expected.to include_recipe('datadog::dd-agent') }
+
+    it { is_expected.to add_datadog_monitor('cassandra') }
+
+    it 'renders expected YAML config file' do
+      expect(chef_run).to render_file('/etc/dd-agent/conf.d/cassandra.yaml').with_content { |content|
+        expect(YAML.load(content).to_json).to be_json_eql(YAML.load(expected_yaml).to_json)
+      }
+    end
+  end
+end

--- a/templates/default/cassandra.yaml.erb
+++ b/templates/default/cassandra.yaml.erb
@@ -42,6 +42,8 @@ init_config:
     - include:
         domain: org.apache.cassandra.metrics
         type: ColumnFamily
+        bean_regex:
+          - .*keyspace=.*
         name:
           - TotalDiskSpaceUsed
           - BloomFilterDiskSpaceUsed
@@ -58,9 +60,11 @@ init_config:
           - MinRowSize
       exclude:
         keyspace:
+          - OpsCenter
           - system
           - system_auth
           - system_distributed
+          - system_schema
           - system_traces
     - include:
         domain: org.apache.cassandra.metrics

--- a/templates/default/cassandra.yaml.erb
+++ b/templates/default/cassandra.yaml.erb
@@ -4,8 +4,94 @@ instances:
   <% (i.keys - ['host']).each do |key| -%>
     <%= key %>: <%= i[key] %>
   <% end -%>
+    cassandra_aliasing: true
 <% end -%>
 
+<% if @version == 2 %>
+init_config:
+  # List of metrics to be collected by the integration
+  # Read http://docs.datadoghq.com/integrations/java/ to learn how to customize it
+  conf:
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: ClientRequest
+        scope:
+          - Read
+          - Write
+        name:
+          - Latency
+          - Timeouts
+          - Unavailables
+        attribute:
+          - Count
+          - OneMinuteRate
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: ClientRequest
+        scope:
+          - Read
+          - Write
+        name:
+          - TotalLatency
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: Storage
+        name:
+          - Load
+          - Exceptions
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: ColumnFamily
+        name:
+          - TotalDiskSpaceUsed
+          - BloomFilterDiskSpaceUsed
+          - BloomFilterFalsePositives
+          - BloomFilterFalseRatio
+          - CompressionRatio
+          - LiveDiskSpaceUsed
+          - LiveSSTableCount
+          - MaxRowSize
+          - MeanRowSize
+          - MemtableColumnsCount
+          - MemtableLiveDataSize
+          - MemtableSwitchCount
+          - MinRowSize
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: Cache
+        name:
+          - Capacity
+          - Size
+        attribute:
+          - Value
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: Cache
+        name:
+          - Hits
+          - Requests
+        attribute:
+          - Count
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: ThreadPools
+        path: request
+        name:
+          - ActiveTasks
+          - CompletedTasks
+          - PendingTasks
+          - CurrentlyBlockedTasks
+    - include:
+        domain: org.apache.cassandra.db
+        attribute:
+          - UpdateInterval
+<% else %>
 # List of metrics to be collected.
 init_config:
   conf:
@@ -57,3 +143,4 @@ init_config:
         domain: org.apache.cassandra.net
         attribute:
           - TotalTimeouts
+<% end %>

--- a/test/integration/datadog_cassandra/serverspec/cassandra_spec.rb
+++ b/test/integration/datadog_cassandra/serverspec/cassandra_spec.rb
@@ -20,7 +20,8 @@ describe file(AGENT_CONFIG) do
           port: 7199,
           user: 'someuser',
           password: 'somepass',
-          process_name_regex: '.*cassandra.*'
+          process_name_regex: '.*cassandra.*',
+          cassandra_aliasing: true
         }
       ],
       'init_config' => {

--- a/test/integration/datadog_cassandra_greater_22/serverspec/Gemfile
+++ b/test/integration/datadog_cassandra_greater_22/serverspec/Gemfile
@@ -1,0 +1,1 @@
+../../helpers/serverspec/Gemfile

--- a/test/integration/datadog_cassandra_greater_22/serverspec/cassandra_spec.rb
+++ b/test/integration/datadog_cassandra_greater_22/serverspec/cassandra_spec.rb
@@ -1,0 +1,152 @@
+# Encoding: utf-8
+require 'spec_helper'
+
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/cassandra.yaml')
+
+describe service(@agent_service_name) do
+  it { should be_running }
+end
+
+describe file(AGENT_CONFIG) do
+  it { should be_a_file }
+
+  it 'is valid yaml matching input values' do
+    generated = YAML.load_file(AGENT_CONFIG)
+
+    expected = {
+      'instances' => [
+        {
+          host: 'localhost',
+          port: 7199,
+          user: 'someuser',
+          password: 'somepass',
+          process_name_regex: '.*cassandra.*',
+          cassandra_aliasing: true
+        }
+      ],
+      'init_config' => {
+        conf: [
+          {
+            include: {
+              domain: 'org.apache.cassandra.metrics',
+              type: 'ClientRequest',
+              scope: [
+                'Read',
+                'Write'
+              ],
+              name: [
+                'Latency',
+                'Timeouts',
+                'Unavailables'
+              ],
+              attribute: [
+                'Count',
+                'OneMinuteRate'
+              ]
+            }
+          },
+          {
+            include: {
+              domain: 'org.apache.cassandra.metrics',
+              type: 'ClientRequest',
+              scope: [
+                'Read',
+                'Write'
+              ],
+              name: [
+                'TotalLatency'
+              ]
+            }
+          },
+          {
+            include: {
+              domain: 'org.apache.cassandra.metrics',
+              type: 'Storage',
+              name: [
+                'Load',
+                'Exceptions'
+              ]
+            }
+          },
+          {
+            include: {
+              domain: 'org.apache.cassandra.metrics',
+              type: 'ColumnFamily',
+              name: %w(
+                TotalDiskSpaceUsed
+                BloomFilterDiskSpaceUsed
+                BloomFilterFalsePositives
+                BloomFilterFalseRatio
+                CompressionRatio
+                LiveDiskSpaceUsed
+                LiveSSTableCount
+                MaxRowSize
+                MeanRowSize
+                MemtableColumnsCount
+                MemtableLiveDataSize
+                MemtableSwitchCount
+                MinRowSize)
+            },
+            exclude: {
+              keyspace: [
+                'system',
+                'system_auth',
+                'system_distributed',
+                'system_traces'
+              ]
+            }
+          },
+          {
+            include: {
+              domain: 'org.apache.cassandra.metrics',
+              type: 'Cache',
+              name: [
+                'Capacity',
+                'Size'
+              ],
+              attribute: [
+                'Value'
+              ]
+            }
+          },
+          {
+            include: {
+              domain: 'org.apache.cassandra.metrics',
+              type: 'Cache',
+              name: [
+                'Hits',
+                'Requests'
+              ],
+              attribute: [
+                'Count'
+              ]
+            }
+          },
+          {
+            include: {
+              domain: 'org.apache.cassandra.metrics',
+              type: 'ThreadPools',
+              path: 'request',
+              name: [
+                'ActiveTasks',
+                'CompletedTasks',
+                'PendingTasks',
+                'CurrentlyBlockedTasks'
+              ]
+            }
+          },
+          {
+            include: {
+              domain: 'org.apache.cassandra.db',
+              attribute: [
+                'UpdateInterval'
+              ]
+            }
+          }
+        ]
+      }
+    }
+
+    expect(generated.to_json).to be_json_eql expected.to_json
+  end
+end


### PR DESCRIPTION
#### [cassandra] YAML configuration template versioning

* Enhance `DatadogMonitor` resource with a `version` attribute.
* Use `version` attribute in `cassandra` recipe to version, i.e.
  select the appriopriate YAML configuration file.
  Two versions are currently available
  * `1` (Default): Legacy YAML configuration file, compatible with
    Cassandra < 2.2.
  * `2`: Required for Cassandra > 2.2, use the YAML configuration file introduced with
    https://github.com/DataDog/dd-agent/commit/2df7566d2d1881ec3a2722a0bde1e3a0a99b3d9a
* Enable `cassandra_aliasing` option to comply with
  https://github.com/DataDog/dd-agent/pull/2035

More information:
https://github.com/DataDog/dd-agent/pull/2142

This is quite an important change, would you mind taking a pass on it @remh, @miketheman please ?

Thanks