### PR TITLE
[handler] Allow configuring `tags_submission_retries` option

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -110,6 +110,11 @@ default['datadog']['tags_blacklist_regex'] = nil
 # Set to `true` if you want the handler to send the Chef policy name and group as host tags
 default['datadog']['send_policy_tags'] = false
 
+# Set to an integer if you want the handler to retry submitting tags if the host isn't yet present
+# on Datadog. The handler will retry evey 2 seconds until this number of retries is reached or the tags are
+# submitted successfully.
+default['datadog']['tags_submission_retries'] = nil
+
 # Autorestart agent
 default['datadog']['autorestart'] = false
 

--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -61,7 +61,7 @@ chef_handler 'Chef::Handler::Datadog' do # rubocop:disable Metrics/BlockLength
     extra_endpoints
   end
 
-  def handler_config # rubocop:disable Metrics/AbcSize
+  def handler_config # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     config = {
       :api_key => Chef::Datadog.api_key(node),
       :application_key => Chef::Datadog.application_key(node),

--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -70,7 +70,8 @@ chef_handler 'Chef::Handler::Datadog' do # rubocop:disable Metrics/BlockLength
       :url => node['datadog']['url'],
       :extra_endpoints => extra_endpoints,
       :tags_blacklist_regex => node['datadog']['tags_blacklist_regex'],
-      :send_policy_tags => node['datadog']['send_policy_tags']
+      :send_policy_tags => node['datadog']['send_policy_tags'],
+      :tags_submission_retries => node['datadog']['tags_submission_retries']
     }
 
     unless node['datadog']['use_ec2_instance_id']

--- a/spec/dd-handler_spec.rb
+++ b/spec/dd-handler_spec.rb
@@ -20,7 +20,8 @@ shared_examples 'a chef-handler-datadog runner' do |extra_endpoints, tags_blackl
       url: 'https://app.datadoghq.com',
       extra_endpoints: extra_endpoints || [],
       tags_blacklist_regex: tags_blacklist_regex,
-      send_policy_tags: false
+      send_policy_tags: false,
+      tags_submission_retries: nil
     }
 
     expect(chef_run).to enable_chef_handler('Chef::Handler::Datadog').with(


### PR DESCRIPTION
This is a short-term solution. Long term, we should allow passing an arbitrary hash of options to the handler.