### PR TITLE
[dd-handler.rb] Attribute for custom gem server

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,11 @@ Usage
   * as a node attribute via an `environment` or `role`, or
   * as a node attribute by declaring it in another cookbook at a higher precedence level, or
   * in the node `run_state` by setting `node.run_state['datadog']['api_key']` in another cookbook preceding `datadog`'s recipes in the run_list. This approach has the benefit of not storing the credential in clear text on the Chef Server.
-3. If you require a private gem server to install the chef-handler-datadog gem, set a node attribute:
-  * e.g. ```default['datadog']['gem_server'] = 'http://custom.gem_server.org'```
-4. Create an 'application key' for `chef_handler` [here](https://app.datadoghq.com/account/settings#api), and add it as a node attribute or in the run state, as in Step #2.
+3. Create an 'application key' for `chef_handler` [here](https://app.datadoghq.com/account/settings#api), and add it as a node attribute or in the run state, as in Step #2.
 
    NB: if you're using the run state to store the api and app keys you need to set them at compile time before `datadog::dd-handler` in the run list.
 
-5. Associate the recipes with the desired `roles`, i.e. "role:chef-client" should contain "datadog::dd-handler" and a "role:base" should start the agent with "datadog::dd-agent".  Here's an example role with both recipes:
+4. Associate the recipes with the desired `roles`, i.e. "role:chef-client" should contain "datadog::dd-handler" and a "role:base" should start the agent with "datadog::dd-agent".  Here's an example role with both recipes:
   ```
   name 'example'
   description 'Example role using DataDog'
@@ -118,7 +116,7 @@ Usage
     recipe[datadog::dd-handler]
   )
   ```
-6. Wait until `chef-client` runs on the target node (or trigger chef-client manually if you're impatient)
+5. Wait until `chef-client` runs on the target node (or trigger chef-client manually if you're impatient)
 
 We are not making use of data_bags in this recipe at this time, as it is unlikely that you will have more than one API key and one application key.
 

--- a/README.md
+++ b/README.md
@@ -95,11 +95,13 @@ Usage
   * as a node attribute via an `environment` or `role`, or
   * as a node attribute by declaring it in another cookbook at a higher precedence level, or
   * in the node `run_state` by setting `node.run_state['datadog']['api_key']` in another cookbook preceding `datadog`'s recipes in the run_list. This approach has the benefit of not storing the credential in clear text on the Chef Server.
-3. Create an 'application key' for `chef_handler` [here](https://app.datadoghq.com/account/settings#api), and add it as a node attribute or in the run state, as in Step #2.
+3. If you require a private gem server to install the chef-handler-datadog gem, set a node attribute:
+  * e.g. ```default['datadog']['gem_server'] = 'http://custom.gem_server.org'```
+4. Create an 'application key' for `chef_handler` [here](https://app.datadoghq.com/account/settings#api), and add it as a node attribute or in the run state, as in Step #2.
 
    NB: if you're using the run state to store the api and app keys you need to set them at compile time before `datadog::dd-handler` in the run list.
 
-4. Associate the recipes with the desired `roles`, i.e. "role:chef-client" should contain "datadog::dd-handler" and a "role:base" should start the agent with "datadog::dd-agent".  Here's an example role with both recipes:
+5. Associate the recipes with the desired `roles`, i.e. "role:chef-client" should contain "datadog::dd-handler" and a "role:base" should start the agent with "datadog::dd-agent".  Here's an example role with both recipes:
   ```
   name 'example'
   description 'Example role using DataDog'
@@ -116,7 +118,7 @@ Usage
     recipe[datadog::dd-handler]
   )
   ```
-5. Wait until `chef-client` runs on the target node (or trigger chef-client manually if you're impatient)
+6. Wait until `chef-client` runs on the target node (or trigger chef-client manually if you're impatient)
 
 We are not making use of data_bags in this recipe at this time, as it is unlikely that you will have more than one API key and one application key.
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ dogstatsd-(python|ruby)
 -----------------------
 Installs the language-specific libraries to interact with `dogstatsd`.
 
+ddtrace-(python|ruby)
+---------------------
+Installs the language-specific libraries for application Traces (APM).
+
 other
 -----
 There are many other integration-specific recipes, that are meant to assist in deploying the correct agent configuration files and dependencies for a given integration.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -256,7 +256,6 @@ default['datadog']['legacy_integrations']['nagios']['enabled'] = false
 default['datadog']['legacy_integrations']['nagios']['description'] = 'Nagios integration'
 default['datadog']['legacy_integrations']['nagios']['config']['nagios_log'] = '/var/log/nagios3/nagios.log'
 
-<<<<<<< HEAD
 # Trace functionality settings
 default['datadog']['enable_trace_agent'] = false
 default['datadog']['extra_sample_rate'] = 1

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -256,6 +256,7 @@ default['datadog']['legacy_integrations']['nagios']['enabled'] = false
 default['datadog']['legacy_integrations']['nagios']['description'] = 'Nagios integration'
 default['datadog']['legacy_integrations']['nagios']['config']['nagios_log'] = '/var/log/nagios3/nagios.log'
 
+<<<<<<< HEAD
 # Trace functionality settings
 default['datadog']['enable_trace_agent'] = false
 default['datadog']['extra_sample_rate'] = 1

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -268,7 +268,7 @@ default['datadog']['ddtrace_python_version'] = nil
 
 # ddtrace ruby gem version
 default['datadog']['ddtrace_gem_version'] = nil
+
 # For custom gem servers on restricted networks
-# This attribute only works on Chef >= 12.3
 # Change false to the URL of your custom gem server
 default['datadog']['gem_server'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -257,4 +257,5 @@ default['datadog']['legacy_integrations']['nagios']['description'] = 'Nagios int
 default['datadog']['legacy_integrations']['nagios']['config']['nagios_log'] = '/var/log/nagios3/nagios.log'
 
 # For custom gem servers on restricted networks
+# Change false to the URL of your custom gem server
 default['datadog']['gem_server'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -270,6 +270,5 @@ default['datadog']['ddtrace_python_version'] = nil
 default['datadog']['ddtrace_gem_version'] = nil
 
 # For custom gem servers on restricted networks
-# This attribute only works on Chef >= 12.3
 # Change false to the URL of your custom gem server
 default['datadog']['gem_server'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -270,5 +270,6 @@ default['datadog']['ddtrace_python_version'] = nil
 default['datadog']['ddtrace_gem_version'] = nil
 
 # For custom gem servers on restricted networks
+# This attribute only works on Chef >= 12.3
 # Change false to the URL of your custom gem server
 default['datadog']['gem_server'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -270,5 +270,6 @@ default['datadog']['ddtrace_python_version'] = nil
 default['datadog']['ddtrace_gem_version'] = nil
 
 # For custom gem servers on restricted networks
+# This only works on Chef >= 12.3
 # Change false to the URL of your custom gem server
 default['datadog']['gem_server'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -268,7 +268,3 @@ default['datadog']['ddtrace_python_version'] = nil
 
 # ddtrace ruby gem version
 default['datadog']['ddtrace_gem_version'] = nil
-
-# For custom gem servers on restricted networks
-# Change false to the URL of your custom gem server
-default['datadog']['gem_server'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -255,3 +255,6 @@ default['datadog']['extra_packages'] = {}
 default['datadog']['legacy_integrations']['nagios']['enabled'] = false
 default['datadog']['legacy_integrations']['nagios']['description'] = 'Nagios integration'
 default['datadog']['legacy_integrations']['nagios']['config']['nagios_log'] = '/var/log/nagios3/nagios.log'
+
+# For custom gem servers on restricted networks
+default['datadog']['gem_server'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -256,7 +256,19 @@ default['datadog']['legacy_integrations']['nagios']['enabled'] = false
 default['datadog']['legacy_integrations']['nagios']['description'] = 'Nagios integration'
 default['datadog']['legacy_integrations']['nagios']['config']['nagios_log'] = '/var/log/nagios3/nagios.log'
 
+# Trace functionality settings
+default['datadog']['enable_trace_agent'] = false
+default['datadog']['extra_sample_rate'] = 1
+default['datadog']['max_traces_per_second'] = 10
+default['datadog']['receiver_port'] = 8126
+default['datadog']['connection_limit'] = 2000
+
+# ddtrace python version
+default['datadog']['ddtrace_python_version'] = nil
+
+# ddtrace ruby gem version
+default['datadog']['ddtrace_gem_version'] = nil
+
 # For custom gem servers on restricted networks
-# This attribute only works on Chef >= 12.3
 # Change false to the URL of your custom gem server
 default['datadog']['gem_server'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -268,3 +268,7 @@ default['datadog']['ddtrace_python_version'] = nil
 
 # ddtrace ruby gem version
 default['datadog']['ddtrace_gem_version'] = nil
+# For custom gem servers on restricted networks
+# This attribute only works on Chef >= 12.3
+# Change false to the URL of your custom gem server
+default['datadog']['gem_server'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -257,5 +257,6 @@ default['datadog']['legacy_integrations']['nagios']['description'] = 'Nagios int
 default['datadog']['legacy_integrations']['nagios']['config']['nagios_log'] = '/var/log/nagios3/nagios.log'
 
 # For custom gem servers on restricted networks
+# This attribute only works on Chef >= 12.3
 # Change false to the URL of your custom gem server
 default['datadog']['gem_server'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -34,6 +34,8 @@ recipe 'datadog::dd-handler', 'Installs a Chef handler for Datadog'
 recipe 'datadog::repository', 'Installs the Datadog package repository'
 recipe 'datadog::dogstatsd-python', 'Installs the Python dogstatsd package for custom metrics'
 recipe 'datadog::dogstatsd-ruby', 'Installs the Ruby dogstatsd package for custom metrics'
+recipe 'datadog::ddtrace-python', 'Installs the Python ddtrace package for APM'
+recipe 'datadog::ddtrace-ruby', 'Installs the Ruby ddtrace package for APM'
 
 # integration-specific
 recipe 'datadog::cassandra', 'Installs and configures the Cassandra integration'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'package@datadoghq.com'
 license          'Apache 2.0'
 description      'Installs/Configures datadog components'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.8.1'
+version          '2.9.0'
 source_url       'https://github.com/DataDog/chef-datadog' if respond_to? :source_url
 issues_url       'https://github.com/DataDog/chef-datadog/issues' if respond_to? :issues_url
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'package@datadoghq.com'
 license          'Apache 2.0'
 description      'Installs/Configures datadog components'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.9.0'
+version          '2.8.1'
 source_url       'https://github.com/DataDog/chef-datadog' if respond_to? :source_url
 issues_url       'https://github.com/DataDog/chef-datadog/issues' if respond_to? :issues_url
 

--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -34,6 +34,8 @@ chef_gem 'chef-handler-datadog' do # ~FC009
   version node['datadog']['chef_handler_version']
   # Chef 12 introduced `compile_time` - remove when Chef 11 is EOL.
   compile_time true if respond_to?(:compile_time)
+  clear_sources true if node['datadog']['gem_server']
+  source node['datadog']['gem_server'] if node['datadog']['gem_server']
 end
 require 'chef/handler/datadog'
 

--- a/recipes/ddtrace-python.rb
+++ b/recipes/ddtrace-python.rb
@@ -1,0 +1,8 @@
+#
+# Cookbook Name:: datadog
+# Recipe:: ddtrace-python.rb
+#
+
+easy_install_package 'ddtrace' do
+  version node['datadog']['ddtrace_python_version']
+end

--- a/recipes/ddtrace-ruby.rb
+++ b/recipes/ddtrace-ruby.rb
@@ -1,0 +1,8 @@
+#
+# Cookbook Name:: datadog
+# Recipe:: ddtrace-ruby.rb
+#
+
+gem_package 'ddtrace' do
+  version node['datadog']['ddtrace_gem_version']
+end

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -11,7 +11,7 @@ describe 'datadog::repository' do
     end
 
     it 'installs apt-transport-https' do
-      expect(chef_run).to install_package('apt-transport-https')
+      expect(chef_run).to install_package('install-apt-transport-https')
     end
 
     it 'installs new apt key' do

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -61,6 +61,19 @@ graphite_listen_port: <%= node['datadog']['graphite_port'] %>
 histogram_aggregates: <%= node['datadog']['histogram_aggregates'] %>
 histogram_percentiles: <%= node['datadog']['histogram_percentiles'] %>
 
+<% if node['datadog']['enable_trace_agent'] == true -%>
+## Trace settings
+apm_enabled: true
+
+[trace.sampler]
+extra_sample_rate: <%= node['datadog']['extra_sample_rate'] %>
+max_traces_per_second: <%= node['datadog']['max_traces_per_second'] %>
+
+[trace.receiver]
+receiver_port: <%= node['datadog']['receiver_port'] %>
+connection_limit: <%= node['datadog']['connection_limit'] %>
+<% end -%>
+
 <% if node['datadog']['dogstatsd'] -%>
 # ========================================================================== #
 # DogStatsd configuration                                                    #


### PR DESCRIPTION
chef_gem resource in recipes/dd-handler.rb doesn't account for servers in severely restricted networks.  Added an attribute, which can be optionally set by the user, for a custom gem server.  If it's an empty attribute or doesn't exist, then it's business as usual with the gem source being https://rubygems.org.

default['datadog']['gem_server'] = 'http://custom.gem_server.org'