### PR TITLE
Pass 'tag_prefix' attribute to chef-handler-datadog

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,11 +26,11 @@ default['datadog']['api_key'] = nil
 # Create an application key on the Account Settings page
 default['datadog']['application_key'] = nil
 
-# Add this prefix to all Chef tags sent to Datadog: "#{tag_prefix}:#{tag}"
+# Add this prefix to all Chef tags sent to Datadog: "#{tag_prefix}#{tag}"
 # This makes it easy to group hosts in Datadog by their Chef tags, but might be counterproductive
 # if your Chef tags are already in the "#{tag_group}:#{value}" form.
 # Set prefix to '' if you want Chef tags to be sent without prefix.
-default['datadog']['tag_prefix'] = 'tag'
+default['datadog']['tag_prefix'] = 'tag:'
 
 # Don't change these
 # The host of the Datadog intake server to send agent data to

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,6 +26,12 @@ default['datadog']['api_key'] = nil
 # Create an application key on the Account Settings page
 default['datadog']['application_key'] = nil
 
+# Add this prefix to all Chef tags sent to Datadog: "#{tag_prefix}:#{tag}"
+# This makes it easy to group hosts in Datadog by their Chef tags, but might be counterproductive
+# if your Chef tags are already in the "#{tag_group}:#{value}" form.
+# Set prefix to '' if you want Chef tags to be sent without prefix.
+default['datadog']['tag_prefix'] = 'tag'
+
 # Don't change these
 # The host of the Datadog intake server to send agent data to
 default['datadog']['url'] = 'https://app.datadoghq.com'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'package@datadoghq.com'
 license          'Apache 2.0'
 description      'Installs/Configures datadog components'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.2.0'
+version          '2.3.0'
 source_url       'https://github.com/DataDog/chef-datadog' if respond_to? :source_url
 issues_url       'https://github.com/DataDog/chef-datadog/issues' if respond_to? :issues_url
 

--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -42,7 +42,8 @@ chef_handler 'Chef::Handler::Datadog' do
   arguments [
     :api_key => node['datadog']['api_key'],
     :application_key => node['datadog']['application_key'],
-    :use_ec2_instance_id => node['datadog']['use_ec2_instance_id']
+    :use_ec2_instance_id => node['datadog']['use_ec2_instance_id'],
+    :tag_prefix => node['datadog']['tag_prefix']
   ]
   supports :report => true, :exception => true
   action :nothing


### PR DESCRIPTION
Allows users to specify custom tag prefix with `tag_prefix` default cookbook attribute. User can decide to send tags unprefixed by specifying `tag_prefix = ''`. Default prefix is still `'tag:'`. Backwards compatibility is preserved.

Depends on https://github.com/DataDog/chef-handler-datadog/pull/81