### PR TITLE
[cassandra] Add updated metrics for Cassandra 2 and 3.x

### DIFF
--- a/recipes/cassandra.rb
+++ b/recipes/cassandra.rb
@@ -10,9 +10,12 @@ include_recipe 'datadog::dd-agent'
 #   Select the appropriate configuration file template. Available options are:
 #   * `1` (Default, recommended for Cassandra < 2.2).
 #     Use Cassandra legacy metrics, i.e. https://github.com/DataDog/dd-agent/blob/5.6.x/conf.d/cassandra.yaml.example#L23-L74
-#   * `2` (recommended for Cassandra >= 2.2).
+#   * `2` (recommended for existing Agent installs for Cassandra >= 2.2 and < 3.0).
 #     Use Cassandra expanded metrics (CASSANDRA-4009) introduced in 1.2 (https://wiki.apache.org/cassandra/Metrics),
 #     i.e. https://github.com/DataDog/integrations-core/blob/master/cassandra/conf.yaml.example#L23-L102
+#   * `3` (recommended for Cassandra >= 3.0, and for new Agent installs for Cassandra >= 2.2).
+#     Collect most Cassandra metrics to fully populate the default Cassandra dashboard on Datadog,
+#     i.e. https://github.com/DataDog/integrations-core/blob/5.22.0/cassandra/conf.yaml.example#L35-L460
 
 # Example:
 

--- a/spec/integrations/cassandra_spec.rb
+++ b/spec/integrations/cassandra_spec.rb
@@ -816,7 +816,7 @@ describe 'datadog::cassandra' do
                 password: 'somepass',
                 process_name_regex: '.*cassandra.*'
               }
-            ],
+            ]
           }
         }
       end.converge(described_recipe)

--- a/spec/integrations/cassandra_spec.rb
+++ b/spec/integrations/cassandra_spec.rb
@@ -362,4 +362,478 @@ describe 'datadog::cassandra' do
       })
     end
   end
