### PR TITLE
support disabling the agent service

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -125,8 +125,8 @@ default['datadog']['use_mount'] = false
 # Change port the agent is listening to
 default['datadog']['agent_port'] = 17123
 
-# Disable the agent from starting at boot
-default['datadog']['agent_disable'] = false
+# Enable the agent to start at boot
+default['datadog']['agent_enable'] = true
 
 # Start agent or not
 default['datadog']['agent_start'] = true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -125,6 +125,9 @@ default['datadog']['use_mount'] = false
 # Change port the agent is listening to
 default['datadog']['agent_port'] = 17123
 
+# Disable the agent from starting at boot
+default['datadog']['agent_disable'] = false
+
 # Start agent or not
 default['datadog']['agent_start'] = true
 

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -24,6 +24,8 @@ else
   include_recipe 'datadog::_install-linux'
 end
 
+# Set the Agent service enable or disable
+agent_boot_startup = node['datadog']['agent_disable'] ? :disable : :enable
 # Set the correct Agent startup action
 agent_action = node['datadog']['agent_start'] ? :start : :stop
 # Set the correct config file
@@ -68,7 +70,7 @@ end
 # Common configuration
 service 'datadog-agent' do
   service_name node['datadog']['agent_name']
-  action [:enable, agent_action]
+  action [agent_boot_startup, agent_action]
   if node['platform_family'] == 'windows'
     supports :restart => true, :start => true, :stop => true
   else

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -25,7 +25,7 @@ else
 end
 
 # Set the Agent service enable or disable
-agent_boot_startup = node['datadog']['agent_disable'] ? :disable : :enable
+agent_enable = node['datadog']['agent_enable'] ? :enable : :disable
 # Set the correct Agent startup action
 agent_action = node['datadog']['agent_start'] ? :start : :stop
 # Set the correct config file
@@ -70,7 +70,7 @@ end
 # Common configuration
 service 'datadog-agent' do
   service_name node['datadog']['agent_name']
-  action [agent_boot_startup, agent_action]
+  action [agent_enable, agent_action]
   if node['platform_family'] == 'windows'
     supports :restart => true, :start => true, :stop => true
   else

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -27,7 +27,7 @@ end
 # Set the Agent service enable or disable
 agent_enable = node['datadog']['agent_enable'] ? :enable : :disable
 # Set the correct Agent startup action
-agent_action = node['datadog']['agent_start'] ? :start : :stop
+agent_start = node['datadog']['agent_start'] ? :start : :stop
 # Set the correct config file
 agent_config_file = ::File.join(node['datadog']['config_dir'], 'datadog.conf')
 
@@ -70,7 +70,7 @@ end
 # Common configuration
 service 'datadog-agent' do
   service_name node['datadog']['agent_name']
-  action [agent_enable, agent_action]
+  action [agent_enable, agent_start]
   if node['platform_family'] == 'windows'
     supports :restart => true, :start => true, :stop => true
   else


### PR DESCRIPTION
We use a Packer workflow to create AMIs for our apps and then promote them through non-production environments before deploying to production. In non-production environments, it is desirable to install the Datadog Agent, but leave the service stopped and disabled via an environment attribute setting. Once in launched in production, the Agent starts and is enabled.

The cookbook already had an attribute to stop the Agent, but not to control the Agent service's `:enable`/`:disable` action. This PR adds that functionality.