### PR TITLE
direct recipe support for sqlserver configuration

### DIFF
--- a/providers/monitor.rb
+++ b/providers/monitor.rb
@@ -21,7 +21,8 @@ action :add do
     variables(
       :init_config => new_resource.init_config,
       :instances => new_resource.instances,
-      :version => new_resource.version
+      :version => new_resource.version,
+      :custom_metrics => new_resource.custom_metrics
     )
     cookbook new_resource.cookbook
     sensitive true if Chef::Resource.instance_methods(false).include?(:sensitive)

--- a/recipes/sqlserver.rb
+++ b/recipes/sqlserver.rb
@@ -1,0 +1,23 @@
+include_recipe 'datadog::dd-agent'
+
+# Monitor MSSQL
+
+# Set the following attributes
+# * `instances` (required)
+# Example:
+
+# ```
+# node['datadog']['sqlserver'] =
+#     instances: [
+#     {
+#         host: 'localhost',
+#         port: 1433,
+#         username: 'username',
+#         password: 'secret'
+#     }]
+# }
+# ```
+
+datadog_monitor 'sqlserver' do
+  instances node['datadog']['sqlserver']['instances']
+end

--- a/recipes/sqlserver.rb
+++ b/recipes/sqlserver.rb
@@ -20,4 +20,5 @@ include_recipe 'datadog::dd-agent'
 
 datadog_monitor 'sqlserver' do
   instances node['datadog']['sqlserver']['instances']
+  custom_metrics node['datadog']['sqlserver']['custom_metrics']
 end

--- a/resources/monitor.rb
+++ b/resources/monitor.rb
@@ -12,3 +12,4 @@ attribute :cookbook, :kind_of => String, :default => 'datadog'
 attribute :init_config, :kind_of => Hash, :required => false, :default => {}
 attribute :instances, :kind_of => Array, :required => false, :default => []
 attribute :version, :kind_of => Integer, :required => false, :default => nil
+attribute :custom_metrics, :kind_of => Array, :required => false, :default => []

--- a/templates/default/sqlserver.yaml.erb
+++ b/templates/default/sqlserver.yaml.erb
@@ -34,6 +34,8 @@ init_config:
     #        tag_by: db
 
 instances:
-    -   host: HOST,PORT
-        username: my_username
-        password: my_password
+<% @instances.each do |i| -%>
+  - host: <%= i['host'] %>,<%= i['port'] %>
+    username: <%= i['user'] %>
+    password: <%= i['pass'] %>
+<% end -%>

--- a/templates/default/sqlserver.yaml.erb
+++ b/templates/default/sqlserver.yaml.erb
@@ -47,6 +47,6 @@ init_config:
 instances:
 <% @instances.each do |i| -%>
   - host: <%= i['host'] %>,<%= i['port'] %>
-    username: <%= i['user'] %>
-    password: <%= i['pass'] %>
+    username: <%= i['username'] %>
+    password: <%= i['password'] %>
 <% end -%>

--- a/templates/default/sqlserver.yaml.erb
+++ b/templates/default/sqlserver.yaml.erb
@@ -37,10 +37,10 @@ init_config:
       - name: <%= metric['name'] %>
         type: <%= metric['type'] %>
         counter_name: <%= metric['counter_name'] %>
-        <% if i.key?('instance_name') -%>
+        <% if metric.key?('instance_name') -%>
         instance_name: <%= metric['instance_name'] %>
         <% end -%>
-        <% if i.key?('tag_by') -%>
+        <% if metric.key?('tag_by') -%>
         tag_by: <%= metric['tag_by'] %>
         <% end -%>
     <% end -%>

--- a/templates/default/sqlserver.yaml.erb
+++ b/templates/default/sqlserver.yaml.erb
@@ -32,7 +32,18 @@ init_config:
     #        counter_name: Log Flushes/sec
     #        instance_name: ALL
     #        tag_by: db
-
+    custom_metrics:
+    <% @custom_metrics.each do |metric| -%>
+      - name: <%= metric['name'] %>
+        type: <%= metric['type'] %>
+        counter_name: <%= metric['counter_name'] %>
+        <% if i.key?('instance_name') -%>
+        instance_name: <%= metric['instance_name'] %>
+        <% end -%>
+        <% if i.key?('tag_by') -%>
+        tag_by: <%= metric['tag_by'] %>
+        <% end -%>
+    <% end -%>
 instances:
 <% @instances.each do |i| -%>
   - host: <%= i['host'] %>,<%= i['port'] %>


### PR DESCRIPTION
This update would allow you to use recipe['datadog::sqlserver'] and configure both instances and custom_metrics.
