### PR TITLE
Fix process agent attribute in datadog.conf template

### DIFF
--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -178,8 +178,8 @@ end
   <% end -%>
 <% end -%>
 
-<% if node['datadog']['enabled_process_agent'].is_a?(TrueClass) || node['datadog']['enabled_process_agent'].is_a?(FalseClass) -%>
-process_agent_enabled: <%= node['datadog']['enabled_process_agent'] %>
+<% if node['datadog']['enable_process_agent'].is_a?(TrueClass) || node['datadog']['enable_process_agent'].is_a?(FalseClass) -%>
+process_agent_enabled: <%= node['datadog']['enable_process_agent'] %>
 <% end -%>
 
 ## Trace settings


### PR DESCRIPTION
Changes the reference to the `enable_process_agent` attribute in the datadog.conf template to ensure the template can resolve as expected