### PR TITLE
Explicitly set gpgcheck to true for yum_repository

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -78,6 +78,7 @@ when 'rhel', 'fedora'
     proxy_username node['datadog']['yumrepo_proxy_username']
     proxy_password node['datadog']['yumrepo_proxy_password']
     gpgkey node['datadog']['yumrepo_gpgkey']
+    gpgcheck true
     action :create
   end
 end


### PR DESCRIPTION
The yum_repository resource did not have gpgcheck `true` as the default until Chef 12.15