### PR TITLE
Allow for disable_ssl_validation in the apache conf

### DIFF
--- a/templates/default/apache.yaml.erb
+++ b/templates/default/apache.yaml.erb
@@ -3,6 +3,7 @@ instances:
   - apache_status_url: <%= i['status_url'] %>
     <% if i['apache_user'] -%>apache_user: <%= i['apache_user'] %><% end -%>
     <% if i['apache_password'] -%>apache_password: <%= i['apache_password'] %><% end -%>
+    <% if i['disable_ssl_validation'] -%>disable_ssl_validation: <%= i['disable_ssl_validation'] %><% end -%>
 
   <% if i.key?('tags') -%>
     tags:


### PR DESCRIPTION

This allows you to pass in the disabling of ssl validation on local calls to apache's status module.