### PR TITLE
[trace-agent] Leave the default enabled/disabled behavior to the agent

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -272,7 +272,11 @@ default['datadog']['sd_template_dir'] = '/datadog/check_configs'
 default['datadog']['service_discovery_backend'] = nil
 
 # Trace functionality settings
-default['datadog']['enable_trace_agent'] = false
+# Set `enable_trace_agent` to:
+# * `true` to explicitly enable the trace agent and customize its settings
+# * `false` to explicitly disable it
+# Leave it to `nil` to let the agent's default behavior decide whether to run the trace-agent
+default['datadog']['enable_trace_agent'] = nil
 default['datadog']['extra_sample_rate'] = 1
 default['datadog']['max_traces_per_second'] = 10
 default['datadog']['receiver_port'] = 8126

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -273,14 +273,14 @@ default['datadog']['service_discovery_backend'] = nil
 
 # Trace functionality settings
 # Set `enable_trace_agent` to:
-# * `true` to explicitly enable the trace agent and customize its settings
+# * `true` to explicitly enable the trace agent
 # * `false` to explicitly disable it
 # Leave it to `nil` to let the agent's default behavior decide whether to run the trace-agent
 default['datadog']['enable_trace_agent'] = nil
-default['datadog']['extra_sample_rate'] = 1
-default['datadog']['max_traces_per_second'] = 10
-default['datadog']['receiver_port'] = 8126
-default['datadog']['connection_limit'] = 2000
+default['datadog']['extra_sample_rate'] = nil
+default['datadog']['max_traces_per_second'] = nil
+default['datadog']['receiver_port'] = nil
+default['datadog']['connection_limit'] = nil
 
 # ddtrace python version
 default['datadog']['ddtrace_python_version'] = nil

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -189,6 +189,6 @@ max_traces_per_second: <%= node['datadog']['max_traces_per_second'] %>
 [trace.receiver]
 receiver_port: <%= node['datadog']['receiver_port'] %>
 connection_limit: <%= node['datadog']['connection_limit'] %>
-<% else -%>
+<% elsif node['datadog']['enable_trace_agent'] == false -%>
 apm_enabled: false
 <% end -%>

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -178,17 +178,23 @@ end
   <% end -%>
 <% end -%>
 
-<% if node['datadog']['enable_trace_agent'] == true -%>
 ## Trace settings
-apm_enabled: true
+<% if node['datadog']['enable_trace_agent'].is_a?(TrueClass) || node['datadog']['enable_trace_agent'].is_a?(FalseClass) -%>
+apm_enabled: <%= node['datadog']['enable_trace_agent'] %>
+<% end -%>
 
 [trace.sampler]
+<% unless node['datadog']['extra_sample_rate'].nil? -%>
 extra_sample_rate: <%= node['datadog']['extra_sample_rate'] %>
+<% end -%>
+<% unless node['datadog']['max_traces_per_second'].nil? -%>
 max_traces_per_second: <%= node['datadog']['max_traces_per_second'] %>
+<% end -%>
 
 [trace.receiver]
+<% unless node['datadog']['receiver_port'].nil? -%>
 receiver_port: <%= node['datadog']['receiver_port'] %>
+<% end -%>
+<% unless node['datadog']['connection_limit'].nil? -%>
 connection_limit: <%= node['datadog']['connection_limit'] %>
-<% elsif node['datadog']['enable_trace_agent'] == false -%>
-apm_enabled: false
 <% end -%>


### PR DESCRIPTION
Since agent 5.13.0, the trace agent is enabled by default.

This cookbook should allow explicitly enabling or disabling the trace
agent, however, when the attribute that controls this is not set, the
cookbook should leave it to the agent to decide whether to run the
trace agent.

This change modifies the default value of an attribute. Technically
this is a breaking change that requires a major version bump of the
cookbook, however I think this change actually improves backward
compatibility and can go with a minor version of the cookbook.

Follow-up to https://github.com/DataDog/chef-datadog/pull/428, cc @ed-flanagan 