### PR TITLE
Allow non-breaking updates of chef_handler

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -22,7 +22,7 @@ issues_url       'https://github.com/DataDog/chef-datadog/issues' if respond_to?
 end
 
 depends          'apt' # We recommend '>= 2.1.0'. See CHANGELOG.md for details
-depends          'chef_handler', '~> 1.1.0'
+depends          'chef_handler', '~> 1.1'
 depends          'windows'
 depends          'yum'
 


### PR DESCRIPTION
Reading back to #25 when this constraint was first introduced, it doesn't seem like there's any compelling reason not to allow future non-breaking changes to come in automatically. However, refusing to allow anything above 1.1.x definitely causes problems for my other cookbooks that also need to use `chef_handler` (and there are several).