### PR TITLE
[windows] Add option to support EXE Agent installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,18 @@ dd-agent
 --------
 Installs the Datadog agent on the target system, sets the API key, and start the service to report on the local system metrics
 
-**Note for Windows**: With Chef >= 12.6 _and_ the `windows` cookbook >= 1.39.0, Agent upgrades are known to fail.
-For Chef>=12.6 users on Windows, we recommend pinning the `windows` cookbook to a lower version (`~> 1.38.0` for instance).
-If that's not an option, a known workaround is to use the `remove-dd-agent` recipe (since the `2.5.0` version of the present cookbook) to uninstall the Agent
-prior to any Agent upgrade.
+**Notes for Windows**:
+
+* With Chef >= 12.6 _and_ the `windows` cookbook >= 1.39.0, Agent upgrades are known to fail.
+  For Chef>=12.6 users on Windows, we recommend pinning the `windows` cookbook to a lower version (`~> 1.38.0` for instance).
+
+  If that's not an option, a known workaround is to use the `remove-dd-agent` recipe (since the `2.5.0` version of the present cookbook) to uninstall the Agent
+  prior to any Agent upgrade.
+
+* Because of changes in the Windows Agent packaging and install in version 5.12.0, when upgrading the Agent from versions <= 5.10.1 to versions >= 5.12.0,
+  please set the `windows_agent_use_exe` attribute to `true`.
+
+  Once the upgrade is complete, you can leave the attribute to its default value (`false`).
 
 dd-handler
 ----------

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Installs the Datadog agent on the target system, sets the API key, and start the
 
   Once the upgrade is complete, you can leave the attribute to its default value (`false`).
 
