### PR TITLE
[dd-agent] Add attribute to allow agent downgrade

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -127,6 +127,10 @@ default['datadog']['agent_version'] = nil
 # Allow override with `upgrade` to get latest (Linux only)
 default['datadog']['agent_package_action'] = 'install'
 
+# Allow downgrades of the agent (Linux only)
+# Note: on apt-based platforms, this will use the `--force-yes` option on the apt-get command. Use with caution.
+default['datadog']['agent_allow_downgrade'] = false
+
 # Chef handler version
 default['datadog']['chef_handler_version'] = nil
 

--- a/recipes/_install-linux.rb
+++ b/recipes/_install-linux.rb
@@ -42,5 +42,7 @@ else
   package 'datadog-agent' do
     version dd_agent_version
     action node['datadog']['agent_package_action'] # default is :install
+    allow_downgrade node['datadog']['agent_allow_downgrade'] if %w(rhel fedora).include?(node['platform_family'])
+    options '--force-yes' if node['datadog']['agent_allow_downgrade'] && node['platform_family'] == 'debian'
   end
 end

--- a/recipes/_install-linux.rb
+++ b/recipes/_install-linux.rb
@@ -39,10 +39,18 @@ else
     not_if 'apt-cache policy datadog-agent-base | grep "Installed: (none)"' if node['platform_family'] == 'debian'
   end
   # Install the regular package
-  package 'datadog-agent' do
-    version dd_agent_version
-    action node['datadog']['agent_package_action'] # default is :install
-    allow_downgrade node['datadog']['agent_allow_downgrade'] if %w(rhel fedora).include?(node['platform_family'])
-    options '--force-yes' if node['datadog']['agent_allow_downgrade'] && node['platform_family'] == 'debian'
+  case node['platform_family']
+  when 'debian'
+    apt_package 'datadog-agent' do
+      version dd_agent_version
+      action node['datadog']['agent_package_action'] # default is :install
+      options '--force-yes' if node['datadog']['agent_allow_downgrade']
+    end
+  when 'rhel', 'fedora'
+    yum_package 'datadog-agent' do
+      version dd_agent_version
+      action node['datadog']['agent_package_action'] # default is :install
+      allow_downgrade node['datadog']['agent_allow_downgrade']
+    end
   end
 end

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -16,10 +16,12 @@ shared_examples_for 'datadog-agent-base' do
 
   it 'does not install the datadog-agent package' do
     expect(chef_run).not_to install_package 'datadog-agent'
+    expect(chef_run).not_to install_apt_package 'datadog-agent'
+    expect(chef_run).not_to install_yum_package 'datadog-agent'
   end
 end
 
-shared_examples_for 'debianoids' do
+shared_examples_for 'debianoids repo' do
   it 'sets up an apt repo' do
     expect(chef_run).to add_apt_repository('datadog')
   end
@@ -29,16 +31,22 @@ shared_examples_for 'debianoids' do
   end
 end
 
-shared_examples_for 'rhellions' do
+shared_examples_for 'rhellions repo' do
   it 'sets up a yum repo' do
     expect(chef_run).to add_yum_repository('datadog')
   end
 end
 
-shared_examples_for 'no version set' do
+shared_examples_for 'debianoids no version set' do
   it_behaves_like 'common linux resources'
 
-  it_behaves_like 'datadog-agent'
+  it_behaves_like 'debianoids datadog-agent'
+end
+
+shared_examples_for 'rhellions no version set' do
+  it_behaves_like 'common linux resources'
+
+  it_behaves_like 'rhellions datadog-agent'
 end
 
 shared_examples_for 'version set below 4.x' do
@@ -66,8 +74,8 @@ describe 'datadog::dd-agent' do
         end.converge described_recipe
       end
 
-      it_behaves_like 'debianoids'
-      it_behaves_like 'no version set'
+      it_behaves_like 'debianoids repo'
+      it_behaves_like 'debianoids no version set'
     end
 
     context 'on debian-family w/non-numeric python version string' do
@@ -81,8 +89,8 @@ describe 'datadog::dd-agent' do
         end.converge described_recipe
       end
 
-      it_behaves_like 'debianoids'
-      it_behaves_like 'no version set'
+      it_behaves_like 'debianoids repo'
+      it_behaves_like 'debianoids no version set'
     end
 
     context 'on debian-family with older python' do
