### PR TITLE
Enable log collection with chef

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Chef recipes to deploy Datadog's components and configuration automatically.
 This cookbook includes experimental support of the beta version of the Datadog Agent 6.0, please refer to
 the [inline docs](https://github.com/DataDog/chef-datadog/blob/v2.13.0/attributes/default.rb#L31-L68)
 for more details on the supported platforms and how to use it.
+Log collection is now available with agent 6.0, please refer to the [inline docs](https://github.com/DataDog/chef-datadog/blob/v2.13.0/attributes/default.rb#L371-L376) to enable it.
 
 For general information on the Datadog Agent 6, please refer to the [datadog-agent](https://github.com/DataDog/datadog-agent/) repo.
 


### PR DESCRIPTION
Documentation update because log collection is available for agent 6. 