### PR TITLE
add support for dogstatsd_socket tunable in datadog.yaml

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -70,6 +70,8 @@ default['datadog']['agent6_config_dir'] =
 # Leave key value to nil to use agent6 default for that endpoint.
 # Supported keys: "series", "events", "service checks"
 default['datadog']['use_v2_api'] = {}
+# set path to dogstatsd unix socket - https://docs.datadoghq.com/developers/dogstatsd/unix_socket/
+default['datadog']['dogstatsd_socket'] = false
 
 ###                 End of Agent6-only attributes                    ###
 ########################################################################

--- a/templates/default/datadog.yaml.erb
+++ b/templates/default/datadog.yaml.erb
@@ -112,6 +112,10 @@ if node['datadog']['statsd_forward_host']
   agent_config['statsd_forward_port'] = node['datadog']['statsd_forward_port']
 end
 
+if node['datadog']['agent6'] && node['datadog']['dogstatsd_socket']
+  agent_config['dogstatsd_socket'] = node['datadog']['dogstatsd_socket']
+end
+
 if node['datadog']['log_file_directory']
   agent_config['log_file'] = ::File.join(node['datadog']['log_file_directory'], "agent.log")
 end


### PR DESCRIPTION
add support for dogstatsd_socket setting in datadog.yaml https://docs.datadoghq.com/developers/dogstatsd/unix_socket/