### PR TITLE
Mongo & Elasticsearch: extend config templates with more options

### DIFF
--- a/templates/default/elastic.yaml.erb
+++ b/templates/default/elastic.yaml.erb
@@ -8,7 +8,7 @@ instances:
     pshard_stats: <%= i["pshard_stats"] %>
     <% end %>
     <% unless i["cluster_stats"].nil? %>
-      cluster_stats: <%= i["cluster_stats"] %>
+    cluster_stats: <%= i["cluster_stats"] %>
     <% end %>
     <% unless i["is_external"].nil? %>
     is_external: <%= i["is_external"] %>

--- a/templates/default/elastic.yaml.erb
+++ b/templates/default/elastic.yaml.erb
@@ -7,6 +7,9 @@ instances:
     <% unless i["pshard_stats"].nil? %>
     pshard_stats: <%= i["pshard_stats"] %>
     <% end %>
+    <% unless i["cluster_stats"].nil? %>
+      cluster_stats: <%= i["cluster_stats"] %>
+    <% end %>
     <% unless i["is_external"].nil? %>
     is_external: <%= i["is_external"] %>
     <% end %>

--- a/templates/default/mongo.yaml.erb
+++ b/templates/default/mongo.yaml.erb
@@ -7,6 +7,13 @@ instances:
     - <%= t %>
       <% end -%>
     <% end -%>
+    <% if i.key?('ssl') -%>
+      ssl: <%= i['ssl'] %>
+      ssl_ca_certs: <%= i['ssl_ca_certs'] %>
+      ssl_cert_reqs: <%= i['ssl_cert_reqs'] %>
+      ssl_certfile: <%= i['ssl_certfile'] %>
+      ssl_keyfile: <%= i['ssl_keyfile'] %>
+    <% end %>
   <% end -%>
 
 init_config:

--- a/templates/default/mongo.yaml.erb
+++ b/templates/default/mongo.yaml.erb
@@ -8,11 +8,11 @@ instances:
       <% end -%>
     <% end -%>
     <% if i.key?('ssl') -%>
-      ssl: <%= i['ssl'] %>
-      ssl_ca_certs: <%= i['ssl_ca_certs'] %>
-      ssl_cert_reqs: <%= i['ssl_cert_reqs'] %>
-      ssl_certfile: <%= i['ssl_certfile'] %>
-      ssl_keyfile: <%= i['ssl_keyfile'] %>
+    ssl: <%= i['ssl'] %>
+    ssl_ca_certs: <%= i['ssl_ca_certs'] %>
+    ssl_cert_reqs: <%= i['ssl_cert_reqs'] %>
+    ssl_certfile: <%= i['ssl_certfile'] %>
+    ssl_keyfile: <%= i['ssl_keyfile'] %>
     <% end %>
   <% end -%>
 


### PR DESCRIPTION
We need these options in production and are currently overriding the config. We'd like to have these available to configure.