### PR TITLE
[spec] Update spec test on apt-transport-https resource

### DIFF
--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -11,7 +11,7 @@ describe 'datadog::repository' do
     end
 
     it 'installs apt-transport-https' do
-      expect(chef_run).to install_package('apt-transport-https')
+      expect(chef_run).to install_package('install-apt-transport-https')
     end
 
     it 'installs new apt key' do


### PR DESCRIPTION
Since we changed the resource name the spec should now check
the right resource.

The spec would still pass with a lucky combination of the `apt`
cookbook and Chef version since recent versions of the `apt`
cookbook define the resource with the name `apt-transport-https`