### PR TITLE
[redis] COMMANDSTATS integration

### DIFF
--- a/spec/integrations/redis_spec.rb
+++ b/spec/integrations/redis_spec.rb
@@ -1,44 +1,46 @@
 describe 'datadog::redisdb' do
   expected_yaml = <<-EOF
-  init_config:
+    init_config:
 
-  instances:
-    - host: localhost
-      port: 6379
-      db: 0
-      password: mypassword
-      socket_timeout: 5
-      tags:
-        - optional_tag1
-        - optional_tag2
-      keys:
-        - key1
-        - key2
-      warn_on_missing_keys: True
-      slowlog-max-len: 128
+    instances:
+      - host: localhost
+        port: 6379
+        db: 0
+        password: somepass
+        socket_timeout: 5
+        tags:
+          - optional_tag1
+          - optional_tag2
+        keys:
+          - key1
+          - key2
+        warn_on_missing_keys: True
+        slowlog-max-len: 128
+        command_stats: True
   EOF
 
   cached(:chef_run) do
     ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
-      node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
+      node.automatic['languages'] = { python: { version: '2.7.2' } }
 
       node.set['datadog'] = {
-        'api_key' => 'someapikey',
-        'redisdb' => {
-          'instances' => [
+        api_key: 'someapikey',
+        redisdb: {
+          instances: [
             {
-              'db' => 0,
-              'keys' => ['key1', 'key2'],
-              'port' => 6379,
-              'password' => 'mypassword',
-              'server' => 'localhost',
+              command_stats: true,
+              db: 0,
+              keys: ['key1', 'key2'],
+              port: 6379,
+              password: 'somepass',
+              server: 'localhost',
               'slowlog-max-len' => 128,
-              'socket_timeout' => 5,
-              'tags' => [
+              socket_timeout: 5,
+              tags: [
                 'optional_tag1',
                 'optional_tag2'
               ],
-              'warn_on_missing_keys' => true
+              warn_on_missing_keys: true
             }
           ]
         }

--- a/templates/default/redisdb.yaml.erb
+++ b/templates/default/redisdb.yaml.erb
@@ -29,6 +29,7 @@ instances:
     <% end -%>
     <% if i.key?('slowlog-max-len') -%>slowlog-max-len: <%= i['slowlog-max-len'] %><% end -%>
     <% if i.key?('socket_timeout') -%>socket_timeout: <%= i['socket_timeout'] %><% end -%>
+    <% if i.key?('command_stats') -%>command_stats: <%= i['command_stats'] %><% end -%>
 <% end -%>
 
 init_config:


### PR DESCRIPTION
Allow setting the `command_stats` flag in redisdb.yaml, so we can enable the `INFO COMMANDSTATS` integration from DataDog/dd-agent#2109