### PR TITLE
Update default.rb - typo fix

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -390,7 +390,7 @@ default['datadog']['process_agent']['container_interval'] = nil
 default['datadog']['process_agent']['rtcontainer_interval'] = nil
 
 # Logs functionality settings (Agent 6 only)
-# Set `enable_log_agent` to:
+# Set `enable_logs_agent` to:
 # * `true` to explicitly enable the log agent
 # * `false` to explicitly disable it
 # Leave it to `nil` to let the agent's default behavior decide whether to run the log-agent


### PR DESCRIPTION
type for enabling logs agent in the comment
where the line is checked: https://github.com/DataDog/chef-datadog/blob/master/templates/default/datadog.yaml.erb#L90