+
+  context 'version 3' do
+    expected_yaml = <<-EOF
+    logs: ~
+    instances:
+      - host: localhost
+        port: 7199
+        cassandra_aliasing: true
+        user: someuser
+        password: somepass
+        process_name_regex: .*cassandra.*
+    init_config:
+      conf:
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: ClientRequest
+            name:
+              - Latency
+            attribute:
+              - 75thPercentile
+              - 95thPercentile
+              - OneMinuteRate
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: DroppedMessage
+            name:
+              - Dropped
+            attribute:
+              - OneMinuteRate
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: ThreadPools
+            scope:
+              - MutationStage
+              - CounterMutationStage
+              - ReadStage
+              - ViewMutationStage
+            name:
+              - PendingTasks
+              - CurrentlyBlockedTasks
+            path:
+              - request
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: ThreadPools
+            scope:
+              - MemtableFlushWriter
+              - HintsDispatcher
+              - MemtablePostFlush
+              - MigrationStage
+              - MiscStage
+              - SecondaryIndexManagement
+            name:
+              - PendingTasks
+              - CurrentlyBlockedTasks
+            path:
+              - internal
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: Storage
+            name:
+              - Load
+              - Exceptions
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: Table
+            bean_regex:
+              - .*keyspace=.*
+            name:
+              - ReadLatency
+              - WriteLatency
+            attribute:
+              - 75thPercentile
+              - 95thPercentile
+              - 99thPercentile
+              - OneMinuteRate
+          exclude:
+            keyspace:
+              - system
+              - system_auth
+              - system_distributed
+              - system_schema
+              - system_traces
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: Table
+            bean_regex:
+              - .*keyspace=.*
+            name:
+              - RangeLatency
+              - CasPrepareLatency
+              - CasProposeLatency
+              - CasCommitLatency
+              - ViewLockAcquireTime
+              - ViewReadTime
+            attribute:
+              - 75thPercentile
+              - 95thPercentile
+              - OneMinuteRate
+          exclude:
+            keyspace:
+              - system
+              - system_auth
+              - system_distributed
+              - system_schema
+              - system_traces
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: Table
+            bean_regex:
+              - .*keyspace=.*
+            name:
+              - SSTablesPerReadHistogram
+              - TombstoneScannedHistogram
+              - WaitingOnFreeMemtableSpace
+            attribute:
+              - 75thPercentile
+              - 95thPercentile
+          exclude:
+            keyspace:
+              - system
+              - system_auth
+              - system_distributed
+              - system_schema
+              - system_traces
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: Table
+            bean_regex:
+              - .*keyspace=.*
+            name:
+              - ColUpdateTimeDeltaHistogram
+            attribute:
+              - Min
+              - 75thPercentile
+              - 95thPercentile
+          exclude:
+            keyspace:
+              - system
+              - system_auth
+              - system_distributed
+              - system_schema
+              - system_traces
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: Table
+            bean_regex:
+              - .*keyspace=.*
+            name:
+              - BloomFilterFalseRatio
+              - CompressionRatio
+              - KeyCacheHitRate
+              - LiveSSTableCount
+              - MaxPartitionSize
+              - MeanPartitionSize
+              - MeanRowSize
+              - MaxRowSize
+              - PendingCompactions
+              - SnapshotsSize
+            attribute:
+              - Value
+          exclude:
+            keyspace:
+              - system
+              - system_auth
+              - system_distributed
+              - system_schema
+              - system_traces
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: Table
+            bean_regex:
+              - .*keyspace=.*
+            name:
+              - CompactionBytesWritten
+              - BytesFlushed
+              - PendingFlushes
+              - LiveDiskSpaceUsed
+              - TotalDiskSpaceUsed
+              - RowCacheHitOutOfRange
+              - RowCacheHit
+              - RowCacheMiss
+            attribute:
+              - Count
+          exclude:
+            keyspace:
+              - system
+              - system_auth
+              - system_distributed
+              - system_schema
+              - system_traces
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: Cache
+            scope: KeyCache
+            name:
+              - HitRate
+            attribute:
+              - Count
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: CommitLog
+            name:
+              - PendingTasks
+              - TotalCommitLogSize
+            attribute:
+              - Value
+        - include:
+            domain: org.apache.cassandra.db
+            type: Tables
+            attribute:
+              DroppableTombstoneRatio:
+                alias: cassandra.db.droppable_tombstone_ratio
+        # Young Gen Collectors (Minor Collections)
+        - include:
+            domain: java.lang
+            type: GarbageCollector
+            name: Copy
+            attribute:
+              CollectionCount:
+                metric_type: counter
+                alias: jmx.gc.minor_collection_count
+              CollectionTime:
+                metric_type: counter
+                alias: jmx.gc.minor_collection_time
+        - include:
+            domain: java.lang
+            type: GarbageCollector
+            name: PS Scavenge
+            attribute:
+              CollectionCount:
+                metric_type: counter
+                alias: jmx.gc.minor_collection_count
+              CollectionTime:
+                metric_type: counter
+                alias: jmx.gc.minor_collection_time
+        - include:
+            domain: java.lang
+            type: GarbageCollector
+            name: ParNew
+            attribute:
+              CollectionCount:
+                metric_type: counter
+                alias: jmx.gc.minor_collection_count
+              CollectionTime:
+                metric_type: counter
+                alias: jmx.gc.minor_collection_time
+        - include:
+            domain: java.lang
+            type: GarbageCollector
+            name: G1 Young Generation
+            attribute:
+              CollectionCount:
+                metric_type: counter
+                alias: jmx.gc.minor_collection_count
+              CollectionTime:
+                metric_type: counter
+                alias: jmx.gc.minor_collection_time
+        # Old Gen Collectors (Major collections)
+        - include:
+            domain: java.lang
+            type: GarbageCollector
+            name: MarkSweepCompact
+            attribute:
+              CollectionCount:
+                metric_type: counter
+                alias: jmx.gc.major_collection_count
+              CollectionTime:
+                metric_type: counter
+                alias: jmx.gc.major_collection_time
+        - include:
+            domain: java.lang
+            type: GarbageCollector
+            name: PS MarkSweep
+            attribute:
+              CollectionCount:
+                metric_type: counter
+                alias: jmx.gc.major_collection_count
+              CollectionTime:
+                metric_type: counter
+                alias: jmx.gc.major_collection_time
+        - include:
+            domain: java.lang
+            type: GarbageCollector
+            name: ConcurrentMarkSweep
+            attribute:
+              CollectionCount:
+                metric_type: counter
+                alias: jmx.gc.major_collection_count
+              CollectionTime:
+                metric_type: counter
+                alias: jmx.gc.major_collection_time
+        - include:
+            domain: java.lang
+            type: GarbageCollector
+            name: G1 Mixed Generation
+            attribute:
+              CollectionCount:
+                metric_type: counter
+                alias: jmx.gc.major_collection_count
+              CollectionTime:
+                metric_type: counter
+                alias: jmx.gc.major_collection_time
+
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: ColumnFamily
+            bean_regex:
+              - .*keyspace=.*
+            name:
+              - ReadLatency
+              - WriteLatency
+            attribute:
+              - 75thPercentile
+              - 95thPercentile
+              - 99thPercentile
+              - OneMinuteRate
+          exclude:
+            keyspace:
+              - system
+              - system_auth
+              - system_distributed
+              - system_schema
+              - system_traces
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: ColumnFamily
+            bean_regex:
+              - .*keyspace=.*
+            name:
+              - RangeLatency
+              - CasPrepareLatency
+              - CasProposeLatency
+              - CasCommitLatency
+              - ViewLockAcquireTime
+              - ViewReadTime
+            attribute:
+              - 75thPercentile
+              - 95thPercentile
+              - OneMinuteRate
+          exclude:
+            keyspace:
+              - system
+              - system_auth
+              - system_distributed
+              - system_schema
+              - system_traces
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: ColumnFamily
+            bean_regex:
+              - .*keyspace=.*
+            name:
+              - SSTablesPerReadHistogram
+              - TombstoneScannedHistogram
+              - WaitingOnFreeMemtableSpace
+            attribute:
+              - 75thPercentile
+              - 95thPercentile
+          exclude:
+            keyspace:
+              - system
+              - system_auth
+              - system_distributed
+              - system_schema
+              - system_traces
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: ColumnFamily
+            bean_regex:
+              - .*keyspace=.*
+            name:
+              - ColUpdateTimeDeltaHistogram
+            attribute:
+              - Min
+              - 75thPercentile
+              - 95thPercentile
+          exclude:
+            keyspace:
+              - system
+              - system_auth
+              - system_distributed
+              - system_schema
+              - system_traces
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: ColumnFamily
+            bean_regex:
+              - .*keyspace=.*
+            name:
+              - BloomFilterFalseRatio
+              - CompressionRatio
+              - KeyCacheHitRate
+              - LiveSSTableCount
+              - MaxPartitionSize
+              - MeanPartitionSize
+              - MeanRowSize
+              - MaxRowSize
+              - PendingCompactions
+              - SnapshotsSize
+            attribute:
+              - Value
+          exclude:
+            keyspace:
+              - system
+              - system_auth
+              - system_distributed
+              - system_schema
+              - system_traces
+        - include:
+            domain: org.apache.cassandra.metrics
+            type: ColumnFamily
+            bean_regex:
+              - .*keyspace=.*
+            name:
+              - PendingFlushes
+              - LiveDiskSpaceUsed
+              - TotalDiskSpaceUsed
+              - RowCacheHitOutOfRange
+              - RowCacheHit
+              - RowCacheMiss
+            attribute:
+              - Count
+          exclude:
+            keyspace:
+              - system
+              - system_auth
+              - system_distributed
+              - system_schema
+              - system_traces
+        - include:
+            domain: org.apache.cassandra.db
+            type: ColumnFamilies
+            attribute:
+              DroppableTombstoneRatio:
+                alias: cassandra.db.droppable_tombstone_ratio
+    EOF
+
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+        node.automatic['languages'] = { python: { version: '2.7.2' } }
+
+        node.set['datadog'] = {
+          api_key: 'someapikey',
+          cassandra: {
+            version: 3,
+            instances: [
+              {
+                host: 'localhost',
+                port: 7199,
+                user: 'someuser',
+                password: 'somepass',
+                process_name_regex: '.*cassandra.*'
+              }
+            ],
+          }
+        }
+      end.converge(described_recipe)
+    end
+
+    subject { chef_run }
+
+    it_behaves_like 'datadog-agent'
+
+    it { is_expected.to include_recipe('datadog::dd-agent') }
+
+    it { is_expected.to add_datadog_monitor('cassandra') }
+
+    it 'renders expected YAML config file' do
+      expect(chef_run).to(render_file('/etc/dd-agent/conf.d/cassandra.yaml').with_content { |content|
+        expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
+      })
+    end
+  end
 end

