### PR TITLE
node['tags'] can be nil

### DIFF
--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -35,6 +35,6 @@ end
 # Install the package
 windows_package 'Datadog Agent' do
   source temp_file
-  options %(APIKEY="#{node['datadog']['api_key']}" HOSTNAME="#{node['hostname']}" TAGS="#{node['tags'].join(',')}")
+  options %(APIKEY="#{node['datadog']['api_key']}" HOSTNAME="#{node['hostname']}" TAGS="#{node['tags'].join(',') if node['tags']}")
   action :install
 end


### PR DESCRIPTION
For some reason on some machines the tags array can be nil rather than empty. This causes an exception. This PR adds a simple guard condition to prevent it.
