### PR TITLE
Prepare pkg keys rotation

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -91,6 +91,10 @@ default['datadog']['yumrepo_proxy_username'] = nil
 default['datadog']['yumrepo_proxy_password'] = nil
 default['datadog']['windows_agent_url'] = 'https://s3.amazonaws.com/ddagent-windows-stable/'
 
+# Location of additional rpm gpgkey to import (with signature `e09422b3`). In the future the rpm packages
+# of the Agent will be signed with this key.
+default['datadog']['yumrepo_gpgkey_new'] = "#{yum_protocol}://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
+
 # Agent installer checksum
 # Expected checksum to validate correct agent installer is downloaded (Windows only)
 default['datadog']['windows_agent_checksum'] = nil

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -25,6 +25,13 @@ when 'debian'
     action :install
   end
 
+  # Trust new APT key
+  execute 'apt-key import key 382E94DE' do
+    command 'apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE'
+    not_if 'apt-key list | grep 382E94DE'
+  end
+
+  # Add APT repository
   apt_repository 'datadog' do
     keyserver 'hkp://keyserver.ubuntu.com:80'
     key 'C7A7DA52'

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -44,6 +44,30 @@ when 'debian'
 when 'rhel', 'fedora'
   include_recipe 'yum'
 
+  # Import new RPM key
+  if node['datadog']['yumrepo_gpgkey_new']
+    # gnupg is required to check the downloaded key's fingerprint
+    package 'gnupg' do
+      action :install
+    end
+
+    # Download new RPM key
+    key_local_path = ::File.join(Chef::Config[:file_cache_path], 'DATADOG_RPM_KEY_E09422B3.public')
+    remote_file 'DATADOG_RPM_KEY_E09422B3.public' do
+      path key_local_path
+      source node['datadog']['yumrepo_gpgkey_new']
+    end
+
+    # Import key if fingerprint matches
+    execute 'rpm-import datadog key e09422b3' do
+      command "rpm --import #{key_local_path}"
+      not_if 'rpm -q gpg-pubkey-e09422b3' # (key already imported)
+      only_if "gpg --dry-run --quiet --with-fingerprint #{key_local_path} | grep 'A4C0 B90D 7443 CF6E 4E8A  A341 F106 8E14 E094 22B3'"
+      action :run
+    end
+  end
+
+  # Add YUM repository
   yum_repository 'datadog' do
     name 'datadog'
     description 'datadog'

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -22,6 +22,12 @@ shared_examples_for 'datadog-agent-base' do
 end
 
 shared_examples_for 'debianoids repo' do
+  it 'installs new apt key' do
+    expect(chef_run).to run_execute('apt-key import key 382E94DE').with(
+      command: 'apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE'
+    )
+  end
+
   it 'sets up an apt repo' do
     expect(chef_run).to add_apt_repository('datadog')
   end

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -38,6 +38,17 @@ shared_examples_for 'debianoids repo' do
 end
 
 shared_examples_for 'rhellions repo' do
+  it 'installs gnupg' do
+    expect(chef_run).to install_package('gnupg')
+  end
+
+  it 'downloads and imports the new RPM key' do
+    expect(chef_run).to create_remote_file('DATADOG_RPM_KEY_E09422B3.public').with(path: '/var/chef/cache/DATADOG_RPM_KEY_E09422B3.public')
+    expect(chef_run).to run_execute('rpm-import datadog key e09422b3').with(
+      command: 'rpm --import /var/chef/cache/DATADOG_RPM_KEY_E09422B3.public'
+    )
+  end
+
   it 'sets up a yum repo' do
     expect(chef_run).to create_yum_repository('datadog')
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,8 @@ RSpec.configure do |config|
     " | grep 'A4C0 B90D 7443 CF6E 4E8A  A341 F106 8E14 E094 22B3'").and_return(true)
     stub_command('rpm -q gpg-pubkey-e09422b3').and_return(false)
   end
+
+  Ohai::Config[:log_level] = :warn
 end
 
 ChefSpec::Coverage.start!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,7 @@ RSpec.configure do |config|
   config.before do
     stub_command('rpm -q datadog-agent-base').and_return(true)
     stub_command('apt-cache policy datadog-agent-base | grep "Installed: (none)"').and_return(false)
+    stub_command('apt-key list | grep 382E94DE').and_return(false)
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,10 +19,18 @@ RSpec.configure do |config|
   # @see https://github.com/chef-cookbooks/yum/issues/140
   config.log_level = :error
 
+  config.file_cache_path = '/var/chef/cache'
+
   config.before do
+    # recipes/dd-agent.rb
     stub_command('rpm -q datadog-agent-base').and_return(true)
     stub_command('apt-cache policy datadog-agent-base | grep "Installed: (none)"').and_return(false)
+
+    # recipes/repository.rb
     stub_command('apt-key list | grep 382E94DE').and_return(false)
+    stub_command('gpg --dry-run --quiet --with-fingerprint /var/chef/cache/DATADOG_RPM_KEY_E09422B3.public'\
+    " | grep 'A4C0 B90D 7443 CF6E 4E8A  A341 F106 8E14 E094 22B3'").and_return(true)
+    stub_command('rpm -q gpg-pubkey-e09422b3').and_return(false)
   end
 end
 

--- a/test/integration/dd-agent/serverspec/dd-agent_spec.rb
+++ b/test/integration/dd-agent/serverspec/dd-agent_spec.rb
@@ -13,3 +13,8 @@ describe command('/etc/init.d/datadog-agent info'), :if => os[:family] != 'windo
   its(:stdout) { should contain 'OK' }
   its(:stdout) { should_not contain 'ERROR' }
 end
+
+describe command('apt-key list'), :if => ['debian', 'ubuntu'].include?(os[:family]) do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should contain '382E94DE' }
+end

--- a/test/integration/dd-agent/serverspec/dd-agent_spec.rb
+++ b/test/integration/dd-agent/serverspec/dd-agent_spec.rb
@@ -14,7 +14,14 @@ describe command('/etc/init.d/datadog-agent info'), :if => os[:family] != 'windo
   its(:stdout) { should_not contain 'ERROR' }
 end
 
+# The new APT key is imported
 describe command('apt-key list'), :if => ['debian', 'ubuntu'].include?(os[:family]) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should contain '382E94DE' }
+end
+
+# The new RPM key is imported
+describe command('rpm -q gpg-pubkey-e09422b3'), :if => os[:family] == 'redhat' do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should contain 'gpg-pubkey-e09422b3' }
 end


### PR DESCRIPTION
~~_WIP, PR open for discussion. Tests are failing for now, I'll fix them and add new ones once we agree that this is the right approach_~~

The idea is to make the pkg managers trust the new keys in addition to the current keys, in the next version of this cookbook (before the new keys are used). In the future, once we switch the APT repository and the RPM packages over to the new keys, we could release yet another version of the cookbook that only trusts the newer keys.

This approach ensures that, when we switch over to the new keys:
- for people using a version of the cookbook that includes this PR, the switch will be unnoticeable
- for people using an older version of the cookbook, apt pkg installs will fail (no way to work around that), rpm installs won't fail as long as the Agent is pinned to a version that's signed with the older keys.

AFAIK we import the new keys safely (through a keyserver with `apt`, and with a fingerprint check with `rpm`).

More details in the commit messages.
