### PR TITLE
expose histogram settings as node attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -160,6 +160,10 @@ default['datadog']['dogstatsd_normalize'] = 'yes'
 default['datadog']['statsd_forward_host'] = nil
 default['datadog']['statsd_forward_port'] = 8125
 
+# Histogram settings
+default['datadog']['histogram_aggregates'] = 'max, median, avg, count'
+default['datadog']['histogram_percentiles'] = '0.95'
+
 # For service-specific configuration, use the integration recipes included
 # in this cookbook, and apply them to the appropirate node's run list.
 # Read more at http://docs.datadoghq.com/

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -50,6 +50,10 @@ agent_checks_interval: <%= node['datadog']['agent_checks_interval'] %>
 graphite_listen_port: <%= node['datadog']['graphite_port'] %>
 <% end -%>
 
+## Histogram settings
+histogram_aggregates: <%= node['datadog']['histogram_aggregates'] %>
+histogram_percentiles: <%= node['datadog']['histogram_percentiles'] %>
+
 <% if node['datadog']['dogstatsd'] -%>
 # ========================================================================== #
 # DogStatsd configuration                                                    #


### PR DESCRIPTION
Summary:
This exposes the settings for histograms as node attributes. This should
allow different nodes to set 0.99 percentiles and other custom settings.

These attributes are pulled from:
https://github.com/DataDog/dd-agent/blob/master/datadog.conf.example#L97