### PR TITLE
Don't enable cassandra monitoring everywhere

### DIFF
--- a/attributes/cassandra.rb
+++ b/attributes/cassandra.rb
@@ -1,1 +1,0 @@
-default['datadog']['cassandra']['version'] = 1

--- a/recipes/cassandra.rb
+++ b/recipes/cassandra.rb
@@ -35,6 +35,8 @@ include_recipe 'datadog::dd-agent'
 # }
 # ```
 
+node.default['datadog']['cassandra']['version'] = 1
+
 datadog_monitor 'cassandra' do
   instances node['datadog']['cassandra']['instances']
   version node['datadog']['cassandra']['version']


### PR DESCRIPTION
Attribute to enable cassandra monitoring was set on all hosts.
Only enable it when zendesk_datadog::cassandra is run.