### PR TITLE
Change kafka bean name to be the same as the example

### DIFF
--- a/templates/default/kafka.yaml.erb
+++ b/templates/default/kafka.yaml.erb
@@ -157,8 +157,8 @@ init_config:
             metric_type: gauge
             alias: kafka.replication.leader_elections
     - include:
-        domain: '"kafka.server"'
-        bean: '"kafka.server":type="ControllerStats",name="UncleanLeaderElectionsPerSec"'
+        domain: '"kafka.controller"'
+        bean: '"kafka.controller":type="ControllerStats",name="UncleanLeaderElectionsPerSec"'
         attribute:
           MeanRate:
             metric_type: gauge


### PR DESCRIPTION
The cookbook uses an incorrect value for the bean name. It is correct in the kafka.yaml.example. I chatted with support and noticed this error. 
The link the support rep gave me
https://github.com/DataDog/dd-agent/blob/master/conf.d/kafka.yaml.example#L161
There are a few others that don't match I noticed too when you compare the cookbook with the example config.

I checked with this on one of our kafka servers and this is how it shows.
```$ sudo /etc/init.d/datadog-agent jmx list_everything | grep kafka.controller | grep UncleanL
2016-01-08 18:42:47,327 | INFO | dd.collector | jmxfetch(jmxfetch.py:210) | Starting jmxfetch:
2016-01-08 18:42:47,327 | INFO | dd.collector | jmxfetch(jmxfetch.py:257) | Running java -Xms50m -Xmx200m -classpath /opt/datadog-agent/agent/checks/libs/jmxfetch-0.7.0-jar-with-dependencies.jar org.datadog.jmxfetch.App --check kafka.yaml --check_period 15000 --conf_directory /etc/dd-agent/conf.d --log_level INFO --log_location /var/log/datadog/jmxfetch.log --reporter console --status_location /opt/datadog-agent/agent/utils/../../run/jmx_status.yaml list_everything
       Not Matching: Bean name: "kafka.controller":type="ControllerStats",name="UncleanLeaderElectionsPerSec" - Attribute name: Count  - Attribute type: long
       Matching: 12/350. Bean name: "kafka.controller":type="ControllerStats",name="UncleanLeaderElectionsPerSec" - Attribute name: OneMinuteRate  - Attribute type: double
       Not Matching: Bean name: "kafka.controller":type="ControllerStats",name="UncleanLeaderElectionsPerSec" - Attribute name: FiveMinuteRate  - Attribute type: double
       Not Matching: Bean name: "kafka.controller":type="ControllerStats",name="UncleanLeaderElectionsPerSec" - Attribute name: FifteenMinuteRate  - Attribute type: double
       Not Matching: Bean name: "kafka.controller":type="ControllerStats",name="UncleanLeaderElectionsPerSec" - Attribute name: EventType  - Attribute type: java.lang.String
       Not Matching: Bean name: "kafka.controller":type="ControllerStats",name="UncleanLeaderElectionsPerSec" - Attribute name: MeanRate  - Attribute type: double```