### PR TITLE
Defer evaluation of api key attribute

### DIFF
--- a/attributes/cassandra.rb
+++ b/attributes/cassandra.rb
@@ -1,1 +1,0 @@
-default['datadog']['cassandra']['version'] = 1

--- a/recipes/cassandra.rb
+++ b/recipes/cassandra.rb
@@ -35,6 +35,8 @@ include_recipe 'datadog::dd-agent'
 # }
 # ```
 
+node.default['datadog']['cassandra']['version'] = 1
+
 datadog_monitor 'cassandra' do
   instances node['datadog']['cassandra']['instances']
   version node['datadog']['cassandra']['version']

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -49,9 +49,14 @@ end
 # To add integration-specific configurations, add 'datadog::config_name' to
 # the node's run_list and set the relevant attributes
 #
-raise "Add a ['datadog']['api_key'] attribute to configure this node's Datadog Agent." if node['datadog'] && node['datadog']['api_key'].nil?
 
 template agent_config_file do
+  def template_vars
+    {
+      :api_key => node['datadog']['api_key'],
+      :dd_url => node['datadog']['url']
+    }
+  end
   if node['platform_family'] == 'windows'
     owner 'Administrators'
     rights :full_control, 'Administrators'
@@ -62,8 +67,11 @@ template agent_config_file do
     mode 0640
   end
   variables(
-    :api_key => node['datadog']['api_key'],
-    :dd_url => node['datadog']['url']
+    if respond_to?(:lazy)
+      lazy { template_vars }
+    else
+      template_vars
+    end
   )
   sensitive true if Chef::Resource.instance_methods(false).include?(:sensitive)
 end

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -51,7 +51,6 @@ describe 'datadog::dd-agent' do
   include EnvVar
 
   context 'no version set' do
-    # This recipe needs to have an api_key, otherwise `raise` is called.
     # It also depends on the version of Python present on the platform:
     #   2.6 and up => datadog-agent is installed
     #   below 2.6 => datadog-agent-base is installed


### PR DESCRIPTION
Some users may wish to assign the `api_key` attribute during runtime
instead of compile time -- particularly, users who want to obtain the
value of the key from an external service. Allow doing so by deferring
evaluation of the `api_key` attribute.

Closes #328 