### PR TITLE
update kafka template to match kafka current sample yaml

### DIFF
--- a/templates/default/kafka.yaml.erb
+++ b/templates/default/kafka.yaml.erb
@@ -43,47 +43,54 @@ init_config:
     # Aggregate cluster stats
     #
     - include:
-        domain: '"kafka.server"'
-        bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsBytesOutPerSec"'
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec'
         attribute:
           MeanRate:
             metric_type: gauge
             alias: kafka.net.bytes_out
     - include:
-        domain: '"kafka.server"'
-        bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsBytesInPerSec"'
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec'
         attribute:
           MeanRate:
             metric_type: gauge
             alias: kafka.net.bytes_in
     - include:
-        domain: '"kafka.server"'
-        bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsMessagesInPerSec"'
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec'
         attribute:
           MeanRate:
             metric_type: gauge
             alias: kafka.messages_in
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=BrokerTopicMetrics,name=BytesRejectedPerSec'
+        attribute:
+          MeanRate:
+            metric_type: gauge
+            alias: kafka.net.bytes_rejected
 
     #
     # Request timings
     #
     - include:
-        domain: '"kafka.server"'
-        bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsFailedFetchRequestsPerSec"'
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=BrokerTopicMetrics,name=FailedFetchRequestsPerSec'
         attribute:
           MeanRate:
             metric_type: gauge
             alias: kafka.request.fetch.failed
     - include:
-        domain: '"kafka.server"'
-        bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsFailedProduceRequestsPerSec"'
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=BrokerTopicMetrics,name=FailedProduceRequestsPerSec'
         attribute:
           MeanRate:
             metric_type: gauge
             alias: kafka.request.produce.failed
     - include:
-        domain: '"kafka.network"'
-        bean: '"kafka.network":type="RequestMetrics",name="Produce-TotalTimeMs"'
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestMetrics,name=TotalTimeMs,request=Produce'
         attribute:
           Mean:
             metric_type: gauge
@@ -92,8 +99,8 @@ init_config:
             metric_type: gauge
             alias: kafka.request.produce.time.99percentile
     - include:
-        domain: '"kafka.network"'
-        bean: '"kafka.network":type="RequestMetrics",name="Fetch-TotalTimeMs"'
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestMetrics,name=TotalTimeMs,request=Fetch'
         attribute:
           Mean:
             metric_type: gauge
@@ -102,8 +109,8 @@ init_config:
             metric_type: gauge
             alias: kafka.request.fetch.time.99percentile
     - include:
-        domain: '"kafka.network"'
-        bean: '"kafka.network":type="RequestMetrics",name="UpdateMetadata-TotalTimeMs"'
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestMetrics,name=TotalTimeMs,request=UpdateMetadata'
         attribute:
           Mean:
             metric_type: gauge
@@ -112,8 +119,8 @@ init_config:
             metric_type: gauge
             alias: kafka.request.update_metadata.time.99percentile
     - include:
-        domain: '"kafka.network"'
-        bean: '"kafka.network":type="RequestMetrics",name="Metadata-TotalTimeMs"'
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestMetrics,name=TotalTimeMs,request=Metadata'
         attribute:
           Mean:
             metric_type: gauge
@@ -122,8 +129,8 @@ init_config:
             metric_type: gauge
             alias: kafka.request.metadata.time.99percentile
     - include:
-        domain: '"kafka.network"'
-        bean: '"kafka.network":type="RequestMetrics",name="Offsets-TotalTimeMs"'
+        domain: 'kafka.network'
+        bean: 'kafka.network:type=RequestMetrics,name=TotalTimeMs,request=Offsets'
         attribute:
           Mean:
             metric_type: gauge
@@ -131,34 +138,41 @@ init_config:
           99thPercentile:
             metric_type: gauge
             alias: kafka.request.offsets.time.99percentile
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=KafkaRequestHandlerPool,name=RequestHandlerAvgIdlePercent'
+        attribute:
+          MeanRate:
+            metric_type: gauge
+            alias: kafka.request.handler.avg.idle.pct
 
     #
     # Replication stats
     #
     - include:
-        domain: '"kafka.server"'
-        bean: '"kafka.server":type="ReplicaManager",name="ISRShrinksPerSec"'
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=ReplicaManager,name=IsrShrinksPerSec'
         attribute:
           MeanRate:
             metric_type: gauge
             alias: kafka.replication.isr_shrinks
     - include:
-        domain: '"kafka.server"'
-        bean: '"kafka.server":type="ReplicaManager",name="ISRExpandsPerSec"'
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=ReplicaManager,name=IsrExpandsPerSec'
         attribute:
           MeanRate:
             metric_type: gauge
             alias: kafka.replication.isr_expands
     - include:
-        domain: '"kafka.server"'
-        bean: '"kafka.server":type="ControllerStats",name="LeaderElectionRateAndTimeMs"'
+        domain: 'kafka.controller'
+        bean: 'kafka.controller:type=ControllerStats,name=LeaderElectionRateAndTimeMs'
         attribute:
           MeanRate:
             metric_type: gauge
             alias: kafka.replication.leader_elections
     - include:
-        domain: '"kafka.server"'
-        bean: '"kafka.server":type="ControllerStats",name="UncleanLeaderElectionsPerSec"'
+        domain: 'kafka.controller'
+        bean: 'kafka.controller:type=ControllerStats,name=UncleanLeaderElectionsPerSec'
         attribute:
           MeanRate:
             metric_type: gauge
@@ -168,8 +182,8 @@ init_config:
     # Log flush stats
     #
     - include:
-        domain: '"kafka.log"'
-        bean: '"kafka.log":type="LogFlushStats",name="LogFlushRateAndTimeMs"'
+        domain: 'kafka.log'
+        bean: 'kafka.log:type=LogFlushStats,name=LogFlushRateAndTimeMs'
         attribute:
           MeanRate:
             metric_type: gauge


### PR DESCRIPTION
The datadog::kafka recipe will not work with current kafka versions, and does not reflect the sample YAML shipped in the main product.

This patch brings the kafka.yaml.erb template to match the current kafka.yaml.sample file.
