### PR TITLE
[dd-handler] Bump requirement on `chef_handler`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ before_script:
   - eval "$(/opt/chefdk/bin/chef shell-init bash)"
   - chef gem install coveralls -v '0.8.19'
   - chef gem install json_spec -v '~> 1.1.4'
-  - chef gem install chef-handler-datadog
 
 script:
   - chef --version

--- a/Rakefile
+++ b/Rakefile
@@ -103,7 +103,7 @@ task :circle do
       # TODO: This could likely be pulled from kitchen_config.instances somehow
       name = platform.name.delete('.')
 
-      # Execute a suite that installs the handler and the Agent.
+      # Scope the suites to only execute against the Agent+handler installer suites.
       commands.push "kitchen verify dd-agent-handler-#{name}"
     end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -23,7 +23,7 @@ issues_url       'https://github.com/DataDog/chef-datadog/issues' if respond_to?
 end
 
 depends          'apt' # We recommend '>= 2.1.0'. See CHANGELOG.md for details
-depends          'chef_handler', '>= 1.1' # We recommend '~> 1.3' with Chef < 12. See CHANGELOG.md for details
+depends          'chef_handler', '>= 1.2' # We recommend '~> 1.3' with Chef < 12. See CHANGELOG.md for details
 depends          'windows' # We recommend '< 1.39.0' if running Chef >= 12.6. See README.md for details
 depends          'yum', '>= 3.0' # Use '~> 3.0' with Chef < 12
 

--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -19,9 +19,8 @@
 require 'uri'
 
 if Chef::Config[:why_run]
-  # chef_handler 1.1 needs us to require datadog handler's file,
-  # which makes why-run runs fail when chef-handler-datadog is not installed,
-  # so skip the recipe when in why-run mode until we can use chef_handler 1.2
+  # chef_handler 1.4 doesn't support why-run mode
+  # see https://github.com/chef-cookbooks/chef_handler/issues/41
   Chef::Log.warn('Running in why-run mode, skipping dd-handler')
   return
 end
@@ -32,12 +31,11 @@ ENV['DATADOG_HOST'] = node['datadog']['url']
 chef_gem 'chef-handler-datadog' do # ~FC009
   action :install
   version node['datadog']['chef_handler_version']
-  # Chef 12 introduced `compile_time` - remove when Chef 11 is EOL.
+  # Chef 12 introduced `compile_time` - remove respond_to? when Chef 11 is EOL.
   compile_time true if respond_to?(:compile_time)
   clear_sources true if node['datadog']['gem_server']
   source node['datadog']['gem_server'] if node['datadog']['gem_server']
 end
-require 'chef/handler/datadog'
 
 # add web proxy from config support
 web_proxy = node['datadog']['web_proxy']


### PR DESCRIPTION
Allows removing the `require` on our handler, since `chef_handler` >= 1.2
can take care of requiring our handler. Should fix #338

Keep installing the `chef_gem` and enabling the handler at compile time
so that the handler can report compilation errors.

Unfortunately we still need to skip the `dd-handler` recipe in `why_run` mode with `chef_handler` `1.4` (see inline comment for link to related issue)