### PR TITLE
Allow full disable of dogstatsd

### DIFF
--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -92,7 +92,6 @@ statsd_metric_namespace: <%= node['datadog']['statsd_metric_namespace'] %>
 <% else -%>
 use_dogstatsd: no
 <% end -%>
-<% end -%>
 
 # ========================================================================== #
 # Logging

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -89,6 +89,9 @@ statsd_forward_port: <%= node['datadog']['statsd_forward_port'] %>
 <% if node['datadog']['statsd_metric_namespace'] -%>
 statsd_metric_namespace: <%= node['datadog']['statsd_metric_namespace'] %>
 <% end -%>
+<% else -%>
+use_dogstatsd: no
+<% end -%>
 <% end -%>
 
 # ========================================================================== #


### PR DESCRIPTION
If default['datadog']['dogstatsd'] = false|nil, not only don't set dogstatsd attributes, but also set
use_dogstatsd: no
to fully disable dogstatsd, don't start the statsd process.
See: https://github.com/DataDog/dd-agent/blob/master/datadog.conf.example#L149