@@ -96,8 +104,8 @@ describe 'datadog::dd-agent' do
         end.converge described_recipe
       end
 
-      it_behaves_like 'debianoids'
-      it_behaves_like 'no version set'
+      it_behaves_like 'debianoids repo'
+      it_behaves_like 'debianoids no version set'
     end
 
     context 'on RedHat-family distro above 6.x' do
@@ -111,8 +119,8 @@ describe 'datadog::dd-agent' do
         end.converge described_recipe
       end
 
-      it_behaves_like 'rhellions'
-      it_behaves_like 'no version set'
+      it_behaves_like 'rhellions repo'
+      it_behaves_like 'rhellions no version set'
     end
 
     context 'on CentOS 5.8 distro' do
@@ -126,8 +134,8 @@ describe 'datadog::dd-agent' do
         end.converge described_recipe
       end
 
-      it_behaves_like 'rhellions'
-      it_behaves_like 'no version set'
+      it_behaves_like 'rhellions repo'
+      it_behaves_like 'rhellions no version set'
     end
 
     context 'on Fedora distro' do
@@ -141,8 +149,8 @@ describe 'datadog::dd-agent' do
         end.converge described_recipe
       end
 
-      it_behaves_like 'rhellions'
-      it_behaves_like 'no version set'
+      it_behaves_like 'rhellions repo'
+      it_behaves_like 'rhellions no version set'
     end
 
     context 'on Windows' do
@@ -175,8 +183,8 @@ describe 'datadog::dd-agent' do
       end.converge described_recipe
     end
 
-    it_behaves_like 'debianoids'
-    it_behaves_like 'no version set'
+    it_behaves_like 'debianoids repo'
+    it_behaves_like 'debianoids no version set'
   end
 
   context 'version 4.x is set' do
@@ -193,7 +201,7 @@ describe 'datadog::dd-agent' do
       end.converge described_recipe
     end
 
-    it_behaves_like 'debianoids'
+    it_behaves_like 'debianoids repo'
     it_behaves_like 'version set below 4.x'
   end
 
@@ -209,8 +217,8 @@ describe 'datadog::dd-agent' do
         end.converge described_recipe
       end
 
-      it_behaves_like 'debianoids'
-      it_behaves_like 'no version set'
+      it_behaves_like 'debianoids repo'
+      it_behaves_like 'debianoids no version set'
     end
 
     context 'override with :upgrade' do
@@ -225,10 +233,10 @@ describe 'datadog::dd-agent' do
       end
 
       it 'upgrades the datadog-agent package' do
-        expect(chef_run).to upgrade_package('datadog-agent')
+        expect(chef_run).to upgrade_apt_package('datadog-agent')
       end
 
-      it_behaves_like 'debianoids'
+      it_behaves_like 'debianoids repo'
     end
 
     context 'allows a string for tags' do

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -365,6 +365,98 @@ describe 'datadog::dd-agent' do
     end
   end
 
