### PR TITLE
Add support for any config options

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -218,6 +218,11 @@ default['datadog']['statsd_metric_namespace'] = nil
 default['datadog']['histogram_aggregates'] = 'max, median, avg, count'
 default['datadog']['histogram_percentiles'] = '0.95'
 
+# extra config options
+# If an agent is released with a new config option which is not yet supported by this cookbook
+# you can use this attribute to set it. Will be ignored if nil.
+default['datadog']['extra_config']['forwarder_timeout'] = nil
+
 # extra_packages to install
 default['datadog']['extra_packages'] = {}
 

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -65,6 +65,12 @@ node['datadog']['extra_endpoints'].each do |_, endpoint|
              end
 end
 
+extra_config = {}
+node['datadog']['extra_config'].each do |option, value|
+  next if value.nil?
+  extra_config[option] = value
+end
+
 template agent_config_file do
   if is_windows
     owner 'Administrators'
@@ -77,7 +83,8 @@ template agent_config_file do
   end
   variables(
     :api_keys => api_keys,
-    :dd_urls => dd_urls
+    :dd_urls => dd_urls,
+    :extra_config => extra_config
   )
   sensitive true if Chef::Resource.instance_methods(false).include?(:sensitive)
 end

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -483,6 +483,38 @@ describe 'datadog::dd-agent' do
     end
   end
 
+  context 'does accept extra config options' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '12.04'
+      ) do |node|
+        node.set['datadog'] = {
+          'api_key' => 'something1',
+          'url' => 'https://app.example.com',
+          'extra_config' => {
+            'example_key' => 'example_value',
+            'false_key' => false,
+            'no_example_key' => nil
+          }
+        }
+        node.set['languages'] = { 'python' => { 'version' => '2.6.2' } }
+      end.converge described_recipe
+    end
+
+    it_behaves_like 'common linux resources'
+
+    it 'uses the multiples apikeys and urls' do
+      expect(chef_run).to render_file('/etc/dd-agent/datadog.conf')
+        .with_content(/^example_key: example_value$/)
+        .with_content(/^false_key: false$/)
+        .with_content(/^# Other config options$/)
+
+      expect(chef_run).to_not render_file('/etc/dd-agent/datadog.conf')
+        .with_content(/^no_example_key:/)
+    end
+  end
+
   context 'package downgrade' do
     context 'left to default' do
       context 'on debianoids' do

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -131,7 +131,6 @@ if node['datadog']['legacy_integrations']
 -%>
 <%= description %>
 <%
-    ## Todo: add guardrails against other valid config directives
       int_hash['config'].each do |k,v|
 -%>
 <%= k %>: <%= v %>
@@ -141,3 +140,12 @@ if node['datadog']['legacy_integrations']
   end
 end
 -%>
+
+<% if ! @extra_config.empty? -%>
+# ========================================================================== #
+# Other config options
+# ========================================================================== #
+  <% @extra_config.each do |k, v| -%>
+<%= k %>: <%= v %>
+  <% end -%>
+<% end -%>


### PR DESCRIPTION
It is annoying to have to wait for a new cookbook release when an agent
is released with a new config option.
This commit aims to fix it by allowing any config options to be added.

Fix https://github.com/DataDog/chef-datadog/issues/336