### PR TITLE
If a cookbook is not specified, fall back to the integration template instead of failing

### DIFF
--- a/providers/monitor.rb
+++ b/providers/monitor.rb
@@ -19,7 +19,10 @@ action :add do
       mode 00600
     end
 
-    source 'integration.yaml.erb' if new_resource.use_integration_template
+    if new_resource.use_integration_template ||
+       new_resource.cookbook == 'datadog'
+      source 'integration.yaml.erb'
+    end
 
     variables(
       init_config: new_resource.init_config,


### PR DESCRIPTION
This seems like it should make the resource behavior a little more intuitive and avoid having to make the resource call overly verbose.

Also I've only really tried this with my own very particular setup so please let me know if there are any use cases I've overlooked here.