+  For more information on these Windows packaging changes, see the related [docs on the dd-agent wiki](https://github.com/DataDog/dd-agent/wiki/Windows-Agent-Installation).
+
 dd-handler
 ----------
 Installs the [chef-handler-datadog](https://rubygems.org/gems/chef-handler-datadog) gem and invokes the handler at the end of a Chef run to report the details back to the newsfeed.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -111,6 +111,13 @@ default['datadog']['yumrepo_gpgkey_new'] = "#{yum_protocol}://yum.datadoghq.com/
 # Expected checksum to validate correct agent installer is downloaded (Windows only)
 default['datadog']['windows_agent_checksum'] = nil
 
+# Set to `true` to use the EXE installer on Windows, recommended to gracefully handle upgrades from per-user
+# to per-machine installs for all known use cases. We recommend setting this option to `true` for Agent upgrades from
+# versions <= 5.10.1 to versions >= 5.12.0.
+# The EXE installer exists since Agent release 5.12.0
+# If you're already using version >= 5.12.0 of the Agent, leave this to false.
+default['datadog']['windows_agent_use_exe'] = false
+
 # Values that differ on Windows
 # The location of the config folder (containing conf.d)
 # The name of the dd agent service

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -112,7 +112,7 @@ default['datadog']['yumrepo_gpgkey_new'] = "#{yum_protocol}://yum.datadoghq.com/
 default['datadog']['windows_agent_checksum'] = nil
 
 # Set to `true` to use the EXE installer on Windows, recommended to gracefully handle upgrades from per-user
-# to per-machine installs for all known use cases. We recommend setting this option to `true` for Agent upgrades from
+# to per-machine installs on most environments. We recommend setting this option to `true` for Agent upgrades from
 # versions <= 5.10.1 to versions >= 5.12.0.
 # The EXE installer exists since Agent release 5.12.0
 # If you're already using version >= 5.12.0 of the Agent, leave this to false.

--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -24,8 +24,9 @@ dd_agent_version =
     node['datadog']['agent_version']
   end
 
-# If no version is specified, select the latest package
-dd_agent_installer_basename = dd_agent_version ? "ddagent-cli-#{dd_agent_version}" : 'ddagent-cli'
+# If no version is specified, select the latest package.
+# The latest package basename is `ddagent-cli-latest` since Agent version 5.12.0
+dd_agent_installer_basename = dd_agent_version ? "ddagent-cli-#{dd_agent_version}" : 'ddagent-cli-latest'
 temp_file_basename = ::File.join(Chef::Config[:file_cache_path], 'ddagent-cli')
 
 if node['datadog']['windows_agent_use_exe']

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -144,7 +144,7 @@ describe 'datadog::dd-agent' do
     end
 
     context 'on Windows' do
-      cached(:chef_run)  do
+      cached(:chef_run) do
         set_env_var('ProgramData', 'C:\ProgramData')
         ChefSpec::SoloRunner.new(
           :platform => 'windows',
@@ -159,7 +159,7 @@ describe 'datadog::dd-agent' do
     end
 
     context 'on Windows with EXE installer' do
-      cached(:chef_run)  do
+      cached(:chef_run) do
         set_env_var('ProgramData', 'C:\ProgramData')
         ChefSpec::SoloRunner.new(
           :platform => 'windows',

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -155,7 +155,25 @@ describe 'datadog::dd-agent' do
         end.converge described_recipe
       end
 
-      it_behaves_like 'windows Datadog Agent'
+      it_behaves_like 'windows Datadog Agent', :msi
+    end
+
+    context 'on Windows with EXE installer' do
+      cached(:chef_run)  do
+        set_env_var('ProgramData', 'C:\ProgramData')
+        ChefSpec::SoloRunner.new(
+          :platform => 'windows',
+          :version => '2012R2',
+          :file_cache_path => 'C:/chef/cache'
+        ) do |node|
+          node.set['datadog'] = {
+            'api_key' => 'somethingnotnil',
+            'windows_agent_use_exe' => true
+          }
+        end.converge described_recipe
+      end
+
+      it_behaves_like 'windows Datadog Agent', :exe
     end
   end
 
@@ -231,7 +249,7 @@ describe 'datadog::dd-agent' do
 
       temp_file = ::File.join('C:/chef/cache', 'ddagent-cli.msi')
 
-      it_behaves_like 'windows Datadog Agent'
+      it_behaves_like 'windows Datadog Agent', :msi
       # remote_file source gets converted to an array, so we need to do
       # some tricky things to be able to regex against it
       # Relevant: http://stackoverflow.com/a/12325983
@@ -286,7 +304,7 @@ describe 'datadog::dd-agent' do
 
       temp_file = ::File.join('C:/chef/cache', 'ddagent-cli.msi')
 
-      it_behaves_like 'windows Datadog Agent'
+      it_behaves_like 'windows Datadog Agent', :msi
       # remote_file source gets converted to an array, so we need to do
       # some tricky things to be able to regex against it
       # Relevant: http://stackoverflow.com/a/12325983

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -72,20 +72,25 @@ shared_examples_for 'common windows resources' do
   end
 end
 
-shared_examples_for 'windows Datadog Agent' do
+shared_examples_for 'windows Datadog Agent' do |installer_extension|
   it_behaves_like 'common windows resources'
 
-  agent_installer = 'C:/chef/cache/ddagent-cli.msi'
+  agent_installer = "C:/chef/cache/ddagent-cli.#{installer_extension}"
 
   it 'downloads the remote file only if it\'s changed' do
     expect(chef_run).to create_remote_file(agent_installer)
   end
 
-  it 'notifies the removal of the Datadog Agent' do
-    expect(chef_run.remote_file(agent_installer)).to notify('windows_package[Datadog Agent]').to(:remove)
+  it 'doesn\'t remove existing version of the Datadog Agent by default' do
+    expect(chef_run.windows_package('Datadog Agent removal')).to do_nothing
+  end
+
+  it 'notifies the removal of the Datadog Agent when a remote file is downloaded' do
+    expect(chef_run.remote_file(agent_installer)).to notify('windows_package[Datadog Agent removal]').to(:remove)
   end
 
   it 'installs Datadog Agent' do
-    expect(chef_run).to install_windows_package('Datadog Agent')
+    installer_type = installer_extension == :msi ? :msi : :custom
+    expect(chef_run).to install_windows_package('Datadog Agent').with(installer_type: installer_type)
   end
 end

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -82,11 +82,11 @@ shared_examples_for 'windows Datadog Agent' do |installer_extension|
   end
 
   it 'doesn\'t remove existing version of the Datadog Agent by default' do
-    expect(chef_run.windows_package('Datadog Agent removal')).to do_nothing
+    expect(chef_run.package('Datadog Agent removal')).to do_nothing
   end
 
   it 'notifies the removal of the Datadog Agent when a remote file is downloaded' do
-    expect(chef_run.remote_file(agent_installer)).to notify('windows_package[Datadog Agent removal]').to(:remove)
+    expect(chef_run.remote_file(agent_installer)).to notify('package[Datadog Agent removal]').to(:remove)
   end
 
   it 'installs Datadog Agent' do


### PR DESCRIPTION
The EXE installer handles per-user to per-machine upgrades
gracefully, including edges cases that the present cookbook can't
reasonably handle on its own.

For this reason, we add the option to use the exe installer when needed
(i.e. for upgrades from Agent <= 5.10.1 to Agent >= 5.12.0).

Also added related documentation