### PR TITLE
Update soon deprecated attribute

### DIFF
--- a/templates/default/datadog.yaml.erb
+++ b/templates/default/datadog.yaml.erb
@@ -92,7 +92,11 @@ agent_config = @extra_config.merge({
   log_file: ::File.join(node['datadog']['log_file_directory'], "agent.log"),
 
   # log agent options
-  log_enabled: node['datadog']['enable_logs_agent'],
+  if node['datadog']['agent6']
+    logs_enabled: node['datadog']['enable_logs_agent'],
+  else
+    log_enabled: node['datadog']['enable_logs_agent'],
+  end
 
   # process agent options
   process_config: {


### PR DESCRIPTION
Since version `6.0.0-rc.1` there is a deprecation notice that indicates `logs_enabled` will replace `log_enabled`.