### PR TITLE
[integrations] Update integration test

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -505,6 +505,7 @@ suites:
 - name: datadog_integrations
   run_list:
     - recipe[datadog::dd-agent]
+  excludes: *WINDOWS_PLATFORMS
   attributes:
     datadog:
       <<: *DATADOG

--- a/test/integration/datadog_integrations/serverspec/integrations_spec.rb
+++ b/test/integration/datadog_integrations/serverspec/integrations_spec.rb
@@ -25,9 +25,7 @@ describe file(AGENT_CONFIG) do
     expect(generated.to_json).to be_json_eql expected.to_json
   end
 
-  if @agent_check_dir
-    describe file('/opt/datadog-agent/3rd-party/twemproxy/check.py') do
-      it { should be_a_file }
-    end
+  describe package('dd-check-twemproxy') do
+    it { should be_installed.with_version('0.1.0-1') }
   end
 end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -13,14 +13,11 @@ if ENV['OS'] == 'Windows_NT'
   @agent_package_name = 'Datadog Agent'
   @agent_service_name = 'DatadogAgent'
   @agent_config_dir = "#{ENV['ProgramData']}/Datadog"
-  @agent_check_dir = ''
 else
   set :backend, :exec
   @agent_package_name = 'datadog-agent'
   @agent_service_name = 'datadog-agent'
   @agent_config_dir = '/etc/dd-agent'
-  @agent_check_dir = '/opt/datadog-agent/agent/checks.d'
-
 end
 
 set :path, '/sbin:/usr/local/sbin:$PATH' unless os[:family] == 'windows'


### PR DESCRIPTION
So that we test that the package is installed instead of testing that
a file is present in a hardcoded folder: what's interesting to test
from the cookbook's perspective is not the exact file installed by the
package, but that the package itself is installed.

Also, remove windows platforms from `datadog_integrations` suite
(since the recipe is not meant to run on windows).
