### PR TITLE
[dd-agent] Add `developer_mode` option to agent main conf

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -54,6 +54,9 @@ default['datadog']['collect_ec2_tags'] = nil
 # Autorestart agent
 default['datadog']['autorestart'] = false
 
+# Run the agent in developer mode
+default['datadog']['developer_mode'] = false
+
 # Repository configuration
 architecture_map = {
   'i686' => 'i386',

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -14,6 +14,9 @@ autorestart: <%= node['datadog']['autorestart'] %>
 <% if node['datadog']['web_proxy']['skip_ssl_validation'] -%>
 skip_ssl_validation: <%= node['datadog']['web_proxy']['skip_ssl_validation'] %>
 <% end -%>
+<% if node['datadog']['developer_mode'] -%>
+developer_mode: <%= node['datadog']['developer_mode'] %>
+<% end -%>
 
 <% if node['datadog']['tags'].respond_to?(:each_pair) -%>
 tags: <%= node['datadog']['tags'].reject{ |_k,v| v.empty? }.map{ |k,v| "#{k}:#{v}" }.join(',') %>


### PR DESCRIPTION
Useful for instances with a test/dev agent