### PR TITLE
make package names compatible

### DIFF
--- a/recipes/integrations.rb
+++ b/recipes/integrations.rb
@@ -30,7 +30,9 @@ include_recipe 'datadog::repository' if node['datadog']['installrepo']
 #   'url' => 'http://localhost:22222'
 # }
 node['datadog']['extra_packages'].each do |name, options|
-  package options['name'] do
+  pkg_name = options['name'].sub '_', '-'
+
+  package pkg_name do
     version options['version']
     action :install
   end

--- a/recipes/integrations.rb
+++ b/recipes/integrations.rb
@@ -30,9 +30,7 @@ include_recipe 'datadog::repository' if node['datadog']['installrepo']
 #   'url' => 'http://localhost:22222'
 # }
 node['datadog']['extra_packages'].each do |name, options|
-  pkg_name = options['name'].sub '_', '-'
-
-  package pkg_name do
+  package options['name'].sub('_', '-') do
     version options['version']
     action :install
   end


### PR DESCRIPTION
many integrations have an underscore in their name. They should install with a dash, underscores are forbidden in most operating systems and omnibus builds it with the dash.