### PR TITLE
Update component of APT repo (and URL of YUM repo) for Agent6

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,10 +29,14 @@ default['datadog']['api_key'] = nil
 default['datadog']['application_key'] = nil
 
 ########################################################################
-###            Beta-Agent6-only attributes, experimental             ###
+###            Agent6-only attributes, experimental                  ###
 ### These attributes are not part of the stable API of the cookbook  ###
 ###   Subject to breaking changes between bugfix/minor versions      ###
 ###              Only works on Linux (DEB/RPM) for now               ###
+
+# If you're installing a pre-release version of Agent 6 (beta or RC), you need to:
+# * on debian: set node['datadog']['agent6_aptrepo_dist'] to 'beta' instead of 'stable'
+# * on RHEL: set node['datadog']['agent6_yumrepo'] to 'https://yum.datadoghq.com/beta/x86_64/'
 
 # Set to true to install an agent6 instead of agent5.
 # To upgrade from agent5 to agent6, you need to:
@@ -49,11 +53,11 @@ default['datadog']['agent6'] = false
 default['datadog']['agent6_version'] = nil
 default['datadog']['agent6_package_action'] = 'install' # set to `upgrade` to always upgrade to latest
 
-# beta repos where datadog-agent v6 packages are available
+# repos where datadog-agent v6 packages are available
 default['datadog']['agent6_aptrepo'] = 'http://apt.datadoghq.com'
-default['datadog']['agent6_aptrepo_dist'] = 'beta'
+default['datadog']['agent6_aptrepo_dist'] = 'stable'
 # RPMs are only available for RHEL >= 6 (-> use https protocol) and x86_64 arch
-default['datadog']['agent6_yumrepo'] = 'https://yum.datadoghq.com/beta/x86_64/'
+default['datadog']['agent6_yumrepo'] = 'https://yum.datadoghq.com/stable/6/x86_64/'
 
 # Values that differ on Windows
 # The location of the config folder (containing conf.d)

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -32,32 +32,22 @@ when 'debian'
     not_if 'apt-key list | grep 382E94DE'
   end
 
+  uri = node['datadog']['agent6'] ? node['datadog']['agent6_aptrepo'] : node['datadog']['aptrepo']
+  distribution = node['datadog']['agent6'] ? node['datadog']['agent6_aptrepo_dist'] : node['datadog']['aptrepo_dist']
+  components = node['datadog']['agent6'] ? ['main', '6'] : ['main']
   # Add APT repository
   apt_repository 'datadog' do
     keyserver 'hkp://keyserver.ubuntu.com:80'
     key 'C7A7DA52'
-    uri node['datadog']['aptrepo']
-    distribution node['datadog']['aptrepo_dist']
-    components ['main']
+    uri uri
+    distribution distribution
+    components components
     action :add
   end
 
+  # Previous versions of the cookbook could create this repo file, make sure we remove it now
   apt_repository 'datadog-beta' do
-    keyserver 'hkp://keyserver.ubuntu.com:80'
-    key 'C7A7DA52'
-    uri node['datadog']['agent6_aptrepo']
-    distribution node['datadog']['agent6_aptrepo_dist']
-    components ['main']
-    if node['datadog']['agent6'] &&
-       (node['datadog']['agent6_aptrepo'] != node['datadog']['aptrepo'] ||
-       node['datadog']['agent6_aptrepo_dist'] != node['datadog']['aptrepo_dist'])
-      # add the beta repo iff:
-      # * agent6 is selected (avoid automatic upgrades to agent6 if it's not), and
-      # * the node is configured to use a different repo than the agent5 (avoid duplicate repos)
-      action :add
-    else
-      action :remove
-    end
+    action :remove
   end
 when 'rhel', 'fedora', 'amazon'
   # Import new RPM key

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -23,6 +23,10 @@ describe 'datadog::repository' do
     it 'sets up an apt repo' do
       expect(chef_run).to add_apt_repository('datadog')
     end
+
+    it 'removes the datadog-beta repo' do
+      expect(chef_run).to remove_apt_repository('datadog-beta')
+    end
   end
 
   context 'rhellions' do


### PR DESCRIPTION
Default to the new stable component/URL when Agent6 is desired.