### PR TITLE
Fixed #403 - Guard new GPG key from being downloaded always

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -56,14 +56,15 @@ when 'rhel', 'fedora'
     remote_file 'DATADOG_RPM_KEY_E09422B3.public' do
       path key_local_path
       source node['datadog']['yumrepo_gpgkey_new']
+      not_if 'rpm -q gpg-pubkey-e09422b3' # (key already imported)
+      notifies :run, 'execute[rpm-import datadog key e09422b3]', :immediately
     end
 
     # Import key if fingerprint matches
     execute 'rpm-import datadog key e09422b3' do
       command "rpm --import #{key_local_path}"
-      not_if 'rpm -q gpg-pubkey-e09422b3' # (key already imported)
       only_if "gpg --dry-run --quiet --with-fingerprint #{key_local_path} | grep 'A4C0 B90D 7443 CF6E 4E8A  A341 F106 8E14 E094 22B3'"
-      action :run
+      action :nothing
     end
   end
 

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -21,36 +21,9 @@ shared_examples_for 'datadog-agent-base' do
   end
 end
 
-shared_examples_for 'debianoids repo' do
-  it 'installs new apt key' do
-    expect(chef_run).to run_execute('apt-key import key 382E94DE').with(
-      command: 'apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE'
-    )
-  end
-
-  it 'sets up an apt repo' do
-    expect(chef_run).to add_apt_repository('datadog')
-  end
-
-  it 'installs apt-transport-https' do
-    expect(chef_run).to install_package('apt-transport-https')
-  end
-end
-
-shared_examples_for 'rhellions repo' do
-  it 'installs gnupg' do
-    expect(chef_run).to install_package('gnupg')
-  end
-
-  it 'downloads and imports the new RPM key' do
-    expect(chef_run).to create_remote_file('DATADOG_RPM_KEY_E09422B3.public').with(path: '/var/chef/cache/DATADOG_RPM_KEY_E09422B3.public')
-    expect(chef_run).to run_execute('rpm-import datadog key e09422b3').with(
-      command: 'rpm --import /var/chef/cache/DATADOG_RPM_KEY_E09422B3.public'
-    )
-  end
-
-  it 'sets up a yum repo' do
-    expect(chef_run).to create_yum_repository('datadog')
+shared_examples_for 'repo recipe' do
+  it 'includes the repository recipe' do
+    expect(chef_run).to include_recipe('dd-agent::repository')
   end
 end
 
@@ -91,7 +64,7 @@ describe 'datadog::dd-agent' do
         end.converge described_recipe
       end
 
-      it_behaves_like 'debianoids repo'
+      it_behaves_like 'repo recipe'
       it_behaves_like 'debianoids no version set'
     end
 
@@ -106,7 +79,7 @@ describe 'datadog::dd-agent' do
         end.converge described_recipe
       end
 
-      it_behaves_like 'debianoids repo'
+      it_behaves_like 'repo recipe'
       it_behaves_like 'debianoids no version set'
     end
 
@@ -121,7 +94,7 @@ describe 'datadog::dd-agent' do
         end.converge described_recipe
       end
 
-      it_behaves_like 'debianoids repo'
+      it_behaves_like 'repo recipe'
       it_behaves_like 'debianoids no version set'
     end
 
@@ -136,7 +109,7 @@ describe 'datadog::dd-agent' do
         end.converge described_recipe
       end
 
-      it_behaves_like 'rhellions repo'
+      it_behaves_like 'repo recipe'
       it_behaves_like 'rhellions no version set'
     end
 
@@ -151,7 +124,7 @@ describe 'datadog::dd-agent' do
         end.converge described_recipe
       end
 
-      it_behaves_like 'rhellions repo'
+      it_behaves_like 'repo recipe'
       it_behaves_like 'rhellions no version set'
     end
 
@@ -166,7 +139,7 @@ describe 'datadog::dd-agent' do
         end.converge described_recipe
       end
 
-      it_behaves_like 'rhellions repo'
+      it_behaves_like 'repo recipe'
       it_behaves_like 'rhellions no version set'
     end
 
@@ -200,7 +173,7 @@ describe 'datadog::dd-agent' do
       end.converge described_recipe
     end
 
-    it_behaves_like 'debianoids repo'
+    it_behaves_like 'repo recipe'
     it_behaves_like 'debianoids no version set'
   end
 
@@ -218,7 +191,7 @@ describe 'datadog::dd-agent' do
       end.converge described_recipe
     end
 
-    it_behaves_like 'debianoids repo'
+    it_behaves_like 'repo recipe'
     it_behaves_like 'version set below 4.x'
   end
 
@@ -381,7 +354,7 @@ describe 'datadog::dd-agent' do
         end.converge described_recipe
       end
 
