### PR TITLE
update elastic.yml to allow for ssl options

### DIFF
--- a/templates/default/elastic.yaml.erb
+++ b/templates/default/elastic.yaml.erb
@@ -22,6 +22,15 @@ instances:
     <% unless i["timeout"].nil? %>
     timeout: <%= i["timeout"] %>
     <% end %>
+    <% unless i["ssl_verify"].nil? %>
+    ssl_verify: <%= i["ssl_verify"] %>
+    <% end %>
+    <% unless i["ssl_cert"].nil? %>
+    ssl_cert: <%= i["ssl_cert"] %>
+    <% end %>
+    <% unless i["ssl_key"].nil? %>
+    ssl_key: <%= i["ssl_key"] %>
+    <% end %>
     <% if i.key?('tags') -%>
     tags:
       <% i['tags'].each do |t| -%>


### PR DESCRIPTION
elastic.py allows for ssl options, however, we are unable to use these options in the cookbook, this change corrects this,.