### PR TITLE
Adding vault recipe and tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -548,3 +548,18 @@ suites:
           - bounce
           tags:
           - test
+
+- name: datadog_vault
+  run_list:
+    - recipe[datadog::vault]
+  attributes:
+    datadog:
+      <<: *DATADOG
+      vault:
+        instances:
+          - api_url: http://localhost:8200/v1
+            detect_leader: false
+            skip_proxy: false
+            ssl_verify: true
+            tags: ['_default']
+            timeout: 20

--- a/recipes/vault.rb
+++ b/recipes/vault.rb
@@ -1,0 +1,9 @@
+include_recipe 'datadog::dd-agent'
+
+# Monitor vault
+#
+
+datadog_monitor 'vault' do
+  instances node['datadog']['vault']['instances']
+  logs node['datadog']['vault']['logs']
+end

--- a/templates/default/vault.yaml.erb
+++ b/templates/default/vault.yaml.erb
@@ -1,0 +1,27 @@
+<%= JSON.parse(({'logs' => @logs }).to_json).to_yaml %>
+
+instances:
+<% @instances.each do |i| -%>
+  - api_url: <%= i['api_url'] %>
+    <% unless i['detect_leader'].nil? %>
+    detect_leader: <%= i['detect_leader'] %>
+    <% end %>
+    <% unless i['skip_proxy'].nil? %>
+    skip_proxy: <%= i['skip_proxy'] %>
+    <% end %>
+    <% unless i['ssl_verify'].nil? %>
+    ssl_verify: <%= i['ssl_verify'] %>
+    <% end %>
+    <% unless i['timeout'].nil? %>
+    timeout: <%= i['timeout'] %>
+    <% end %>
+    <% if i.key?('tags') && !i['tags'].empty? -%>
+    tags:
+      <% i['tags'].each do |t| -%>
+      - <%= t %>
+      <% end -%>
+    <% end -%>
+<% end -%>
+
+# Nothing to configure here
+init_config:

--- a/test/integration/datadog_vault/serverspec/Gemfile
+++ b/test/integration/datadog_vault/serverspec/Gemfile
@@ -1,0 +1,1 @@
+../../helpers/serverspec/Gemfile

--- a/test/integration/datadog_vault/serverspec/vault_spec.rb
+++ b/test/integration/datadog_vault/serverspec/vault_spec.rb
@@ -1,0 +1,38 @@
+# Encoding: utf-8
+
+require 'json_spec'
+require 'serverspec'
+require 'yaml'
+
+set :backend, :exec
+set :path, '/sbin:/usr/local/sbin:$PATH'
+
+AGENT_CONFIG = '/etc/dd-agent/conf.d/vault.yaml'.freeze
+
+describe service('datadog-agent') do
+  it { should be_running }
+end
+
+describe file(AGENT_CONFIG) do
+  it { should be_a_file }
+
+  it 'is valid yaml matching input values' do
+    generated = YAML.load_file(AGENT_CONFIG)
+
+    expected = {
+      'instances' => [
+        {
+          'api_url' => 'http://localhost:8200/v1',
+          'detect_leader' => false,
+          'skip_proxy' => false,
+          'ssl_verify' => true,
+          'tags' => ['_default'],
+          'timeout' => 20
+        }
+      ],
+      'init_config' => nil
+    }
+
+    expect(generated.to_json).to be_json_eql expected.to_json
+  end
+end


### PR DESCRIPTION
DataDog V6  agent supports checks for vault.  I added a recipe similar to the consul recipe that adds the proper configuration file to the configuration directory for enabling vault checks.