-      it_behaves_like 'debianoids repo'
+      it_behaves_like 'repo recipe'
       it_behaves_like 'debianoids no version set'
     end
 
@@ -400,7 +373,7 @@ describe 'datadog::dd-agent' do
         expect(chef_run).to upgrade_apt_package('datadog-agent')
       end
 
-      it_behaves_like 'debianoids repo'
+      it_behaves_like 'repo recipe'
     end
   end
 

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -23,7 +23,7 @@ end
 
 shared_examples_for 'repo recipe' do
   it 'includes the repository recipe' do
-    expect(chef_run).to include_recipe('dd-agent::repository')
+    expect(chef_run).to include_recipe('datadog::repository')
   end
 end
 

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -67,7 +67,7 @@ describe 'datadog::repository' do
     end
 
     context 'version 5' do
-     cached(:chef_run) do
+      cached(:chef_run) do
         ChefSpec::SoloRunner.new(
           platform: 'centos', version: '5.10'
         ).converge(described_recipe)

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -1,37 +1,66 @@
 describe 'datadog::repository' do
-  context 'rhellions' do
-    describe 'on versions 5.x and lower' do
-      cached(:chef_run) do
-        ChefSpec::SoloRunner.new(
-          :platform => 'centos',
-          :version => '5.8'
-        ) do |node|
-          node.set['languages'] = { 'python' => { 'version' => '2.4.3' } }
-        end.converge described_recipe
-      end
-
-      it 'sets up a yum repo' do
-        expect(chef_run).to create_yum_repository('datadog').with(
-          gpgkey: 'http://yum.datadoghq.com/DATADOG_RPM_KEY.public'
-        )
-      end
+  context 'on debianoids' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(
+        platform: 'debian', version: '8.5'
+      ).converge(described_recipe)
     end
 
-    describe 'on versions 6.x and higher' do
-      cached(:chef_run) do
-        ChefSpec::SoloRunner.new(
-          :platform => 'centos',
-          :version => '6.3'
-        ) do |node|
-          node.set['languages'] = { 'python' => { 'version' => '2.7.3' } }
-        end.converge described_recipe
-      end
+    it 'include apt cookbook' do
+      expect(chef_run).to include_recipe('apt::default')
+    end
 
-      it 'sets up a yum repo' do
-        expect(chef_run).to create_yum_repository('datadog').with(
-          gpgkey: 'https://yum.datadoghq.com/DATADOG_RPM_KEY.public'
-        )
-      end
+    it 'installs apt-transport-https' do
+      expect(chef_run).to install_package('apt-transport-https')
+    end
+
+    it 'installs new apt key' do
+      expect(chef_run).to run_execute('apt-key import key 382E94DE').with(
+        command: 'apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE'
+      )
+    end
+
+    it 'sets up an apt repo' do
+      expect(chef_run).to add_apt_repository('datadog')
+    end
+  end
+
+  context 'rhellions' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(
+        platform: 'centos', version: '6.5'
+      ).converge(described_recipe)
+    end
+
+    it 'sets the yumrepo_gpgkey_new attribute' do
+      expect(chef_run.node['datadog']['yumrepo_gpgkey_new']).to match(
+        /DATADOG_RPM_KEY_E09422B3.public/
+      )
+    end
+
+    it 'installs gnupg' do
+      expect(chef_run).to install_package('gnupg')
+    end
+
+    it 'downloads the new RPM key' do
+      expect(chef_run).to create_remote_file('DATADOG_RPM_KEY_E09422B3.public').with(path: '/var/chef/cache/DATADOG_RPM_KEY_E09422B3.public')
+    end
+
+    it 'notifies the GPG key install if a new one is downloaded' do
+      keyfile_r = chef_run.remote_file('DATADOG_RPM_KEY_E09422B3.public')
+      expect(keyfile_r).to notify('execute[rpm-import datadog key e09422b3]')
+        .to(:run).immediately
+    end
+
+    it 'doesn\'t execute[rpm-import datadog key e09422b3] by default' do
+      keyfile_exec_r = chef_run.execute('rpm-import datadog key e09422b3')
+      expect(keyfile_exec_r).to do_nothing
+    end
+
+    it 'sets up a yum repo' do
+      expect(chef_run).to create_yum_repository('datadog').with(
+        gpgkey: 'https://yum.datadoghq.com/DATADOG_RPM_KEY.public'
+      )
     end
   end
 end

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -26,41 +26,85 @@ describe 'datadog::repository' do
   end
 
   context 'rhellions' do
