### PR TITLE
Allow for a hash or string when configuring tags

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,6 +31,9 @@ default['datadog']['application_key'] = nil
 default['datadog']['url'] = 'https://app.datadoghq.com'
 
 # Add tags as override attributes in your role
+# This can be a string of comma separated tags or a hash in this format:
+# default['datadog']['tags'] = { 'datacenter' => 'us-east' }
+# Thie above outputs a string: 'datacenter:us-east'
 # When using the Datadog Chef Handler, tags are set on the node with preset prefixes:
 # `env:node.chef_environment`, `role:node.node.run_list.role`, `tag:somecheftag`
 default['datadog']['tags'] = ''

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -60,13 +60,8 @@ template agent_config_file do
     mode 0640
   end
   variables(
-    lazy {
-      {
-        :api_key => node['datadog']['api_key'],
-        :dd_url => node['datadog']['url'],
-        :tags => node['datadog']['tags']
-      }
-    }
+    :api_key => node['datadog']['api_key'],
+    :dd_url => node['datadog']['url']
   )
   sensitive true if Chef::Resource.instance_methods(false).include?(:sensitive)
 end

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -61,7 +61,8 @@ template agent_config_file do
   end
   variables(
     :api_key => node['datadog']['api_key'],
-    :dd_url => node['datadog']['url']
+    :dd_url => node['datadog']['url'],
+    :tags => node['datadog']['tags']
   )
   sensitive true if Chef::Resource.instance_methods(false).include?(:sensitive)
 end

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -60,9 +60,13 @@ template agent_config_file do
     mode 0640
   end
   variables(
-    :api_key => node['datadog']['api_key'],
-    :dd_url => node['datadog']['url'],
-    :tags => node['datadog']['tags']
+    lazy {
+      {
+        :api_key => node['datadog']['api_key'],
+        :dd_url => node['datadog']['url'],
+        :tags => node['datadog']['tags']
+      }
+    }
   )
   sensitive true if Chef::Resource.instance_methods(false).include?(:sensitive)
 end

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -273,5 +273,27 @@ describe 'datadog::dd-agent' do
           .with_content(/^tags: datacenter:us-foo,database:bar$/)
       end
     end
+
+    context 'does not use empty tags' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(
+          platform: 'ubuntu',
+          version: '12.04'
+        ) do |node|
+          node.set['datadog'] = {
+            'api_key' => 'somethingnotnil',
+            'tags' => { 'datacenter' => 'us-foo', 'database' => '' }
+          }
+          node.set['languages'] = { 'python' => { 'version' => '2.6.2' } }
+        end.converge described_recipe
+      end
+
+      it_behaves_like 'common linux resources'
+
+      it 'sets tags from the tags attribute' do
+        expect(chef_run).to render_file('/etc/dd-agent/datadog.conf')
+          .with_content(/^tags: datacenter:us-foo$/)
+      end
+    end
   end
 end

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -230,6 +230,28 @@ describe 'datadog::dd-agent' do
       it_behaves_like 'debianoids'
     end
 
+    context 'allows a string for tags' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(
+          platform: 'ubuntu',
+          version: '12.04'
+        ) do |node|
+          node.set['datadog'] = {
+            'api_key' => 'somethingnotnil',
+            'tags' => 'datacenter:us-foo,database:bar'
+          }
+          node.set['languages'] = { 'python' => { 'version' => '2.6.2' } }
+        end.converge described_recipe
+      end
+
+      it_behaves_like 'common linux resources'
+
+      it 'sets tags from the tags attribute' do
+        expect(chef_run).to render_file('/etc/dd-agent/datadog.conf')
+          .with_content(/^tags: datacenter:us-foo,database:bar$/)
+      end
+    end
+
     context 'allows key/value for tags' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -229,5 +229,27 @@ describe 'datadog::dd-agent' do
 
       it_behaves_like 'debianoids'
     end
