### PR TITLE
Super-small comment correction for redisb attribute example

### DIFF
--- a/recipes/redisdb.rb
+++ b/recipes/redisdb.rb
@@ -7,7 +7,7 @@ include_recipe 'datadog::dd-agent'
 #     {
 #       'server' => 'localhost',
 #       'port' => '6379',
-#       'password' 'somesecret',
+#       'password' => 'somesecret',
 #       'tags' => ['prod']
 #     }
 #   ]


### PR DESCRIPTION
Alternatively, I can update the whole commented hash to match new-style hashes, if you prefer.