-    cached(:chef_run) do
-      ChefSpec::SoloRunner.new(
-        platform: 'centos', version: '6.5'
-      ).converge(described_recipe)
+    context 'version 6' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(
+          platform: 'centos', version: '6.5'
+        ).converge(described_recipe)
+      end
+
+      it 'sets the yumrepo_gpgkey_new attribute' do
+        expect(chef_run.node['datadog']['yumrepo_gpgkey_new']).to match(
+          /DATADOG_RPM_KEY_E09422B3.public/
+        )
+      end
+
+      it 'installs gnupg' do
+        expect(chef_run).to install_package('gnupg')
+      end
+
+      it 'downloads the new RPM key' do
+        expect(chef_run).to create_remote_file('DATADOG_RPM_KEY_E09422B3.public').with(path: '/var/chef/cache/DATADOG_RPM_KEY_E09422B3.public')
+      end
+
+      it 'notifies the GPG key install if a new one is downloaded' do
+        keyfile_r = chef_run.remote_file('DATADOG_RPM_KEY_E09422B3.public')
+        expect(keyfile_r).to notify('execute[rpm-import datadog key e09422b3]')
+          .to(:run).immediately
+      end
+
+      it 'doesn\'t execute[rpm-import datadog key e09422b3] by default' do
+        keyfile_exec_r = chef_run.execute('rpm-import datadog key e09422b3')
+        expect(keyfile_exec_r).to do_nothing
+      end
+
+      # prefer HTTPS on boxes that support TLS1.2
+      it 'sets up a yum repo' do
+        expect(chef_run).to create_yum_repository('datadog').with(
+          gpgkey: 'https://yum.datadoghq.com/DATADOG_RPM_KEY.public'
+        )
+      end
     end
 
-    it 'sets the yumrepo_gpgkey_new attribute' do
-      expect(chef_run.node['datadog']['yumrepo_gpgkey_new']).to match(
-        /DATADOG_RPM_KEY_E09422B3.public/
-      )
-    end
+    context 'version 5' do
+     cached(:chef_run) do
+        ChefSpec::SoloRunner.new(
+          platform: 'centos', version: '5.10'
+        ).converge(described_recipe)
+      end
 
-    it 'installs gnupg' do
-      expect(chef_run).to install_package('gnupg')
-    end
+      it 'sets the yumrepo_gpgkey_new attribute' do
+        expect(chef_run.node['datadog']['yumrepo_gpgkey_new']).to match(
+          /DATADOG_RPM_KEY_E09422B3.public/
+        )
+      end
 
-    it 'downloads the new RPM key' do
-      expect(chef_run).to create_remote_file('DATADOG_RPM_KEY_E09422B3.public').with(path: '/var/chef/cache/DATADOG_RPM_KEY_E09422B3.public')
-    end
+      it 'installs gnupg' do
+        expect(chef_run).to install_package('gnupg')
+      end
 
-    it 'notifies the GPG key install if a new one is downloaded' do
-      keyfile_r = chef_run.remote_file('DATADOG_RPM_KEY_E09422B3.public')
-      expect(keyfile_r).to notify('execute[rpm-import datadog key e09422b3]')
-        .to(:run).immediately
-    end
+      it 'downloads the new RPM key' do
+        expect(chef_run).to create_remote_file('DATADOG_RPM_KEY_E09422B3.public').with(path: '/var/chef/cache/DATADOG_RPM_KEY_E09422B3.public')
+      end
 
-    it 'doesn\'t execute[rpm-import datadog key e09422b3] by default' do
-      keyfile_exec_r = chef_run.execute('rpm-import datadog key e09422b3')
-      expect(keyfile_exec_r).to do_nothing
-    end
+      it 'notifies the GPG key install if a new one is downloaded' do
+        keyfile_r = chef_run.remote_file('DATADOG_RPM_KEY_E09422B3.public')
+        expect(keyfile_r).to notify('execute[rpm-import datadog key e09422b3]')
+          .to(:run).immediately
+      end
 
-    it 'sets up a yum repo' do
-      expect(chef_run).to create_yum_repository('datadog').with(
-        gpgkey: 'https://yum.datadoghq.com/DATADOG_RPM_KEY.public'
-      )
+      it 'doesn\'t execute[rpm-import datadog key e09422b3] by default' do
+        keyfile_exec_r = chef_run.execute('rpm-import datadog key e09422b3')
+        expect(keyfile_exec_r).to do_nothing
+      end
+
+      # RHEL5 has to use insecure HTTP due to lack of support for TLS1.2
+      # https://github.com/DataDog/chef-datadog/blob/v2.8.1/attributes/default.rb#L85-L91
+      it 'sets up a yum repo' do
+        expect(chef_run).to create_yum_repository('datadog').with(
+          gpgkey: 'http://yum.datadoghq.com/DATADOG_RPM_KEY.public'
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
- Moved chefspec examples for repo out of dd-agent_spec and into repository_spec
- Collapsed rhellions contexts since repository recipe doesn't care about python version
- Add a few missing examples