### PR TITLE
Remove knife.rb file from repo.

### DIFF
--- a/.chef/knife.rb
+++ b/.chef/knife.rb
@@ -1,2 +1,0 @@
-cache_type 'BasicFile'
-cache_options(:path => "#{ENV['HOME']}/.chef/checksums")


### PR DESCRIPTION
This was added for testing a couple of years ago, when testing was brand
new. We may not need this file any longer, expecially as it causes odd
path loading with CLI commands within the repo.