### PR TITLE
add no_proxy option

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -296,7 +296,7 @@ default['datadog']['web_proxy']['port'] = nil
 default['datadog']['web_proxy']['user'] = nil
 default['datadog']['web_proxy']['password'] = nil
 default['datadog']['web_proxy']['skip_ssl_validation'] = nil # accepted values 'yes' or 'no'
-default['datadog']['web_proxy']['no_proxy'] = nil
+default['datadog']['web_proxy']['no_proxy'] = nil # only used for agent v6.0+
 
 # dogstatsd
 default['datadog']['dogstatsd'] = true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -296,6 +296,7 @@ default['datadog']['web_proxy']['port'] = nil
 default['datadog']['web_proxy']['user'] = nil
 default['datadog']['web_proxy']['password'] = nil
 default['datadog']['web_proxy']['skip_ssl_validation'] = nil # accepted values 'yes' or 'no'
+default['datadog']['web_proxy']['no_proxy'] = nil
 
 # dogstatsd
 default['datadog']['dogstatsd'] = true

--- a/templates/default/datadog.yaml.erb
+++ b/templates/default/datadog.yaml.erb
@@ -37,6 +37,7 @@ if node['datadog']['web_proxy']['host']
   user = node['datadog']['web_proxy']['user']
   password = node['datadog']['web_proxy']['password']
   scheme = ""
+  no_proxy = node['datadog']['web_proxy']['no_proxy']
 
   unless host.start_with?('http://') or host.start_with?('https://')
     scheme = 'http://'
@@ -134,6 +135,10 @@ if !http_proxy.nil?
     http: http_proxy,
     https: http_proxy
   }
+end
+
+if !no_proxy.nil?
+  agent_config['proxy']['no_proxy'] = no_proxy
 end
 
 ## Trace agent options ##

--- a/templates/default/datadog.yaml.erb
+++ b/templates/default/datadog.yaml.erb
@@ -31,6 +31,7 @@ end
 
 # TODO: support the more complete proxy settings that the agent6 supports
 http_proxy = nil
+no_proxy = nil
 if node['datadog']['web_proxy']['host']
   host = node['datadog']['web_proxy']['host']
   port = node['datadog']['web_proxy']['port']
@@ -135,10 +136,7 @@ if !http_proxy.nil?
     http: http_proxy,
     https: http_proxy
   }
-end
-
-if !no_proxy.nil?
-  agent_config['proxy']['no_proxy'] = no_proxy
+  agent_config['proxy']['no_proxy'] = no_proxy if !no_proxy.nil?
 end
 
 ## Trace agent options ##


### PR DESCRIPTION
TL:DR Adds no_proxy option

The behaviour in agent v6 seems to behave differently than v5 when a web proxy is configured. With v5, the agent would connect directly to 127.0.0.1 whereas with v6, the agent will try to connect to 127.0.0.1 via the proxy. In v6, there is a no_proxy option which is not supported the chef datadog cookbook. 