### PR TITLE
[docs] Document easy_install_package removal from Chef 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,23 @@ dogstatsd-(python|ruby)
 -----------------------
 Installs the language-specific libraries to interact with `dogstatsd`.
 
+* Note for Chef >= 13 users: the `datadog::dogstatsd-python` recipe is not compatible with Chef >= 13, as it relies on a resource that was removed in Chef 13.0.
+  To install the `dogstatsd-python` library with Chef, please add a dependency on the `poise-python` cookbook to your custom/wrapper cookbook, and use the following resource:
+  ```ruby
+  python_package 'dogstatsd-python' # assumes that python and pip are installed
+  ```
+  For more advanced usage, please refer to the [`poise-python` cookbook documentation](https://github.com/poise/poise-python)
+
 ddtrace-(python|ruby)
 ---------------------
 Installs the language-specific libraries for application Traces (APM).
+
+* Note for Chef >= 13 users: the `datadog::ddtrace-python` recipe is not compatible with Chef >= 13, as it relies on a resource that was removed in Chef 13.0.
+  To install the `ddtrace-python` library with Chef, please add a dependency on the `poise-python` cookbook to your custom/wrapper cookbook, and use the following resource:
+  ```ruby
+  python_package 'ddtrace' # assumes that python and pip are installed
+  ```
+  For more advanced usage, please refer to the [`poise-python` cookbook documentation](https://github.com/poise/poise-python)
 
 other
 -----

--- a/recipes/ddtrace-python.rb
+++ b/recipes/ddtrace-python.rb
@@ -1,7 +1,10 @@
 #
 # Cookbook Name:: datadog
-# Recipe:: ddtrace-python.rb
+# Recipe:: ddtrace-python
 #
+
+# NB: This recipe is compatible with Chef <= 12 only. If you're using Chef 13 or higher
+# please refer to the README of the cookbook.
 
 easy_install_package 'ddtrace' do
   version node['datadog']['ddtrace_python_version']

--- a/recipes/dogstatsd-python.rb
+++ b/recipes/dogstatsd-python.rb
@@ -17,4 +17,7 @@
 # limitations under the License.
 #
 
+# NB: This recipe is compatible with Chef <= 12 only. If you're using Chef 13 or higher
+# please refer to the README of the cookbook.
+
 easy_install_package 'dogstatsd-python'


### PR DESCRIPTION
Affects the dogstatsd-python and ddtrace-python recipes.