### PR TITLE
Enhance remove-dd-agent.rb 

### DIFF
--- a/recipes/remove-dd-agent.rb
+++ b/recipes/remove-dd-agent.rb
@@ -1,4 +1,11 @@
 # Run this recipe to completely remove the Datadog Agent
-package 'datadog-agent' do
-  action :purge
+case node['os']
+when 'linux'
+  package 'datadog-agent' do
+    action :purge
+  end
+when 'windows'
+  package 'Datadog Agent' do
+    action :remove
+  end
 end


### PR DESCRIPTION
Patch to fix or enhance remove-dd-agent.rb's functionality to include Windows. Tested on Windows 2012 R2 and Windows 2008 R2 SP1. In response to open issue 331 (DataDog#331).

Prior Linux-only code was included in case logic unchanged.