+  context 'package downgrade' do
+    context 'left to default' do
+      context 'on debianoids' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(
+            platform: 'ubuntu',
+            version: '12.04'
+          ) do |node|
+            node.set['datadog'] = { 'api_key' => 'somethingnotnil' }
+            node.set['languages'] = { 'python' => { 'version' => '2.6.2' } }
+          end.converge described_recipe
+        end
+
+        it_behaves_like 'common linux resources'
+        it_behaves_like 'debianoids no version set'
+
+        it 'does not allow downgrade' do
+          expect(chef_run).to install_apt_package('datadog-agent')
+            .with(options: nil)
+        end
+      end
+
+      context 'on rhellions' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(
+            platform: 'centos',
+            version: '6.6'
+          ) do |node|
+            node.set['datadog'] = { 'api_key' => 'somethingnotnil' }
+            node.set['languages'] = { 'python' => { 'version' => '2.6.2' } }
+          end.converge described_recipe
+        end
+
+        it_behaves_like 'common linux resources'
+        it_behaves_like 'rhellions no version set'
+
+        it 'does not allow downgrade' do
+          expect(chef_run).to install_yum_package('datadog-agent')
+            .with(allow_downgrade: false)
+        end
+      end
+    end
+
+    context 'set to true' do
+      context 'on debianoids' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(
+            platform: 'ubuntu',
+            version: '12.04'
+          ) do |node|
+            node.set['datadog'] = {
+              'api_key' => 'somethingnotnil',
+              'agent_allow_downgrade' => true
+            }
+            node.set['languages'] = { 'python' => { 'version' => '2.6.2' } }
+          end.converge described_recipe
+        end
+
+        it_behaves_like 'common linux resources'
+        it_behaves_like 'debianoids no version set'
+
+        it 'allows downgrade' do
+          expect(chef_run).to install_apt_package('datadog-agent')
+            .with(options: '--force-yes')
+        end
+      end
+
+      context 'on rhellions' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(
+            platform: 'centos',
+            version: '6.6'
+          ) do |node|
+            node.set['datadog'] = {
+              'api_key' => 'somethingnotnil',
+              'agent_allow_downgrade' => true
+            }
+            node.set['languages'] = { 'python' => { 'version' => '2.6.2' } }
+          end.converge described_recipe
+        end
+
+        it_behaves_like 'common linux resources'
+        it_behaves_like 'rhellions no version set'
+
+        it 'allows downgrade' do
+          expect(chef_run).to install_yum_package('datadog-agent')
+            .with(allow_downgrade: true)
+        end
+      end
+    end
+  end
+
   context 'service action' do
     describe 'default' do
       cached(:chef_run) do

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -27,12 +27,24 @@ end
 shared_examples_for 'datadog-agent' do
   it_behaves_like 'common linux resources'
 
-  it 'installs the datadog-agent' do
-    expect(chef_run).to install_package 'datadog-agent'
+  it 'removes the datadog-agent-base package' do
+    expect(chef_run).to remove_package 'datadog-agent-base'
   end
+end
 
-  it 'does not install the datadog-agent-base package' do
-    expect(chef_run).not_to install_package 'datadog-agent-base'
+shared_examples_for 'debianoids datadog-agent' do
+  it_behaves_like 'datadog-agent'
+
+  it 'installs the datadog-agent' do
+    expect(chef_run).to install_apt_package 'datadog-agent'
+  end
+end
+
+shared_examples_for 'rhellions datadog-agent' do
+  it_behaves_like 'datadog-agent'
+
+  it 'installs the datadog-agent' do
+    expect(chef_run).to install_yum_package 'datadog-agent'
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,8 +20,8 @@ RSpec.configure do |config|
   config.log_level = :error
 
   config.before do
-    stub_command('rpm -q datadog-agent-base')
-    stub_command('apt-cache policy datadog-agent-base | grep "Installed: (none)"')
+    stub_command('rpm -q datadog-agent-base').and_return(true)
+    stub_command('apt-cache policy datadog-agent-base | grep "Installed: (none)"').and_return(false)
   end
 end
 


### PR DESCRIPTION
Still not allowed by default. Switching the attribute to `true` allows downgrades:

* Straightforward for rhel/fedora: the yum and rpm package providers
support a parameter that does just that
* Uses `--force-yes` on debian because:

 1. there's no direct option on the apt
provider
 2. `apt-get` supports a more fine-grained option
(`--allow-downgrades`) since version `1.1` of `apt`, but it ships with
ubuntu starting from `16.04` only, so we stick to using `--force-yes`. It could be nice to switch the option depending on the version of `apt`, but it'd add some complexity to the logic.

### Notes on downgrading packages with `apt`

With `apt`, downgrading can be dangerous for packages that have dependencies/on which other packages depend. From `dpkg`'s manpage, on downgrades:

> Warning: At present dpkg does not do any dependency checking on downgrades  and  therefore  will not warn  you  if  the  downgrade breaks the dependency of some other package. This can have serious side effects, downgrading essential system components can even make your whole system unusable.

This shouldn't be the case of the `datadog-agent` package so downgrading should be relatively safe.

Also, using `--force-yes` is equivalent to allowing `remove-essential`, `downgrades` and `change-held-packages`. None of these should be dangerous when applied to the `datadog-agent` package only. For reference see the manpage of `apt` `1.2`: http://manpages.ubuntu.com/manpages/xenial/en/man8/apt-get.8.html