### PR TITLE
Add attributes for package download retries options

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -139,6 +139,11 @@ default['datadog']['agent_version'] = nil
 # Allow override with `upgrade` to get latest (Linux only)
 default['datadog']['agent_package_action'] = 'install'
 
+# Agent package options
+# retries and retry_delay for package download/install
+default['datadog']['agent_package_retries'] = nil
+default['datadog']['agent_package_retry_delay'] = nil
+
 # Allow downgrades of the agent (Linux only)
 # Note: on apt-based platforms, this will use the `--force-yes` option on the apt-get command. Use with caution.
 default['datadog']['agent_allow_downgrade'] = false

--- a/recipes/_install-linux.rb
+++ b/recipes/_install-linux.rb
@@ -48,17 +48,23 @@ else
     only_if 'rpm -q datadog-agent-base' if %w(rhel fedora).include?(node['platform_family'])
     not_if 'apt-cache policy datadog-agent-base | grep "Installed: (none)"' if node['platform_family'] == 'debian'
   end
+  package_retries = node['datadog']['agent_package_retries']
+  package_retry_delay = node['datadog']['agent_package_retry_delay']
   # Install the regular package
   case node['platform_family']
   when 'debian'
     apt_package 'datadog-agent' do
       version dd_agent_version
+      retries package_retries unless package_retries.nil?
+      retry_delay package_retry_delay unless package_retry_delay.nil?
       action node['datadog']['agent_package_action'] # default is :install
       options '--force-yes' if node['datadog']['agent_allow_downgrade']
     end
   when 'rhel', 'fedora'
     yum_package 'datadog-agent' do
       version dd_agent_version
+      retries package_retries unless package_retries.nil?
+      retry_delay package_retry_delay unless package_retry_delay.nil?
       action node['datadog']['agent_package_action'] # default is :install
       allow_downgrade node['datadog']['agent_allow_downgrade']
     end

--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -28,10 +28,15 @@ dd_agent_version =
 dd_agent_msi = dd_agent_version ? "ddagent-cli-#{dd_agent_version}.msi" : 'ddagent-cli.msi'
 temp_file = ::File.join(Chef::Config[:file_cache_path], 'ddagent-cli.msi')
 
+package_retries = node['datadog']['agent_package_retries']
+package_retry_delay = node['datadog']['agent_package_retry_delay']
+
 # Download the installer to a temp location
 remote_file temp_file do
   source node['datadog']['windows_agent_url'] + dd_agent_msi
   checksum node['datadog']['windows_agent_checksum'] if node['datadog']['windows_agent_checksum']
+  retries package_retries unless package_retries.nil?
+  retry_delay package_retry_delay unless package_retry_delay.nil?
   # As of v1.37, the windows cookbook doesn't upgrade the package if a newer version is downloaded
   # As a workaround uninstall the package first if a new MSI is downloaded
   notifies :remove, 'windows_package[Datadog Agent]', :immediately


### PR DESCRIPTION
Allow users to specify the retries/retry_delay options of the package
resource with an attribute.

Fix https://github.com/DataDog/chef-datadog/issues/320