+
+    context 'allows key/value for tags' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(
+          platform: 'ubuntu',
+          version: '12.04'
+        ) do |node|
+          node.set['datadog'] = {
+            'api_key' => 'somethingnotnil',
+            'tags' => { 'datacenter' => 'us-foo', 'database' => 'bar' }
+          }
+          node.set['languages'] = { 'python' => { 'version' => '2.6.2' } }
+        end.converge described_recipe
+      end
+
+      it_behaves_like 'common linux resources'
+
+      it 'sets tags from the tags attribute' do
+        expect(chef_run).to render_file('/etc/dd-agent/datadog.conf')
+          .with_content(/^tags: datacenter:us-foo,database:bar$/)
+      end
+    end
   end
 end

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -15,10 +15,10 @@ autorestart: <%= node['datadog']['autorestart'] %>
 skip_ssl_validation: <%= node['datadog']['web_proxy']['skip_ssl_validation'] %>
 <% end -%>
 
-<% if @tags.respond_to?(:each_pair) -%>
-tags: <%= @tags.reject{|k,v| v.empty? }.map{|k,v| "#{k}:#{v}" }.join(",") %>
+<% if node['datadog']['tags'].respond_to?(:each_pair) -%>
+tags: <%= node['datadog']['tags'].reject{|k,v| v.empty? }.map{|k,v| "#{k}:#{v}" }.join(',') %>
 <% else -%>
-tags: <%= @tags %>
+tags: <%= node['datadog']['tags'] %>
 <% end -%>
 <% if node['datadog']['create_dd_check_tags'] -%>
 create_dd_check_tags: <%= node['datadog']['create_dd_check_tags'] %>

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -15,7 +15,7 @@ autorestart: <%= node['datadog']['autorestart'] %>
 skip_ssl_validation: <%= node['datadog']['web_proxy']['skip_ssl_validation'] %>
 <% end -%>
 
-tags: <%= node['datadog']['tags'] %>
+tags: <%= @tags %>
 <% if node['datadog']['create_dd_check_tags'] -%>
 create_dd_check_tags: <%= node['datadog']['create_dd_check_tags'] %>
 <% end -%>

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -15,7 +15,11 @@ autorestart: <%= node['datadog']['autorestart'] %>
 skip_ssl_validation: <%= node['datadog']['web_proxy']['skip_ssl_validation'] %>
 <% end -%>
 
+<% if @tags.respond_to?(:each_pair) -%>
+tags: <%= @tags.reject{|k,v| v.empty? }.map{|k,v| "#{k}:#{v}" }.join(",") %>
+<% else -%>
 tags: <%= @tags %>
+<% end -%>
 <% if node['datadog']['create_dd_check_tags'] -%>
 create_dd_check_tags: <%= node['datadog']['create_dd_check_tags'] %>
 <% end -%>

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -16,7 +16,7 @@ skip_ssl_validation: <%= node['datadog']['web_proxy']['skip_ssl_validation'] %>
 <% end -%>
 
 <% if node['datadog']['tags'].respond_to?(:each_pair) -%>
-tags: <%= node['datadog']['tags'].reject{|k,v| v.empty? }.map{|k,v| "#{k}:#{v}" }.join(',') %>
+tags: <%= node['datadog']['tags'].reject{ |_k,v| v.empty? }.map{ |k,v| "#{k}:#{v}" }.join(',') %>
 <% else -%>
 tags: <%= node['datadog']['tags'] %>
 <% end -%>


### PR DESCRIPTION
A pattern we're employing with our wrapper cookbooks is to compose the datadog tags attribute so they're rendered out properly in the datadog template. The way it currently is now, the template is rendered at compile time which prevents wrapper cookbooks from modifying the tags during run time. By extracting the attribute to a template variable, we delay the rendering of the template variable until the run phase.

With this patch you will be able to do the following in a recipe:
```ruby
node.default['datadog']['tags'] = node['datadog']['tags'].merge('region' => 'us-east')
```
What this does is composes the current set of tags defined in the attribute with an additional tag by way of merging in a new key and value into the hash. You can still provide a string instead which is the currently shipped default so these changes are fully backward compatible.
