### PR TITLE
Support for iis wmi provider

### DIFF
--- a/templates/default/iis.yaml.erb
+++ b/templates/default/iis.yaml.erb
@@ -19,6 +19,7 @@ instances:
     username: <%= i['username'] %>
     password: <%= i['password'] %>
     <% end -%>
+    provider: <%= i['provider'] %>
     <% if i.key?('tags') -%>
     tags:
       <% i['tags'].each do |t| -%>
@@ -34,3 +35,4 @@ instances:
   <% end -%>
 
 init_config:
+

--- a/templates/default/iis.yaml.erb
+++ b/templates/default/iis.yaml.erb
@@ -35,4 +35,3 @@ instances:
   <% end -%>
 
 init_config:
-

--- a/templates/default/iis.yaml.erb
+++ b/templates/default/iis.yaml.erb
@@ -19,7 +19,9 @@ instances:
     username: <%= i['username'] %>
     password: <%= i['password'] %>
     <% end -%>
+    <% if i.key?('provider') -%>
     provider: <%= i['provider'] %>
+    <% end -%>
     <% if i.key?('tags') -%>
     tags:
       <% i['tags'].each do |t| -%>


### PR DESCRIPTION
The new Datadog agent has been released and with it comes the solution for the issue #306 

This pull request include the support to use this new feature adding "provider" to the IIS attributes declaration, as follows.

`node.datadog.iis.instances = [
	{
		"host" => "localhost",
		"provider" => '64',
		"tags" => ["tag1", "tag2"],
		"sites" => ["Default Web Site"]
	}
]
`                                 