### PR TITLE
Don't log the agent configuration changes

### DIFF
--- a/providers/monitor.rb
+++ b/providers/monitor.rb
@@ -23,6 +23,7 @@ action :add do
       :instances   => new_resource.instances
     )
     cookbook new_resource.cookbook
+    sensitive true if Chef::Resource.instance_methods(false).include?(:sensitive)
     notifies :restart, 'service[datadog-agent]', :delayed if node['datadog']['agent_start']
   end
 
@@ -36,6 +37,7 @@ action :remove do
   Chef::Log.debug "Removing #{new_resource.name} from #{confd_dir}"
   file ::File.join(confd_dir, "#{new_resource.name}.yaml") do
     action :delete
+    sensitive true if Chef::Resource.instance_methods(false).include?(:sensitive)
     notifies :restart, 'service[datadog-agent]', :delayed if node['datadog']['agent_start']
   end
 

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -63,7 +63,7 @@ template agent_config_file do
     :api_key => node['datadog']['api_key'],
     :dd_url => node['datadog']['url']
   )
-  sensitive true if Chef::Resource::ChefGem.instance_methods(false).include?(:sensitive)
+  sensitive true if Chef::Resource.instance_methods(false).include?(:sensitive)
 end
 
 # Common configuration

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -63,6 +63,7 @@ template agent_config_file do
     :api_key => node['datadog']['api_key'],
     :dd_url => node['datadog']['url']
   )
+  sensitive true if Chef::Resource::ChefGem.instance_methods(false).include?(:sensitive)
 end
 
 # Common configuration


### PR DESCRIPTION
This will work on any Chef Client 11.14+ by suppressing the diff output in the logs to prevent API credentials from leaking into logs. This could go even farther if needed by using the new ability in Chef to `node.rm('datadog', 'api_key')` the key from the node data before it is saved back to the Chef server.