### PR TITLE
Added check to consul.yaml.erb for 'tags:'

### DIFF
--- a/templates/default/consul.yaml.erb
+++ b/templates/default/consul.yaml.erb
@@ -10,7 +10,7 @@ instances:
     <% unless i['service_whitelist'].nil? %>
     service_whitelist: <%= i['service_whitelist'] %>
     <% end %>
-    <% if i.key?('tags') -%>
+    <% if i.key?('tags') && !i['tags'].empty? -%>
     tags:
       <% i['tags'].each do |t| -%>
       - <%= t %>


### PR DESCRIPTION
I noticed when you don't pass a tag to
`default['datadog']['consul']['instances']`, it prints an empty tags section.
```
instances:
  - url: http://127.0.0.1:8500
    new_leader_checks: false
    catalog_checks: true
    service_whitelist: []
    tags:
```

This messes up with [this](https://github.com/DataDog/integrations-core/blob/master/consul/check.py#L240) line in the check.

The consul check is then failing with 
```
2017-10-11 10:52:32 UTC | ERROR | dd.collector | checks.consul(__init__.py:814) | Check 'consul' instance #0 failed
Traceback (most recent call last):
  File "/opt/datadog-agent/agent/checks/__init__.py", line 797, in run
    self.check(copy.deepcopy(instance))
  File "/opt/datadog-agent/agent/checks.d/consul.py", line 240, in check
    for tag in instance.get('tags', []):
TypeError: 'NoneType' object is not iterable
```

This adds an extra check to the template so it also checks if the 'tags' section actually has elements.
