### PR TITLE
[windows] Update version logic for Agent 6

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,9 +12,11 @@ platforms:
       ubuntu-12.04
       centos-6.6
       centos-5.11
+      centos-7.1
       debian-7.7
     )
     chef_versions = %w(
+      13
       12.2.1
       11.18.6
     )

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -162,7 +162,7 @@ default['datadog']['windows_agent_checksum'] = nil
 # Set to `true` to use the EXE installer on Windows, recommended to gracefully handle upgrades from per-user
 # to per-machine installs on most environments. We recommend setting this option to `true` for Agent upgrades from
 # versions <= 5.10.1 to versions >= 5.12.0.
-# The EXE installer exists since Agent release 5.12.0
+# The EXE installer exists since Agent release 5.12.0. It is not provided for >= 6.0.0 versions.
 # If you're already using version >= 5.12.0 of the Agent, leave this to false.
 default['datadog']['windows_agent_use_exe'] = false
 

--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -17,16 +17,31 @@
 # limitations under the License.
 #
 
-dd_agent_version =
+dd_agent5_version =
   if node['datadog']['agent_version'].respond_to?(:each_pair)
     node['datadog']['agent_version']['windows']
   else
     node['datadog']['agent_version']
   end
 
+dd_agent6_version =
+  if node['datadog']['agent6_version'].respond_to?(:each_pair)
+    node['datadog']['agent6_version']['windows']
+  else
+    node['datadog']['agent6_version']
+  end
+
+if node['datadog']['agent6']
+  dd_agent_version = dd_agent6_version
+  dd_agent_latest = 'datadog-agent-6-latest.amd64'
+else
+  dd_agent_version = dd_agent5_version
+  # The latest package basename is `ddagent-cli-latest` for '~> 5.12' versions
+  dd_agent_latest = 'ddagent-cli-latest'
+end
+
 # If no version is specified, select the latest package.
-# The latest package basename is `ddagent-cli-latest` since Agent version 5.12.0
-dd_agent_installer_basename = dd_agent_version ? "ddagent-cli-#{dd_agent_version}" : 'ddagent-cli-latest'
+dd_agent_installer_basename = dd_agent_version ? "ddagent-cli-#{dd_agent_version}" : dd_agent_latest
 temp_file_basename = ::File.join(Chef::Config[:file_cache_path], 'ddagent-cli')
 
 if node['datadog']['windows_agent_use_exe']


### PR DESCRIPTION
* update "latest" MSI URL for Agent 6
* make version handling consistent with Linux, with `agent6_version` attribute