### PR TITLE
Add service discovery attributes and datadog.conf template to enable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -263,6 +263,14 @@ default['datadog']['legacy_integrations']['nagios']['enabled'] = false
 default['datadog']['legacy_integrations']['nagios']['description'] = 'Nagios integration'
 default['datadog']['legacy_integrations']['nagios']['config']['nagios_log'] = '/var/log/nagios3/nagios.log'
 
+# Service discovery settings
+# Enable with service_discovery_backend ('docker' is only valid option currently)
+default['datadog']['sd_backend_host'] = '127.0.0.1'
+default['datadog']['sd_backend_port'] = 4001
+default['datadog']['sd_config_backend'] = 'etcd'
+default['datadog']['sd_template_dir'] = '/datadog/check_configs'
+default['datadog']['service_discovery_backend'] = nil
+
 # Trace functionality settings
 default['datadog']['enable_trace_agent'] = false
 default['datadog']['extra_sample_rate'] = 1

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -61,6 +61,32 @@ graphite_listen_port: <%= node['datadog']['graphite_port'] %>
 histogram_aggregates: <%= node['datadog']['histogram_aggregates'] %>
 histogram_percentiles: <%= node['datadog']['histogram_percentiles'] %>
 
+<% if node['datadog']['service_discovery_backend'] -%>
+# ========================================================================== #
+# Service Discovery                                                          #
+# See https://docs.datadoghq.com/guides/servicediscovery/ for details        #
+# ========================================================================== #
+
+# Service discovery allows the agent to look for running services
+# and load a configuration object for the one it recognizes.
+# This feature is disabled by default.
+# Uncomment this line to enable it (works for docker containers only for now).
+service_discovery_backend: <%= node['datadog']['service_discovery_backend'] %>
+
+# Define which key/value store must be used to look for configuration templates.
+# Default is etcd. Consul is also supported.
+sd_config_backend: <%= node['datadog']['sd_config_backend'] %>
+
+# Settings for connecting to the service discovery backend.
+sd_backend_host: <%= node['datadog']['sd_backend_host'] %>
+sd_backend_port: <%= node['datadog']['sd_backend_port'] %>
+
+# By default, the agent will look for the configuration templates under the
+# `/datadog/check_configs` key in the back-end. If you wish otherwise, uncomment this option
+# and modify its value.
+sd_template_dir: <%= node['datadog']['sd_template_dir'] %>
+<% end -%>
+
 <% if node['datadog']['enable_trace_agent'] == true -%>
 ## Trace settings
 apm_enabled: true


### PR DESCRIPTION
Semi-related to #418, this adds the service discovery attributes as well as keeps them above the trace agent configuration which breaks the `[Main]` datadog.conf configuration section. 