### PR TITLE
[yum_repository] Use `:create` action instead of deprecated `:add`

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -45,6 +45,6 @@ when 'rhel', 'fedora'
     proxy_username node['datadog']['yumrepo_proxy_username']
     proxy_password node['datadog']['yumrepo_proxy_password']
     gpgkey node['datadog']['yumrepo_gpgkey']
-    action :add
+    action :create
   end
 end

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -33,7 +33,7 @@ end
 
 shared_examples_for 'rhellions repo' do
   it 'sets up a yum repo' do
-    expect(chef_run).to add_yum_repository('datadog')
+    expect(chef_run).to create_yum_repository('datadog')
   end
 end
 

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -11,7 +11,7 @@ describe 'datadog::repository' do
       end
 
       it 'sets up a yum repo' do
-        expect(chef_run).to add_yum_repository('datadog').with(
+        expect(chef_run).to create_yum_repository('datadog').with(
           gpgkey: 'http://yum.datadoghq.com/DATADOG_RPM_KEY.public'
         )
       end
@@ -28,7 +28,7 @@ describe 'datadog::repository' do
       end
 
       it 'sets up a yum repo' do
-        expect(chef_run).to add_yum_repository('datadog').with(
+        expect(chef_run).to create_yum_repository('datadog').with(
           gpgkey: 'https://yum.datadoghq.com/DATADOG_RPM_KEY.public'
         )
       end


### PR DESCRIPTION
In the same vein as https://github.com/DataDog/chef-datadog/pull/361

`:add` has been an alias of `:create` since version 3.0 of the `yum` cookbook, so it's safe
to use `:create` (see https://github.com/chef-cookbooks/yum/commit/03e455c4798b2eef918381824ca907e839a1207f#diff-ea218fc13ddbe174ac160d2f69f9a01bR67). Before 3.0 it had a slightly different behavior.

Solves the following deprecation warning on `yum` `4.0`:

```
WARN: The :add method in yum_repository has been deprecated in favor of :create. Please update your cookbook to use the :create action
``` 