### PR TITLE
[dd-agent][windows] install per user → per machine

### DIFF
--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -35,6 +35,6 @@ end
 # Install the package
 windows_package 'Datadog Agent' do
   source temp_file
-  options %(APIKEY="#{node['datadog']['api_key']}" HOSTNAME="#{node['hostname']}" TAGS="#{node['tags'].join(',')}")
+  options %(ALLUSERS=1 APIKEY="#{node['datadog']['api_key']}" HOSTNAME="#{node['hostname']}" TAGS="#{node['tags'].join(',')}")
   action :install
 end


### PR DESCRIPTION
Set `ALLUSERS=1` to force install Datadog Agent on Windows per machine
rather than per user.

This avoid having multiple versions of Datadog Agent installed or
overriding whenever chef-client is run by different users.

This causes no backward incompatibility as Datadog Agent is always
removed before a new install.

@olivielpeau can you have a look please ?