### PR TITLE
added additional_metrics and collections parameters to mongo template

### DIFF
--- a/templates/default/mongo.yaml.erb
+++ b/templates/default/mongo.yaml.erb
@@ -14,6 +14,18 @@ instances:
     ssl_certfile: <%= i['ssl_certfile'] %>
     ssl_keyfile: <%= i['ssl_keyfile'] %>
     <% end %>
+    <% if i.key?('additional_metrics') -%>
+    additional_metrics:
+      <% i['additional_metrics'].each do |t| %>
+    - <%= t %>
+      <%end -%>
+    <% end %>
+    <% if i.key?('collections') -%>
+    collections:
+      <% i['collections'].each do |t| %>
+    - <%= t %>
+      <%end -%>
+    <% end %>
   <% end -%>
 
 init_config:


### PR DESCRIPTION
I have added the additional parameters 'additional_metrics' and 'collections' described in the [docs](https://docs.datadoghq.com/integrations/mongodb/) and the [default config file](https://github.com/Datadog/integrations-core/blob/master/mongo/conf.yaml.example)