### PR TITLE
[windows] Add compatibility with windows cookbook 3.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -23,7 +23,7 @@ end
 
 depends          'apt' # We recommend '>= 2.1.0'. See CHANGELOG.md for details
 depends          'chef_handler', '>= 1.1' # We recommend '~> 1.3' with Chef < 12. See CHANGELOG.md for details
-depends          'windows', '< 3.0' # We recommend '< 1.39.0' if running Chef >= 12.6. See README.md for details
+depends          'windows' # We recommend '< 1.39.0' if running Chef >= 12.6. See README.md for details
 depends          'yum', '>= 3.0' # Use '~> 3.0' with Chef < 12
 
 suggests         'sudo' # ~FC052

--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -85,5 +85,9 @@ windows_package 'Datadog Agent' do # ~FC009
   installer_type installer_type
   options install_options
   action :install
-  success_codes [0, 3010]
+  if respond_to?(:returns)
+    returns [0, 3010]
+  else
+    success_codes [0, 3010]
+  end
 end


### PR DESCRIPTION
Requires supporting both `returns` and `success_codes` on the
`windows_package` resource.

Addresses https://github.com/DataDog/chef-datadog/issues/416