### PR TITLE
[dd-agent][windows] Fix agent version pinning

### DIFF
--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -21,7 +21,7 @@ dd_agent_version =
   if node['datadog']['agent_version'].respond_to?(:each_pair)
     node['datadog']['agent_version']['windows']
   else
-    node['datadog']['agent_verison']
+    node['datadog']['agent_version']
   end
 
 # If no version is specified, select the latest package


### PR DESCRIPTION
When the `agent_version` attribute is a string. Bug introduced in #368

Also added the test that would've caught the bug.

I'll release a bugfix version once this is merged.