### PR TITLE
Ability to override default log file directory

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -144,6 +144,7 @@ default['datadog']['syslog']['active'] = false
 default['datadog']['syslog']['udp'] = false
 default['datadog']['syslog']['host'] = nil
 default['datadog']['syslog']['port'] = nil
+default['datadog']['log_file_directory'] = '/var/log/datadog'
 
 # Web proxy configuration
 default['datadog']['web_proxy']['host'] = nil

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -79,10 +79,10 @@ statsd_forward_port: <%= node['datadog']['statsd_forward_port'] %>
 
 log_level: <%= node['datadog']['log_level'] %>
 
-# collector_log_file: /var/log/datadog/collector.log
-# forwarder_log_file: /var/log/datadog/forwarder.log
-# dogstatsd_log_file: /var/log/datadog/dogstatsd.log
-# pup_log_file:       /var/log/datadog/pup.log
+collector_log_file: <%= node['datadog']['log_file_directory'] %>/collector.log
+forwarder_log_file: <%= node['datadog']['log_file_directory'] %>/forwarder.log
+dogstatsd_log_file: <%= node['datadog']['log_file_directory'] %>/dogstatsd.log
+pup_log_file:       <%= node['datadog']['log_file_directory'] %>/pup.log
 
 # if syslog is enabled but a host and port are not set, a local domain socket
 # connection will be attempted


### PR DESCRIPTION
Summary:
This adds a node attribute that sets up the directory for the collector,
forwarder, dogstatsd and pup log files. Doing this allows consumers of
the recipe to change the directory from node attributes.