### PR TITLE
Allow to specify trace env

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -277,6 +277,7 @@ default['datadog']['service_discovery_backend'] = nil
 # * `false` to explicitly disable it
 # Leave it to `nil` to let the agent's default behavior decide whether to run the trace-agent
 default['datadog']['enable_trace_agent'] = nil
+default['datadog']['trace_env'] = nil
 default['datadog']['extra_sample_rate'] = nil
 default['datadog']['max_traces_per_second'] = nil
 default['datadog']['receiver_port'] = nil

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -183,6 +183,11 @@ end
 apm_enabled: <%= node['datadog']['enable_trace_agent'] %>
 <% end -%>
 
+[trace.config]
+<% unless node['datadog']['trace_env'].nil? -%>
+env: <%= node['datadog']['trace_env'] %>
+<% end -%>
+
 [trace.sampler]
 <% unless node['datadog']['extra_sample_rate'].nil? -%>
 extra_sample_rate: <%= node['datadog']['extra_sample_rate'] %>


### PR DESCRIPTION
Our APM just recently started reporting to "env:none". Adding `tags` to a `datadog.conf` does not help for whatever reason. I noticed that configuring trace like this is missing from chef, so here we go.

https://app.datadoghq.com/apm/docs/tutorials/environments