### PR TITLE
[windows] Add constraint on `windows` cookbook version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -23,7 +23,7 @@ end
 
 depends          'apt' # We recommend '>= 2.1.0'. See CHANGELOG.md for details
 depends          'chef_handler', '~> 1.1' # We recommend '~> 1.3' with Chef < 12. See CHANGELOG.md for details
-depends          'windows' # We recommend '< 1.39.0' if running Chef >= 12.6. See README.md for details
+depends          'windows', '< 3.0' # We recommend '< 1.39.0' if running Chef >= 12.6. See README.md for details
 depends          'yum', '>= 3.0' # Use '~> 3.0' with Chef < 12
 
 suggests         'sudo' # ~FC052


### PR DESCRIPTION
The newly-released 3.0 version introduces changes that break the
present cookbook. We can work on handling them in the future, for
now let's update the version constraint.

See the [windows cookbook changelog](https://github.com/chef-cookbooks/windows/blob/master/CHANGELOG.md#300-2017-03-15).