### PR TITLE
Update Agent 6 configuration

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -227,10 +227,10 @@ default['datadog']['chef_handler_enable'] = true
 # Log level. Should be a valid python log level https://docs.python.org/2/library/logging.html#logging-levels
 default['datadog']['log_level'] = 'INFO'
 
-# Set to true to allow non local traffic to Dogstatsd (and, in Agent 5, to the Forwarder)
+# Set to true to allow non local traffic to Dogstatsd and the trace agent (and, in Agent 5, to the Forwarder)
 default['datadog']['non_local_traffic'] = false
 
-# The loopback address the Forwarder and Dogstatsd will bind.
+# The loopback address Dogstatsd will bind (in Agent 5, the Forwarder also uses this address)
 default['datadog']['bind_host'] = 'localhost'
 
 # How often you want the agent to collect data, in seconds. Any value between

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -818,6 +818,7 @@ describe 'datadog::dd-agent' do
             dd_url: https://app.datadoghq.com
             tags: []
             use_dogstatsd: true
+            bind_host: localhost
             additional_endpoints: {}
             histogram_aggregates:
               - "max"
@@ -829,8 +830,9 @@ describe 'datadog::dd-agent' do
             hostname: "chef-nodename"
             log_file: "/var/log/datadog/agent.log"
             log_level: "INFO"
-            non_local_traffic: false
-            apm_config: {}
+            dogstatsd_non_local_traffic: false
+            apm_config:
+              apm_non_local_traffic: false
             process_config:
               enabled: "false"
               blacklist_patterns: []
@@ -866,6 +868,7 @@ describe 'datadog::dd-agent' do
             dd_url: https://app.datadoghq.com
             tags: []
             use_dogstatsd: true
+            bind_host: localhost
             additional_endpoints: {}
             histogram_aggregates:
               - "max"
@@ -876,8 +879,9 @@ describe 'datadog::dd-agent' do
               - "0.95"
             hostname: "chef-nodename"
             log_level: "INFO"
-            non_local_traffic: false
-            apm_config: {}
+            dogstatsd_non_local_traffic: false
+            apm_config:
+              apm_non_local_traffic: false
             process_config:
               enabled: "false"
               blacklist_patterns: []

--- a/templates/default/datadog.yaml.erb
+++ b/templates/default/datadog.yaml.erb
@@ -11,17 +11,11 @@
 # - dogstatsd_interval
 # - dogstatsd_normalize
 # - legacy_integrations
-# - bind_host
 # - listen_port (`agent_port` attribute)
 
 # TODO: options not supported yet:
 # - agent_checks_interval
 # - Autodiscovery (aka Service Discovery) related options
-# - statsd_forward_host
-# - statsd_forward_port
-# - statsd_metric_namespace
-# - enable_trace_agent: always enabled
-# - all trace-related options are written to an INI file
 
 def string_list_to_array(string_list)
   # return an array from a comma-separated list in a string
@@ -79,16 +73,18 @@ agent_config = @extra_config.merge({
   api_key: @api_key,
   dd_url: node['datadog']['url'],
   hostname: node['datadog']['hostname'],
+  bind_host: node['datadog']['bind_host'],
   additional_endpoints: @additional_endpoints,
   skip_ssl_validation: node['datadog']['web_proxy']['skip_ssl_validation'],
   tags: tags,
   create_dd_check_tags: node['datadog']['create_dd_check_tags'],
   collect_ec2_tags: node['datadog']['collect_ec2_tags'],
-  non_local_traffic: node['datadog']['non_local_traffic'],
+  dogstatsd_non_local_traffic: node['datadog']['non_local_traffic'],
   histogram_aggregates: string_list_to_array(node['datadog']['histogram_aggregates']),
   histogram_percentiles: string_list_to_array(node['datadog']['histogram_percentiles']),
   use_dogstatsd: node['datadog']['dogstatsd'],
-  log_level: node['datadog']['log_level'],  # TODO: make sure it's a seelog-compatible log level
+  statsd_metric_namespace: node['datadog']['statsd_metric_namespace'],
+  log_level: node['datadog']['log_level'],
 
   # log agent options
   logs_enabled: node['datadog']['enable_logs_agent'],
@@ -107,6 +103,12 @@ agent_config = @extra_config.merge({
     process_dd_url: node['datadog']['process_agent']['url']
   }
 })
+
+if node['datadog']['statsd_forward_host']
+  # TODO: in next major, make `nil` the default value of `statsd_forward_port` to normalize handling
+  agent_config['statsd_forward_host'] = node['datadog']['statsd_forward_host']
+  agent_config['statsd_forward_port'] = node['datadog']['statsd_forward_port']
+end
 
 if node['datadog']['log_file_directory']
   agent_config['log_file'] = ::File.join(node['datadog']['log_file_directory'], "agent.log")
@@ -138,7 +140,8 @@ apm_config = {
   env: node['datadog']['trace_env'],
   extra_sample_rate: node['datadog']['extra_sample_rate'],
   max_traces_per_second: node['datadog']['max_traces_per_second'],
-  receiver_port: node['datadog']['receiver_port']
+  receiver_port: node['datadog']['receiver_port'],
+  apm_non_local_traffic: node['datadog']['non_local_traffic']
 }
 apm_config.reject!{ |k,v| v.nil? }
 # Take into account options defined under ['extra_config']['apm_config']


### PR DESCRIPTION
Adds options that are supported by Agent 6 since either 6.0 stable
or 6.1.

Please refer to Agent 6 [changelog](https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst)/[docs](https://github.com/DataDog/datadog-agent/tree/master/docs) for information on specific options.