### PR TITLE
[windows] Fix default log file directory

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -160,6 +160,7 @@ default['datadog']['windows_agent_use_exe'] = false
 # Values that differ on Windows
 # The location of the config folder (containing conf.d)
 # The name of the dd agent service
+# The log file directory (see logging section below)
 if node['platform_family'] == 'windows'
   default['datadog']['config_dir'] = "#{ENV['ProgramData']}/Datadog"
   default['datadog']['agent_name'] = 'DatadogAgent'
@@ -262,7 +263,11 @@ default['datadog']['syslog']['active'] = false
 default['datadog']['syslog']['udp'] = false
 default['datadog']['syslog']['host'] = nil
 default['datadog']['syslog']['port'] = nil
-default['datadog']['log_file_directory'] = '/var/log/datadog'
+if node['platform_family'] == 'windows'
+  default['datadog']['log_file_directory'] = nil  # let the agent use a default log file dir
+else
+  default['datadog']['log_file_directory'] = '/var/log/datadog'
+end
 
 # Web proxy configuration
 default['datadog']['web_proxy']['host'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -263,11 +263,12 @@ default['datadog']['syslog']['active'] = false
 default['datadog']['syslog']['udp'] = false
 default['datadog']['syslog']['host'] = nil
 default['datadog']['syslog']['port'] = nil
-if node['platform_family'] == 'windows'
-  default['datadog']['log_file_directory'] = nil  # let the agent use a default log file dir
-else
-  default['datadog']['log_file_directory'] = '/var/log/datadog'
-end
+default['datadog']['log_file_directory'] =
+  if node['platform_family'] == 'windows'
+    nil # let the agent use a default log file dir
+  else
+    '/var/log/datadog'
+  end
 
 # Web proxy configuration
 default['datadog']['web_proxy']['host'] = nil

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -125,12 +125,14 @@ use_dogstatsd: no
 
 log_level: <%= node['datadog']['log_level'] %>
 
+<% if node['datadog']['log_file_directory'] -%>
 collector_log_file: <%= node['datadog']['log_file_directory'] %>/collector.log
 forwarder_log_file: <%= node['datadog']['log_file_directory'] %>/forwarder.log
 dogstatsd_log_file: <%= node['datadog']['log_file_directory'] %>/dogstatsd.log
 jmxfetch_log_file: <%= node['datadog']['log_file_directory'] %>/jmxfetch.log
 <% unless node['platform_family'] == 'windows' -%>
 go-metro_log_file: <%= node['datadog']['log_file_directory'] %>/go-metro.log
+<% end -%>
 <% end -%>
 
 # if syslog is enabled but a host and port are not set, a local domain socket


### PR DESCRIPTION
By default, let the agent determine its log file directory.

Attribute overrides still work.

Fixes #470