### PR TITLE
Add option to use agent hostname as handler's reported host

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -115,6 +115,10 @@ default['datadog']['check_freq'] = 15
 # More information available here: http://docs.datadoghq.com/hostnames/#agent
 default['datadog']['hostname'] = node.name
 
+# If a hostname is set for the agent, and if true,
+# use the agent hostname as the host identifier for chef-handler
+default['datadog']['use_agent_hostname'] = false
+
 # If running on ec2, if true, use the instance-id as the host identifier
 # rather than the hostname for chef-handler.
 default['datadog']['use_ec2_instance_id'] = false

--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -36,14 +36,17 @@ chef_gem 'chef-handler-datadog' do # ~FC009
 end
 require 'chef/handler/datadog'
 
+handler_config = {
+  :api_key => node['datadog']['api_key'],
+  :application_key => node['datadog']['application_key'],
+  :use_ec2_instance_id => node['datadog']['use_ec2_instance_id']
+}
+handler_config[:hostname] = node['datadog']['hostname'] if node['datadog']['use_agent_hostname']
+
 # Create the handler to run at the end of the Chef execution
 chef_handler 'Chef::Handler::Datadog' do
   source 'chef/handler/datadog'
-  arguments [
-    :api_key => node['datadog']['api_key'],
-    :application_key => node['datadog']['application_key'],
-    :use_ec2_instance_id => node['datadog']['use_ec2_instance_id']
-  ]
+  arguments [handler_config]
   supports :report => true, :exception => true
   action :nothing
 end.run_action(:enable) if node['datadog']['chef_handler_enable']


### PR DESCRIPTION
Tries to address #226

When the `use_agent_hostname` attribute is set to `true`, we pass the agent's hostname to the handler so that it reports with the agent hostname.

This attribute would allow users not to have duplicate hosts when the hostname of the agent is set to a custom value while the `node.name` and the ec2 instance id are not part of the host aliases sent by the agent.