### PR TITLE
instance level min_collection_interval

### DIFF
--- a/templates/default/mysql.yaml.erb
+++ b/templates/default/mysql.yaml.erb
@@ -11,6 +11,9 @@ instances:
     <% if i.key?('sock') -%>
     sock: <%= i['sock'] %>
     <% end -%>
+    <% if i.key?('min_collection_interval') -%>
+    min_collection_interval: <%= i['min_collection_interval'] %>
+    <% end -%>
   <% if i.key?('tags') -%>
     tags:
     <% i['tags'].each do |t| -%>


### PR DESCRIPTION
Instance level min_collection_interval is supported, but was not used in the template file. Hence adding it.