### PR TITLE
[dd-handler] Support passing arbitrary config options to DD handler

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -122,6 +122,11 @@ default['datadog']['send_policy_tags'] = false
 # submitted successfully.
 default['datadog']['tags_submission_retries'] = nil
 
+# Additional handler config options
+# If the Chef Datadog handler supports a config option that's not available directly in this cookbook
+# you can set it as a key/value of this hash attribute. `nil` values will be ignored.
+default['datadog']['handler_extra_config'] = {}
+
 # Autorestart agent
 default['datadog']['autorestart'] = false
 

--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -62,8 +62,8 @@ chef_handler 'Chef::Handler::Datadog' do # rubocop:disable Metrics/BlockLength
   end
 
   def handler_config # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-    extra_config = node['datadog']['handler_extra_config'].reject{ |k,v| v.nil? }
-    config = extra_config.merge({
+    extra_config = node['datadog']['handler_extra_config'].reject { |_, v| v.nil? }
+    config = extra_config.merge(
       :api_key => Chef::Datadog.api_key(node),
       :application_key => Chef::Datadog.application_key(node),
       :use_ec2_instance_id => node['datadog']['use_ec2_instance_id'],
@@ -73,7 +73,7 @@ chef_handler 'Chef::Handler::Datadog' do # rubocop:disable Metrics/BlockLength
       :tags_blacklist_regex => node['datadog']['tags_blacklist_regex'],
       :send_policy_tags => node['datadog']['send_policy_tags'],
       :tags_submission_retries => node['datadog']['tags_submission_retries']
-    })
+    )
 
     unless node['datadog']['use_ec2_instance_id']
       config[:hostname] = node['datadog']['hostname']

--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -62,7 +62,8 @@ chef_handler 'Chef::Handler::Datadog' do # rubocop:disable Metrics/BlockLength
   end
 
   def handler_config # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-    config = {
+    extra_config = node['datadog']['handler_extra_config'].reject{ |k,v| v.nil? }
+    config = extra_config.merge({
       :api_key => Chef::Datadog.api_key(node),
       :application_key => Chef::Datadog.application_key(node),
       :use_ec2_instance_id => node['datadog']['use_ec2_instance_id'],
@@ -72,7 +73,7 @@ chef_handler 'Chef::Handler::Datadog' do # rubocop:disable Metrics/BlockLength
       :tags_blacklist_regex => node['datadog']['tags_blacklist_regex'],
       :send_policy_tags => node['datadog']['send_policy_tags'],
       :tags_submission_retries => node['datadog']['tags_submission_retries']
-    }
+    })
 
     unless node['datadog']['use_ec2_instance_id']
       config[:hostname] = node['datadog']['hostname']

--- a/spec/dd-handler_spec.rb
+++ b/spec/dd-handler_spec.rb
@@ -10,7 +10,7 @@ shared_examples 'a chef-handler-datadog installer' do |version|
   end
 end
 
-shared_examples 'a chef-handler-datadog runner' do |extra_endpoints, tags_blacklist_regex|
+shared_examples 'a chef-handler-datadog runner' do |extra_endpoints, tags_blacklist_regex, override_config|
   it 'runs the handler' do
     handler_config = {
       api_key: 'somethingnotnil',
@@ -23,6 +23,12 @@ shared_examples 'a chef-handler-datadog runner' do |extra_endpoints, tags_blackl
       send_policy_tags: false,
       tags_submission_retries: nil
     }
+
+    unless override_config.nil?
+      override_config.each do |k, v|
+        handler_config[k] = v
+      end
+    end
 
     expect(chef_run).to enable_chef_handler('Chef::Handler::Datadog').with(
       source: 'chef/handler/datadog',
@@ -135,7 +141,7 @@ describe 'datadog::dd-handler' do
 
     it_behaves_like 'a chef-handler-datadog installer'
 
-    it_behaves_like 'a chef-handler-datadog runner', extra_endpoints, nil
+    it_behaves_like 'a chef-handler-datadog runner', extra_endpoints, nil, nil
   end
 
   context 'multiple endpoints disabled' do
@@ -175,6 +181,25 @@ describe 'datadog::dd-handler' do
 
     it_behaves_like 'a chef-handler-datadog installer'
 
-    it_behaves_like 'a chef-handler-datadog runner', nil, 'tags.*'
+    it_behaves_like 'a chef-handler-datadog runner', nil, 'tags.*', nil
+  end
+
+  context 'handler_extra_config set' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '14.04'
+      ) do |node|
+        node.set['datadog']['api_key'] = 'somethingnotnil'
+        node.set['datadog']['application_key'] = 'somethingnotnil2'
+        node.set['datadog']['chef_handler_enable'] = true
+        node.set['datadog']['use_ec2_instance_id'] = true
+        node.set['datadog']['handler_extra_config']['foo'] = 'bar'
+      end.converge described_recipe
+    end
+
+    it_behaves_like 'a chef-handler-datadog installer'
+
+    it_behaves_like 'a chef-handler-datadog runner', nil, nil, {'foo' => 'bar'}
   end
 end

--- a/spec/dd-handler_spec.rb
+++ b/spec/dd-handler_spec.rb
@@ -200,6 +200,6 @@ describe 'datadog::dd-handler' do
 
     it_behaves_like 'a chef-handler-datadog installer'
 
-    it_behaves_like 'a chef-handler-datadog runner', nil, nil, {'foo' => 'bar'}
+    it_behaves_like 'a chef-handler-datadog runner', nil, nil, 'foo' => 'bar'
   end
 end


### PR DESCRIPTION
Similar to `extra_config` attribute for the Agent config. Allows passing handler options that are not explicitly supported in the cookbook as their own attribute.

Closes #399