### PR TITLE
[Amazon Linux] Fix detection of Amazon Linux < 2.0

### DIFF
--- a/providers/monitor.rb
+++ b/providers/monitor.rb
@@ -35,7 +35,7 @@ action :add do # rubocop:disable Metrics/BlockLength
 
   service_provider = nil
   if node['datadog']['agent6'] &&
-     (((node['platform'] == 'amazon' || node['platform_family'] == 'amazon') && node['platform_version'].to_i < 2) ||
+     (((node['platform'] == 'amazon' || node['platform_family'] == 'amazon') && node['platform_version'].to_i != 2) ||
      (node['platform'] != 'amazon' && node['platform_family'] == 'rhel' && node['platform_version'].to_i < 7))
     # use Upstart provider explicitly for Agent 6 on Amazon Linux < 2.0 and RHEL < 7
     service_provider = Chef::Provider::Service::Upstart
@@ -62,7 +62,7 @@ action :remove do
 
   service_provider = nil
   if node['datadog']['agent6'] &&
-     (((node['platform'] == 'amazon' || node['platform_family'] == 'amazon') && node['platform_version'].to_i < 2) ||
+     (((node['platform'] == 'amazon' || node['platform_family'] == 'amazon') && node['platform_version'].to_i != 2) ||
      (node['platform'] != 'amazon' && node['platform_family'] == 'rhel' && node['platform_version'].to_i < 7))
     # use Upstart provider explicitly for Agent 6 on Amazon Linux < 2.0 and RHEL < 7
     service_provider = Chef::Provider::Service::Upstart

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -104,7 +104,7 @@ end
 # Common configuration
 service_provider = nil
 if node['datadog']['agent6'] &&
-   (((node['platform'] == 'amazon' || node['platform_family'] == 'amazon') && node['platform_version'].to_i < 2) ||
+   (((node['platform'] == 'amazon' || node['platform_family'] == 'amazon') && node['platform_version'].to_i != 2) ||
    (node['platform'] != 'amazon' && node['platform_family'] == 'rhel' && node['platform_version'].to_i < 7))
   # use Upstart provider explicitly for Agent 6 on Amazon Linux < 2.0 and RHEL < 7
   service_provider = Chef::Provider::Service::Upstart

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -746,7 +746,7 @@ describe 'datadog::dd-agent' do
         cached(:chef_run) do
           ChefSpec::SoloRunner.new(
             :platform => 'amazon',
-            :version => '2017.09'
+            :version => '2017.03'
           ) do |node|
             node.set['datadog'] = { 'api_key' => 'somethingnotnil', 'agent6' => true }
           end.converge described_recipe
@@ -780,7 +780,7 @@ describe 'datadog::dd-agent' do
         cached(:chef_run) do
           ChefSpec::SoloRunner.new(
             :platform => 'redhat',
-            :version => '7.4'
+            :version => '7.3'
           ) do |node|
             node.set['datadog'] = { 'api_key' => 'somethingnotnil', 'agent6' => true }
           end.converge described_recipe

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -739,4 +739,60 @@ describe 'datadog::dd-agent' do
       end
     end
   end
+
+  context 'agent6 set to true' do
+    describe 'the datadog-agent service' do
+      context 'on Amazon Linux < 2.0' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(
+            :platform => 'amazon',
+            :version => '2017.09'
+          ) do |node|
+            node.set['datadog'] = { 'api_key' => 'somethingnotnil', 'agent6' => true }
+          end.converge described_recipe
+        end
+
+        it 'is enabled with Upstart provider' do
+          expect(chef_run).to enable_service('datadog-agent').with(
+            provider: Chef::Provider::Service::Upstart
+          )
+        end
+      end
+
+      context 'on RHEL 6' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(
+            :platform => 'redhat',
+            :version => '6.8'
+          ) do |node|
+            node.set['datadog'] = { 'api_key' => 'somethingnotnil', 'agent6' => true }
+          end.converge described_recipe
+        end
+
+        it 'is enabled with Upstart provider' do
+          expect(chef_run).to enable_service('datadog-agent').with(
+            provider: Chef::Provider::Service::Upstart
+          )
+        end
+      end
+
+      context 'on RHEL 7' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(
+            :platform => 'redhat',
+            :version => '7.4'
+          ) do |node|
+            node.set['datadog'] = { 'api_key' => 'somethingnotnil', 'agent6' => true }
+          end.converge described_recipe
+        end
+
+        it 'is enabled _without_ Upstart provider' do
+          expect(chef_run).to enable_service('datadog-agent')
+          expect(chef_run).to_not enable_service('datadog-agent').with(
+            provider: Chef::Provider::Service::Upstart
+          )
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
In order to use the correct Upstart provider on these platforms.

And add some chefspec tests.