### PR TITLE
[dd-handler] Loosen constraint on `chef_handler` dep

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -12,3 +12,13 @@ platforms:
   - name: centos-6.6
   - name: centos-5.11
   - name: debian-7.7
+
+suites:
+- name: dd-agent-handler
+  run_list:
+    - recipe[datadog::dd-handler]
+    - recipe[datadog::dd-agent]
+  attributes:
+    datadog:
+      api_key: somethingnotnil
+      application_key: alsonotnil

--- a/Rakefile
+++ b/Rakefile
@@ -103,7 +103,7 @@ task :circle do
       name = platform.name.delete('.')
 
       # Scope the suites to only execute against the Agent installer suites.
-      commands.push "kitchen verify dd-agent-#{name}"
+      commands.push "kitchen verify dd-agent-handler-#{name}"
     end
 
     commands.join(' && ')

--- a/Rakefile
+++ b/Rakefile
@@ -102,7 +102,7 @@ task :circle do
       # TODO: This could likely be pulled from kitchen_config.instances somehow
       name = platform.name.delete('.')
 
-      # Scope the suites to only execute against the Agent installer suites.
+      # Execute a suite that installs the handler and the Agent.
       commands.push "kitchen verify dd-agent-handler-#{name}"
     end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -22,7 +22,7 @@ issues_url       'https://github.com/DataDog/chef-datadog/issues' if respond_to?
 end
 
 depends          'apt' # We recommend '>= 2.1.0'. See CHANGELOG.md for details
-depends          'chef_handler', '~> 1.1' # We recommend '~> 1.3' with Chef < 12. See CHANGELOG.md for details
+depends          'chef_handler', '>= 1.1' # We recommend '~> 1.3' with Chef < 12. See CHANGELOG.md for details
 depends          'windows', '< 3.0' # We recommend '< 1.39.0' if running Chef >= 12.6. See README.md for details
 depends          'yum', '>= 3.0' # Use '~> 3.0' with Chef < 12
 

--- a/test/integration/dd-agent-handler/serverspec/dd-agent_spec.rb
+++ b/test/integration/dd-agent-handler/serverspec/dd-agent_spec.rb
@@ -1,0 +1,1 @@
+../../dd-agent/serverspec/dd-agent_spec.rb

--- a/test/integration/dd-agent-handler/serverspec/dd-handler_spec.rb
+++ b/test/integration/dd-agent-handler/serverspec/dd-handler_spec.rb
@@ -1,0 +1,1 @@
+../../dd-handler/serverspec/dd-handler_spec.rb


### PR DESCRIPTION
`2.x` versions of `chef_handler` are known to work with the present cookbook (cc @degemer)

Also, adds the `dd-handler` recipe to the kitchen CI run list