### PR TITLE
Force windows_service to restart in order to cope with restart error:

### DIFF
--- a/providers/monitor.rb
+++ b/providers/monitor.rb
@@ -43,6 +43,7 @@ action :add do # rubocop:disable Metrics/BlockLength
   service 'datadog-agent' do
     service_name node['datadog']['agent_name']
     provider service_provider unless service_provider.nil?
+    restart_command "powershell restart-service #{node['datadog']['agent_name']} -Force" if node['platform_family'] == 'windows'
     # HACK: the restart can fail when we hit systemd's restart limits (by default, 5 starts every 10 seconds)
     # To workaround this, retry once after 5 seconds, and a second time after 10 seconds
     retries 2
@@ -70,5 +71,6 @@ action :remove do
   service 'datadog-agent' do
     service_name node['datadog']['agent_name']
     provider service_provider unless service_provider.nil?
+    restart_command "powershell restart-service #{node['datadog']['agent_name']} -Force" if node['platform_family'] == 'windows'
   end
 end

--- a/providers/monitor.rb
+++ b/providers/monitor.rb
@@ -44,6 +44,7 @@ action :add do # rubocop:disable Metrics/BlockLength
     service_name node['datadog']['agent_name']
     provider service_provider unless service_provider.nil?
     restart_command "powershell restart-service #{node['datadog']['agent_name']} -Force" if node['platform_family'] == 'windows'
+    stop_command "powershell stop-service #{node['datadog']['agent_name']} -Force" if node['platform_family'] == 'windows'
     # HACK: the restart can fail when we hit systemd's restart limits (by default, 5 starts every 10 seconds)
     # To workaround this, retry once after 5 seconds, and a second time after 10 seconds
     retries 2
@@ -72,5 +73,6 @@ action :remove do
     service_name node['datadog']['agent_name']
     provider service_provider unless service_provider.nil?
     restart_command "powershell restart-service #{node['datadog']['agent_name']} -Force" if node['platform_family'] == 'windows'
+    stop_command "powershell stop-service #{node['datadog']['agent_name']} -Force" if node['platform_family'] == 'windows'
   end
 end

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -117,6 +117,7 @@ service 'datadog-agent' do
   if is_windows
     supports :restart => true, :start => true, :stop => true
     restart_command "powershell restart-service #{node['datadog']['agent_name']} -Force"
+    stop_command "powershell stop-service #{node['datadog']['agent_name']} -Force"
   else
     supports :restart => true, :status => true, :start => true, :stop => true
   end

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -116,6 +116,7 @@ service 'datadog-agent' do
   provider service_provider unless service_provider.nil?
   if is_windows
     supports :restart => true, :start => true, :stop => true
+    restart_command "powershell restart-service #{node['datadog']['agent_name']} -Force"
   else
     supports :restart => true, :status => true, :start => true, :stop => true
   end


### PR DESCRIPTION
"Cannot stop service 'Datadog Agent (DatadogAgent)' because it has dependent services.'"

Signed-off-by: Stefan Wessels Beljaars <swesselsbeljaars@schubergphilis.com>