### PR TITLE
Fix logs agent conditional

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -368,7 +368,7 @@ default['datadog']['process_agent']['rtprocess_interval'] = nil
 default['datadog']['process_agent']['container_interval'] = nil
 default['datadog']['process_agent']['rtcontainer_interval'] = nil
 
-# Logs functionality settings
+# Logs functionality settings (Agent 6 only)
 # Set `enable_log_agent` to:
 # * `true` to explicitly enable the log agent
 # * `false` to explicitly disable it

--- a/templates/default/datadog.yaml.erb
+++ b/templates/default/datadog.yaml.erb
@@ -92,11 +92,7 @@ agent_config = @extra_config.merge({
   log_file: ::File.join(node['datadog']['log_file_directory'], "agent.log"),
 
   # log agent options
-  if node['datadog']['agent6']
-    logs_enabled: node['datadog']['enable_logs_agent'],
-  else
-    log_enabled: node['datadog']['enable_logs_agent'],
-  end
+  logs_enabled: node['datadog']['enable_logs_agent'],
 
   # process agent options
   process_config: {


### PR DESCRIPTION
Option should now be set on `logs_enabled`. No conditional necessary. Fixes not-yet-released change made in https://github.com/DataDog/chef-datadog/pull/513