### PR TITLE
[yum][repository] Avoid including the default yum recipe

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -43,8 +43,6 @@ when 'debian'
   end
 
 when 'rhel', 'fedora'
-  include_recipe 'yum'
-
   # Import new RPM key
   if node['datadog']['yumrepo_gpgkey_new']
     # gnupg is required to check the downloaded key's fingerprint


### PR DESCRIPTION
The default recipe of the `yum` cookbook overwrites the main `/etc/yum.conf`
config file, which can be undesirable if the user wants to keep the default one or
wants to customize it outside of the `yum` cookbook.

Let's just assume that the existing config works for our cookbook.
