### PR TITLE
[rubocop] Fix rubocop offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,15 @@ AllCops:
 Metrics/LineLength:
   Max: 160
 
+# Exclude Rakefile and tests since there are long blocks that aren't worth shortening there
+# Also, slightly longer blocks are fine
+Metrics/BlockLength:
+  Max: 30
+  Exclude:
+    - 'Rakefile'
+    - 'spec/**/*.rb'
+    - 'test/**/*.rb'
+
 # TODO: add encoding headers
 Style/Encoding:
   Enabled: false

--- a/providers/monitor.rb
+++ b/providers/monitor.rb
@@ -16,7 +16,7 @@ action :add do
       inherits false
     else
       owner 'dd-agent'
-      mode 00600
+      mode '600'
     end
 
     source 'integration.yaml.erb' if new_resource.use_integration_template

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -42,7 +42,7 @@ directory node['datadog']['config_dir'] do
   else
     owner 'dd-agent'
     group 'root'
-    mode 0755
+    mode '755'
   end
 end
 
@@ -79,7 +79,7 @@ template agent_config_file do
   else
     owner 'dd-agent'
     group 'root'
-    mode 0640
+    mode '640'
   end
   variables(
     :api_keys => api_keys,

--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -73,4 +73,5 @@ chef_handler 'Chef::Handler::Datadog' do
   arguments [handler_config]
   supports :report => true, :exception => true
   action :nothing
-end.run_action(:enable) if node['datadog']['chef_handler_enable']
+  only_if { node['datadog']['chef_handler_enable'] }
+end.run_action(:enable)

--- a/spec/dd-handler_spec.rb
+++ b/spec/dd-handler_spec.rb
@@ -47,6 +47,26 @@ describe 'datadog::dd-handler' do
     it_behaves_like 'a chef-handler-datadog runner'
   end
 
+  context 'handler disabled' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '14.04'
+      ) do |node|
+        node.set['datadog']['api_key'] = 'somethingnotnil'
+        node.set['datadog']['application_key'] = 'somethingnotnil2'
+        node.set['datadog']['chef_handler_enable'] = false
+        node.set['datadog']['use_ec2_instance_id'] = true
+      end.converge described_recipe
+    end
+
+    it_behaves_like 'a chef-handler-datadog installer'
+
+    it "doesn't enable the datadog handler" do
+      expect(chef_run).not_to enable_chef_handler 'Chef::Handler::Datadog'
+    end
+  end
+
   context 'multiple endpoints' do
     cached(:chef_run) do
       ChefSpec::SoloRunner.new(

--- a/test/integration/datadog_cassandra_greater_22/serverspec/cassandra_spec.rb
+++ b/test/integration/datadog_cassandra_greater_22/serverspec/cassandra_spec.rb
@@ -85,7 +85,8 @@ describe file(AGENT_CONFIG) do
                 MemtableColumnsCount
                 MemtableLiveDataSize
                 MemtableSwitchCount
-                MinRowSize)
+                MinRowSize
+              )
             },
             exclude: {
               keyspace: [


### PR DESCRIPTION
Also adds an exclusion for the block length cop on our `test/` folder.

No functional change.

Closes #356 (ended up choosing the `644` notation for the file/dir `mode`s)