### PR TITLE
Fix datadog apt key check

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -29,7 +29,7 @@ when 'debian'
   # Trust new APT key
   execute 'apt-key import key 382E94DE' do
     command 'apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE'
-    not_if 'apt-key list | grep 382E94DE'
+    not_if 'apt-key list | grep "382E 94DE"'
   end
 
   # Add APT repository

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,7 @@ RSpec.configure do |config|
     stub_command('apt-cache policy datadog-agent-base | grep "Installed: (none)"').and_return(false)
 
     # recipes/repository.rb
-    stub_command('apt-key list | grep 382E94DE').and_return(false)
+    stub_command('apt-key list | grep "382E 94DE"').and_return(false)
     stub_command('gpg --dry-run --quiet --with-fingerprint /var/chef/cache/DATADOG_RPM_KEY_E09422B3.public'\
     " | grep 'A4C0 B90D 7443 CF6E 4E8A  A341 F106 8E14 E094 22B3'").and_return(true)
     stub_command('rpm -q gpg-pubkey-e09422b3').and_return(false)

--- a/test/integration/dd-agent/serverspec/dd-agent_spec.rb
+++ b/test/integration/dd-agent/serverspec/dd-agent_spec.rb
@@ -17,7 +17,7 @@ end
 # The new APT key is imported
 describe command('apt-key list'), :if => ['debian', 'ubuntu'].include?(os[:family]) do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should contain '382E94DE' }
+  its(:stdout) { should contain '382E 94DE' }
 end
 
 # The new RPM key is imported


### PR DESCRIPTION
_(Updated PR description)_

`not_if` condition has been failing because of an extra space in key signature, forcing chef to re-fetch key from keyserver on every run.

```
$ apt-key list
/etc/apt/trusted.gpg
--------------------
pub   rsa4096 2016-06-29 [SC] [expires: 2022-06-28]
      A292 3DFF 56ED A6E7 6E55  E492 D3A8 0E30 382E 94DE
uid           [ unknown] Datadog, Inc <package@datadoghq.com>
sub   rsa4096 2016-06-29 [S] [expires: 2022-06-28]
sub   rsa4096 2016-06-29 [S] [expires: 2022-06-28]
sub   rsa4096 2016-07-11 [S] [expires: 2022-07-10]
```

cc: @olivielpeau 