### PR TITLE
[dd-agent] Fix version test when version contains an epoch

### DIFF
--- a/recipes/_install-linux.rb
+++ b/recipes/_install-linux.rb
@@ -23,7 +23,7 @@ include_recipe 'datadog::repository' if node['datadog']['installrepo']
 dd_agent_version = node['datadog']['agent_version']
 
 # If version specified and lower than 5.x
-if !dd_agent_version.nil? && dd_agent_version.split('.')[0].to_i < 5
+if !dd_agent_version.nil? && dd_agent_version.split('.')[0].split(':').last.to_i < 5
   Chef::Log.warn 'Support for Agent pre 5.x will be removed in datadog cookbook version 3.0'
   # Select correct package name based on attribute
   dd_pkg_name = node['datadog']['install_base'] ? 'datadog-agent-base' : 'datadog-agent'

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -169,7 +169,7 @@ describe 'datadog::dd-agent' do
       ) do |node|
         node.set['datadog'] = {
           'api_key' => 'somethingnotnil',
-          'agent_version' => '5.1.0-440'
+          'agent_version' => '1:5.1.0-440'
         }
         node.set['languages'] = { 'python' => { 'version' => '2.4' } }
       end.converge described_recipe


### PR DESCRIPTION
Previously the test wouldn't give the expected result for versions like
`1:5.8.0:1` for instance (which is standard for our debian pkg).