### PR TITLE
[apt] Remove reference to old expired key, keep only newer key

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -26,19 +26,13 @@ when 'debian'
     action :install
   end
 
-  # Trust new APT key
-  execute 'apt-key import key 382E94DE' do
-    command 'apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE'
-    not_if 'apt-key list | grep 382E94DE'
-  end
-
   uri = node['datadog']['agent6'] ? node['datadog']['agent6_aptrepo'] : node['datadog']['aptrepo']
   distribution = node['datadog']['agent6'] ? node['datadog']['agent6_aptrepo_dist'] : node['datadog']['aptrepo_dist']
   components = node['datadog']['agent6'] ? ['main', '6'] : ['main']
   # Add APT repository
   apt_repository 'datadog' do
     keyserver 'hkp://keyserver.ubuntu.com:80'
-    key 'C7A7DA52'
+    key 'A2923DFF56EDA6E76E55E492D3A80E30382E94DE'
     uri uri
     distribution distribution
     components components

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -14,14 +14,10 @@ describe 'datadog::repository' do
       expect(chef_run).to install_package('install-apt-transport-https')
     end
 
-    it 'installs new apt key' do
-      expect(chef_run).to run_execute('apt-key import key 382E94DE').with(
-        command: 'apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE'
-      )
-    end
-
     it 'sets up an apt repo' do
-      expect(chef_run).to add_apt_repository('datadog')
+      expect(chef_run).to add_apt_repository('datadog').with(
+        key: ['A2923DFF56EDA6E76E55E492D3A80E30382E94DE']
+      )
     end
 
     it 'removes the datadog-beta repo' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,9 +27,6 @@ RSpec.configure do |config|
     stub_command('apt-cache policy datadog-agent-base | grep "Installed: (none)"').and_return(false)
 
     # recipes/repository.rb
-    stub_command('apt-key list | grep 382E94DE').and_return(false)
-    stub_command('gpg --dry-run --quiet --with-fingerprint /var/chef/cache/DATADOG_RPM_KEY_E09422B3.public'\
-    " | grep 'A4C0 B90D 7443 CF6E 4E8A  A341 F106 8E14 E094 22B3'").and_return(true)
     stub_command('rpm -q gpg-pubkey-e09422b3').and_return(false)
   end
 


### PR DESCRIPTION
Now that the APT repo key has been rotated, we can remove the reference to the older key (that old key isn't used anywhere anymore, and is expired) and replace it with the newer key. Also allows us to remove the "manual" import of the newer key and let `apt_repository` take care of importing it.