### PR TITLE
Add dogstatsd_target to template

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -173,6 +173,7 @@ default['datadog']['dogstatsd'] = true
 default['datadog']['dogstatsd_port'] = 8125
 default['datadog']['dogstatsd_interval'] = 10
 default['datadog']['dogstatsd_normalize'] = 'yes'
+default['datadog']['dogstatsd_target'] = 'http://localhost:17123'
 default['datadog']['statsd_forward_host'] = nil
 default['datadog']['statsd_forward_port'] = 8125
 default['datadog']['statsd_metric_namespace'] = nil

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -72,6 +72,9 @@ dogstatsd_port: <%= node['datadog']['dogstatsd_port'] %>
 ## The dogstatsd flush period.
 dogstatsd_interval: <%= node['datadog']['dogstatsd_interval'] %>
 
+## The target location to send the data
+dogstatsd_target: <%= node['datadog']['dogstatsd_target'] %>
+
 ## If 'yes', counters and rates will be normalized to 1 second (that is divided
 ## by the dogstatsd_interval) before being sent to the server. Defaults to 'yes'
 dogstatsd_normalize: <%= node['datadog']['dogstatsd_normalize'] %>


### PR DESCRIPTION
This is needed to tell the dogstatd component to send the data to the right place if the default agent port is changed to something else other than the 17123 value