### PR TITLE
Defer evaluation of api and app keys + read from `run_state`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,11 @@ Metrics/BlockLength:
     - 'spec/**/*.rb'
     - 'test/**/*.rb'
 
+
+# Slightly longer methods are fine
+Metrics/MethodLength:
+  Max: 15
+
 # TODO: add encoding headers
 Style/Encoding:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Datadog Cookbook
 
 Chef recipes to deploy Datadog's components and configuration automatically.
 
+**NB: This README may refer to features that are not released yet. Please check the README of the
+git tag/the gem version you're using for your version's documentation**
+
 Requirements
 ============
 - chef >= 10.14
@@ -86,10 +89,16 @@ Usage
 
 1. Add this cookbook to your Chef Server, either by installing with knife or by adding it to your Berksfile:
   ```
-  cookbook 'datadog', '~> 2.1.0'
+  cookbook 'datadog', '~> 2.7.0'
   ```
-2. Add your API Key as a node attribute via an `environment` or `role` or by declaring it in another cookbook at a higher precedence level.
-3. Create an 'application key' for `chef_handler` [here](https://app.datadoghq.com/account/settings#api), and add it as a node attribute, as in Step #2.
+2. Add your API Key either:
+  * as a node attribute via an `environment` or `role`, or
+  * as a node attribute by declaring it in another cookbook at a higher precedence level, or
+  * in the node `run_state` by setting `node.run_state['datadog']['api_key']` in another cookbook preceding `datadog`'s recipes in the run_list. This approach has the benefit of not storing the credential in clear text on the Chef Server.
+3. Create an 'application key' for `chef_handler` [here](https://app.datadoghq.com/account/settings#api), and add it as a node attribute or in the run state, as in Step #2.
+
+   NB: if you're using the run state to store the api and app keys you need to set them at compile time before `datadog::dd-handler` in the run list.
+
 4. Associate the recipes with the desired `roles`, i.e. "role:chef-client" should contain "datadog::dd-handler" and a "role:base" should start the agent with "datadog::dd-agent".  Here's an example role with both recipes:
   ```
   name 'example'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,13 +17,15 @@
 # limitations under the License.
 #
 
-# Place your API Key here, or set it on the role/environment/node
+# Place your API Key here, or set it on the role/environment/node, or set it on your
+# node `run_state` under the key `['datadog']['api_key']`.
 # The Datadog api key to associate your agent's data with your organization.
 # Can be found here:
 # https://app.datadoghq.com/account/settings
 default['datadog']['api_key'] = nil
 
-# Create an application key on the Account Settings page
+# Create an application key on the Account Settings page.
+# Set it as an attribute, or on your node `run_state` under the key `['datadog']['application_key']`
 default['datadog']['application_key'] = nil
 
 # Use this attribute to send data to additional accounts

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -1,0 +1,24 @@
+class Chef
+  # Helper class for Datadog Chef recipes
+  class Datadog
+    class << self
+      def api_key(node)
+        run_state_or_attribute(node, 'api_key')
+      end
+
+      def application_key(node)
+        run_state_or_attribute(node, 'application_key')
+      end
+
+      private
+
+      def run_state_or_attribute(node, attr)
+        if node.run_state.key?('datadog') && node.run_state['datadog'].key?(attr)
+          node.run_state['datadog'][attr]
+        else
+          node['datadog'][attr]
+        end
+      end
+    end
+  end
+end

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -12,11 +12,11 @@ class Chef
 
       private
 
-      def run_state_or_attribute(node, attr)
-        if node.run_state.key?('datadog') && node.run_state['datadog'].key?(attr)
-          node.run_state['datadog'][attr]
+      def run_state_or_attribute(node, attribute)
+        if node.run_state.key?('datadog') && node.run_state['datadog'].key?(attribute)
+          node.run_state['datadog'][attribute]
         else
-          node['datadog'][attr]
+          node['datadog'][attribute]
         end
       end
     end

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -55,7 +55,7 @@ end
 
 template agent_config_file do
   def template_vars
-    api_keys = [node['datadog']['api_key']]
+    api_keys = [Chef::Datadog.api_key(node)]
     dd_urls = [node['datadog']['url']]
     node['datadog']['extra_endpoints'].each do |_, endpoint|
       next unless endpoint['enabled']

--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -58,8 +58,8 @@ chef_handler 'Chef::Handler::Datadog' do
     end
 
     config = {
-      :api_key => node['datadog']['api_key'],
-      :application_key => node['datadog']['application_key'],
+      :api_key => Chef::Datadog.api_key(node),
+      :application_key => Chef::Datadog.application_key(node),
       :use_ec2_instance_id => node['datadog']['use_ec2_instance_id'],
       :tag_prefix => node['datadog']['tag_prefix'],
       :url => node['datadog']['url'],

--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -47,8 +47,8 @@ unless web_proxy['host'].nil?
 end
 
 # Create the handler to run at the end of the Chef execution
-chef_handler 'Chef::Handler::Datadog' do
-  def handler_config # rubocop:disable Metrics/AbcSize
+chef_handler 'Chef::Handler::Datadog' do # rubocop:disable Metrics/BlockLength
+  def extra_endpoints
     extra_endpoints = []
     node['datadog']['extra_endpoints'].each do |_, endpoint|
       next unless endpoint['enabled']
@@ -56,7 +56,10 @@ chef_handler 'Chef::Handler::Datadog' do
       endpoint.delete('enabled')
       extra_endpoints << endpoint
     end
+    extra_endpoints
+  end
 
+  def handler_config # rubocop:disable Metrics/AbcSize
     config = {
       :api_key => Chef::Datadog.api_key(node),
       :application_key => Chef::Datadog.application_key(node),

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -76,6 +76,7 @@ describe 'datadog::dd-agent' do
   include EnvVar
 
   context 'no version set' do
+    # This recipe needs to have an api_key, otherwise `raise` is called.
     # It also depends on the version of Python present on the platform:
     #   2.6 and up => datadog-agent is installed
     #   below 2.6 => datadog-agent-base is installed
@@ -372,7 +373,9 @@ describe 'datadog::dd-agent' do
 
       it_behaves_like 'debianoids repo'
     end
+  end
 
+  context 'datadog.conf configuration' do
     context 'allows a string for tags' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(
@@ -495,6 +498,67 @@ describe 'datadog::dd-agent' do
         expect(chef_run).to render_file('/etc/dd-agent/datadog.conf')
           .with_content(/^api_key: something1,something2$/)
           .with_content(%r{^dd_url: https://app.example.com,https://app.example.com$})
+      end
+    end
+
+    context 'with no api_key set' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(
+          platform: 'ubuntu',
+          version: '12.04'
+        ) do |node|
+          node.set['languages'] = { 'python' => { 'version' => '2.6.2' } }
+        end.converge described_recipe
+      end
+
+      it 'raises an error' do
+        expect(chef_run).to run_ruby_block('datadog-api-key-unset')
+        expect { chef_run.ruby_block('datadog-api-key-unset').old_run_action(:run) }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'with api_key set as node attribute and on node run_state' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(
+          platform: 'ubuntu',
+          version: '12.04'
+        ) do |node|
+          node.set['datadog'] = {
+            'api_key' => 'as_node_attribute',
+            'url' => 'https://app.example.com'
+          }
+          node.set['languages'] = { 'python' => { 'version' => '2.6.2' } }
+          node.run_state['datadog'] = { 'api_key' => 'on_run_state' }
+        end.converge described_recipe
+      end
+
+      it_behaves_like 'common linux resources'
+
+      it 'uses the api_key from the run_state' do
+        expect(chef_run).to render_file('/etc/dd-agent/datadog.conf')
+          .with_content(/^api_key: on_run_state$/)
+
+        expect(chef_run).not_to render_file('/etc/dd-agent/datadog.conf')
+          .with_content(/api_key: as_node_attribute/)
+      end
+    end
+
+    context 'with api_key set on node run_state only' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(
+          platform: 'ubuntu',
+          version: '12.04'
+        ) do |node|
+          node.set['languages'] = { 'python' => { 'version' => '2.6.2' } }
+          node.run_state['datadog'] = { 'api_key' => 'on_run_state' }
+        end.converge described_recipe
+      end
+
+      it_behaves_like 'common linux resources'
+
+      it 'uses the api_key from the run_state' do
+        expect(chef_run).to render_file('/etc/dd-agent/datadog.conf')
+          .with_content(/^api_key: on_run_state$/)
       end
     end
   end

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -76,7 +76,6 @@ describe 'datadog::dd-agent' do
   include EnvVar
 
   context 'no version set' do
-    # This recipe needs to have an api_key, otherwise `raise` is called.
     # It also depends on the version of Python present on the platform:
     #   2.6 and up => datadog-agent is installed
     #   below 2.6 => datadog-agent-base is installed

--- a/spec/dd-handler_spec.rb
+++ b/spec/dd-handler_spec.rb
@@ -68,6 +68,48 @@ describe 'datadog::dd-handler' do
     end
   end
 
+  context 'with api and app keys set as node attributes and on node run_state' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '14.04'
+      ) do |node|
+        node.set['datadog']['api_key'] = 'api_overriden_by_run_state'
+        node.set['datadog']['application_key'] = 'app_overriden_by_run_state'
+        node.set['datadog']['chef_handler_enable'] = true
+        node.set['datadog']['use_ec2_instance_id'] = true
+        node.run_state['datadog'] = {
+          'api_key' => 'somethingnotnil',
+          'application_key' => 'somethingnotnil2'
+        }
+      end.converge described_recipe
+    end
+
+    it_behaves_like 'a chef-handler-datadog installer'
+
+    it_behaves_like 'a chef-handler-datadog runner'
+  end
+
+  context 'with keys set on node run_state only' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '14.04'
+      ) do |node|
+        node.set['datadog']['chef_handler_enable'] = true
+        node.set['datadog']['use_ec2_instance_id'] = true
+        node.run_state['datadog'] = {
+          'api_key' => 'somethingnotnil',
+          'application_key' => 'somethingnotnil2'
+        }
+      end.converge described_recipe
+    end
+
+    it_behaves_like 'a chef-handler-datadog installer'
+
+    it_behaves_like 'a chef-handler-datadog runner'
+  end
+
   context 'multiple endpoints' do
     cached(:chef_run) do
       ChefSpec::SoloRunner.new(
@@ -93,6 +135,7 @@ describe 'datadog::dd-handler' do
 
     it_behaves_like 'a chef-handler-datadog runner', extra_endpoints, nil
   end
+
   context 'multiple endpoints disabled' do
     cached(:chef_run) do
       ChefSpec::SoloRunner.new(

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -8,8 +8,15 @@ shared_examples_for 'datadog-agent service' do
   end
 end
 
+shared_examples_for 'datadog conf' do
+  it 'does not complain about a missing api key' do
+    expect(chef_run).not_to run_ruby_block('datadog-api-key-unset')
+  end
+end
+
 shared_examples_for 'common linux resources' do
   it_behaves_like 'datadog-agent service'
+  it_behaves_like 'datadog conf'
 
   it 'includes the repository recipe' do
     expect(chef_run).to include_recipe('datadog::repository')
@@ -50,6 +57,7 @@ end
 
 shared_examples_for 'common windows resources' do
   it_behaves_like 'datadog-agent service'
+  it_behaves_like 'datadog conf'
 
   it 'ensures the Datadog config directory exists' do
     expect(chef_run).to create_directory 'C:\ProgramData/Datadog'

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -141,11 +141,13 @@ if node['datadog']['legacy_integrations']
 end
 -%>
 
-<% if ! @extra_config.empty? -%>
+<% if ! node['datadog']['extra_config'].empty? -%>
 # ========================================================================== #
 # Other config options
 # ========================================================================== #
-  <% @extra_config.each do |k, v| -%>
+  <% node['datadog']['extra_config'].each do |k, v| -%>
+    <% if ! v.nil? -%>
 <%= k %>: <%= v %>
+    <% end -%>
   <% end -%>
 <% end -%>


### PR DESCRIPTION
Based on #345 (thanks @mfischer), rebased on top of master, and minus the changes on the `compile_time` property in `dd-handler`. Details in the commit messages and in #345.

Tested on both Chef 11 and 12, seems to work fine.

Related to #377