### PR TITLE
deb: remove apt-transport-https, already done in apt cookbook

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -21,10 +21,6 @@ case node['platform_family']
 when 'debian'
   include_recipe 'apt'
 
-  package 'apt-transport-https' do
-    action :install
-  end
-
   # Trust new APT key
   execute 'apt-key import key 382E94DE' do
     command 'apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE'

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -31,10 +31,6 @@ shared_examples_for 'debianoids repo' do
   it 'sets up an apt repo' do
     expect(chef_run).to add_apt_repository('datadog')
   end
-
-  it 'installs apt-transport-https' do
-    expect(chef_run).to install_package('apt-transport-https')
-  end
 end
 
 shared_examples_for 'rhellions repo' do


### PR DESCRIPTION
fixes #392 
