### PR TITLE
chore(yum_repository): use baseurl property

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -24,7 +24,7 @@ end
 depends          'apt' # We recommend '>= 2.1.0'. See CHANGELOG.md for details
 depends          'chef_handler', '~> 1.1' # We recommend '~> 1.3' with Chef < 12. See CHANGELOG.md for details
 depends          'windows' # We recommend '< 1.39.0' if running Chef >= 12.6. See README.md for details
-depends          'yum'
+depends          'yum', '>= 3.0' # Use '~> 3.0' with Chef < 12
 
 suggests         'sudo' # ~FC052
 

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -40,7 +40,7 @@ when 'rhel', 'fedora'
   yum_repository 'datadog' do
     name 'datadog'
     description 'datadog'
-    url node['datadog']['yumrepo']
+    baseurl node['datadog']['yumrepo']
     proxy node['datadog']['yumrepo_proxy']
     proxy_username node['datadog']['yumrepo_proxy_username']
     proxy_password node['datadog']['yumrepo_proxy_password']


### PR DESCRIPTION
This was necessary as I recently started getting problems with the url property:

           NoMethodError
           -------------
           undefined method `url' for Chef::Resource::YumRepository
           
           Cookbook Trace:
           ---------------
           /tmp/kitchen/cache/cookbooks/datadog/recipes/repository.rb:43:in `block in from_file'
           /tmp/kitchen/cache/cookbooks/datadog/recipes/repository.rb:40:in `from_file'
           /tmp/kitchen/cache/cookbooks/datadog/recipes/_install-linux.rb:21:in `from_file'
           /tmp/kitchen/cache/cookbooks/datadog/recipes/dd-agent.rb:24:in `from_file'

Since url is only an alias for baseurl this shouldn't matter.

https://github.com/chef-cookbooks/yum/blob/master/resources/repository.rb#L69

