### PR TITLE
Avoid a resource cloning warning

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -21,11 +21,6 @@ case node['platform_family']
 when 'debian'
   include_recipe 'apt'
 
-  package 'install-apt-transport-https' do
-    package_name 'apt-transport-https'
-    action :install
-  end
-
   # Trust new APT key
   execute 'apt-key import key 382E94DE' do
     command 'apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE'

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -10,10 +10,6 @@ describe 'datadog::repository' do
       expect(chef_run).to include_recipe('apt::default')
     end
 
-    it 'installs apt-transport-https' do
-      expect(chef_run).to install_package('install-apt-transport-https')
-    end
-
     it 'installs new apt key' do
       expect(chef_run).to run_execute('apt-key import key 382E94DE').with(
         command: 'apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE'


### PR DESCRIPTION
This is already done in the apt default recipe which is called above and it has been there for some time now. Resource cloning is currently a warning and in Chef 13.2 it has changed behavior which causes unpredictable resource execution now if you clone resources instead of editing them with the new find_resource and edit_resource helpers.