### PR TITLE
Rename package[apt-transport-https] resource for Chef 13 compatibility

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -21,7 +21,8 @@ case node['platform_family']
 when 'debian'
   include_recipe 'apt'
 
-  package 'apt-transport-https' do
+  package 'install-apt-transport-https' do
+    package_name 'apt-transport-https'
     action :install
   end
 


### PR DESCRIPTION
This PR renames `package[apt-transport-https]` to avoid resource cloning.

Currently, when DataDog cookbook used with `apt` cookbook 2.9.1 or later (released October 24, 2015), Chef throws a deprecation warning:

```
Deprecated features used!
  Cloning resource attributes for apt_package[apt-transport-https] from prior resource
Previous apt_package[apt-transport-https]: /var/chef/cache/cookbooks/apt/recipes/default.rb:85:in `from_file'
Current  apt_package[apt-transport-https]: /var/chef/cache/cookbooks/datadog/recipes/repository.rb:24:in `from_file' at 1 location:
    - /var/chef/cache/cookbooks/datadog/recipes/repository.rb:24:in `from_file'
   See https://docs.chef.io/deprecations_resource_cloning.html for further details.
```

Originally this PR suggested to just remove the resource and bump `apt` cookbook dependency but it's been decided to rename the resource instead — for those who depend on an older `apt` cookbook elsewhere.