--- a/templates/default/cassandra.yaml.erb
+++ b/templates/default/cassandra.yaml.erb
@@ -9,7 +9,439 @@ instances:
     cassandra_aliasing: true
 <% end -%>
 
-<% if @version == 2 %>
+<% if @version == 3 %>
+init_config:
+  # List of metrics to be collected by the integration
+  # Read http://docs.datadoghq.com/integrations/java/ to learn how to customize it
+  # Metrics for Cassandra 3.x
+  conf:
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: ClientRequest
+        name:
+          - Latency
+        attribute:
+          - 75thPercentile
+          - 95thPercentile
+          - OneMinuteRate
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: DroppedMessage
+        name:
+          - Dropped
+        attribute:
+          - OneMinuteRate
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: ThreadPools
+        scope:
+          - MutationStage
+          - CounterMutationStage
+          - ReadStage
+          - ViewMutationStage
+        name:
+          - PendingTasks
+          - CurrentlyBlockedTasks
+        path:
+          - request
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: ThreadPools
+        scope:
+          - MemtableFlushWriter
+          - HintsDispatcher
+          - MemtablePostFlush
+          - MigrationStage
+          - MiscStage
+          - SecondaryIndexManagement
+        name:
+          - PendingTasks
+          - CurrentlyBlockedTasks
+        path:
+          - internal
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: Storage
+        name:
+          - Load
+          - Exceptions
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: Table
+        bean_regex:
+          - .*keyspace=.*
+        name:
+          - ReadLatency
+          - WriteLatency
+        attribute:
+          - 75thPercentile
+          - 95thPercentile
+          - 99thPercentile
+          - OneMinuteRate
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: Table
+        bean_regex:
+          - .*keyspace=.*
+        name:
+          - RangeLatency
+          - CasPrepareLatency
+          - CasProposeLatency
+          - CasCommitLatency
+          - ViewLockAcquireTime
+          - ViewReadTime
+        attribute:
+          - 75thPercentile
+          - 95thPercentile
+          - OneMinuteRate
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: Table
+        bean_regex:
+          - .*keyspace=.*
+        name:
+          - SSTablesPerReadHistogram
+          - TombstoneScannedHistogram
+          - WaitingOnFreeMemtableSpace
+        attribute:
+          - 75thPercentile
+          - 95thPercentile
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: Table
+        bean_regex:
+          - .*keyspace=.*
+        name:
+          - ColUpdateTimeDeltaHistogram
+        attribute:
+          - Min
+          - 75thPercentile
+          - 95thPercentile
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: Table
+        bean_regex:
+          - .*keyspace=.*
+        name:
+          - BloomFilterFalseRatio
+          - CompressionRatio
+          - KeyCacheHitRate
+          - LiveSSTableCount
+          - MaxPartitionSize
+          - MeanPartitionSize
+          - MeanRowSize
+          - MaxRowSize
+          - PendingCompactions
+          - SnapshotsSize
+        attribute:
+          - Value
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: Table
+        bean_regex:
+          - .*keyspace=.*
+        name:
+          - CompactionBytesWritten
+          - BytesFlushed
+          - PendingFlushes
+          - LiveDiskSpaceUsed
+          - TotalDiskSpaceUsed
+          - RowCacheHitOutOfRange
+          - RowCacheHit
+          - RowCacheMiss
+        attribute:
+          - Count
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: Cache
+        scope: KeyCache
+        name:
+          - HitRate
+        attribute:
+          - Count
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: CommitLog
+        name:
+          - PendingTasks
+          - TotalCommitLogSize
+        attribute:
+          - Value
+    - include:
+        domain: org.apache.cassandra.db
+        type: Tables
+        attribute:
+          DroppableTombstoneRatio:
+            alias: cassandra.db.droppable_tombstone_ratio
+    # Young Gen Collectors (Minor Collections)
+    - include:
+        domain: java.lang
+        type: GarbageCollector
+        name: Copy
+        attribute:
+          CollectionCount:
+            metric_type: counter
+            alias: jmx.gc.minor_collection_count
+          CollectionTime:
+            metric_type: counter
+            alias: jmx.gc.minor_collection_time
+    - include:
+        domain: java.lang
+        type: GarbageCollector
+        name: PS Scavenge
+        attribute:
+          CollectionCount:
+            metric_type: counter
+            alias: jmx.gc.minor_collection_count
+          CollectionTime:
+            metric_type: counter
+            alias: jmx.gc.minor_collection_time
+    - include:
+        domain: java.lang
+        type: GarbageCollector
+        name: ParNew
+        attribute:
+          CollectionCount:
+            metric_type: counter
+            alias: jmx.gc.minor_collection_count
+          CollectionTime:
+            metric_type: counter
+            alias: jmx.gc.minor_collection_time
+    - include:
+        domain: java.lang
+        type: GarbageCollector
+        name: G1 Young Generation
+        attribute:
+          CollectionCount:
+            metric_type: counter
+            alias: jmx.gc.minor_collection_count
+          CollectionTime:
+            metric_type: counter
+            alias: jmx.gc.minor_collection_time
+    # Old Gen Collectors (Major collections)
+    - include:
+        domain: java.lang
+        type: GarbageCollector
+        name: MarkSweepCompact
+        attribute:
+          CollectionCount:
+            metric_type: counter
+            alias: jmx.gc.major_collection_count
+          CollectionTime:
+            metric_type: counter
+            alias: jmx.gc.major_collection_time
+    - include:
+        domain: java.lang
+        type: GarbageCollector
+        name: PS MarkSweep
+        attribute:
+          CollectionCount:
+            metric_type: counter
+            alias: jmx.gc.major_collection_count
+          CollectionTime:
+            metric_type: counter
+            alias: jmx.gc.major_collection_time
+    - include:
+        domain: java.lang
+        type: GarbageCollector
+        name: ConcurrentMarkSweep
+        attribute:
+          CollectionCount:
+            metric_type: counter
+            alias: jmx.gc.major_collection_count
+          CollectionTime:
+            metric_type: counter
+            alias: jmx.gc.major_collection_time
+    - include:
+        domain: java.lang
+        type: GarbageCollector
+        name: G1 Mixed Generation
+        attribute:
+          CollectionCount:
+            metric_type: counter
+            alias: jmx.gc.major_collection_count
+          CollectionTime:
+            metric_type: counter
+            alias: jmx.gc.major_collection_time
+
+     # Deprecated metrics for pre Cassandra 3.0 versions compatibility.
+     # If you are using cassandra 2, the metrics below will be used,
+     # otherwise they will be ignored.
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: ColumnFamily
+        bean_regex:
+          - .*keyspace=.*
+        name:
+          - ReadLatency
+          - WriteLatency
+        attribute:
+          - 75thPercentile
+          - 95thPercentile
+          - 99thPercentile
+          - OneMinuteRate
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: ColumnFamily
+        bean_regex:
+          - .*keyspace=.*
+        name:
+          - RangeLatency
+          - CasPrepareLatency
+          - CasProposeLatency
+          - CasCommitLatency
+          - ViewLockAcquireTime
+          - ViewReadTime
+        attribute:
+          - 75thPercentile
+          - 95thPercentile
+          - OneMinuteRate
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: ColumnFamily
+        bean_regex:
+          - .*keyspace=.*
+        name:
+          - SSTablesPerReadHistogram
+          - TombstoneScannedHistogram
+          - WaitingOnFreeMemtableSpace
+        attribute:
+          - 75thPercentile
+          - 95thPercentile
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: ColumnFamily
+        bean_regex:
+          - .*keyspace=.*
+        name:
+          - ColUpdateTimeDeltaHistogram
+        attribute:
+          - Min
+          - 75thPercentile
+          - 95thPercentile
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: ColumnFamily
+        bean_regex:
+          - .*keyspace=.*
+        name:
+          - BloomFilterFalseRatio
+          - CompressionRatio
+          - KeyCacheHitRate
+          - LiveSSTableCount
+          - MaxPartitionSize
+          - MeanPartitionSize
+          - MeanRowSize
+          - MaxRowSize
+          - PendingCompactions
+          - SnapshotsSize
+        attribute:
+          - Value
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.metrics
+        type: ColumnFamily
+        bean_regex:
+          - .*keyspace=.*
+        name:
+          - PendingFlushes
+          - LiveDiskSpaceUsed
+          - TotalDiskSpaceUsed
+          - RowCacheHitOutOfRange
+          - RowCacheHit
+          - RowCacheMiss
+        attribute:
+          - Count
+      exclude:
+        keyspace:
+          - system
+          - system_auth
+          - system_distributed
+          - system_schema
+          - system_traces
+    - include:
+        domain: org.apache.cassandra.db
+        type: ColumnFamilies
+        attribute:
+          DroppableTombstoneRatio:
+            alias: cassandra.db.droppable_tombstone_ratio
+<% elsif @version == 2 %>
 init_config:
   # List of metrics to be collected by the integration
   # Read http://docs.datadoghq.com/integrations/java/ to learn how to customize it


### PR DESCRIPTION
Updates the metrics collected by the cassandra integration, when the version attribute is set to `3`. We don't update the metrics when the version attribute is set to `2` to avoid changing the metrics
collected on existing Agent installs.

Fixes #510