### PR TITLE
Use the documented data structure for tags in lighttpd's template.

### DIFF
--- a/templates/default/lighttpd.yaml.erb
+++ b/templates/default/lighttpd.yaml.erb
@@ -5,8 +5,8 @@ instances:
   - lighttpd_status_url: <%= i['status_url'] %>
     <% if i.key?('tags') -%>
     tags:
-      <% i['tags'].each_pair do |k, v| -%>
-      - <%= k %>: <%= v %>
+      <% i['tags'].each do |t| -%>
+      - <%= t %>
       <% end -%>
     <% end -%>
   <% end -%>


### PR DESCRIPTION
The [integration documentation][] shows tags as a list of strings not as a hash, so this change allows the cookbook to generate lighttpd monitoring configuration. 

[integration documentation]: https://docs.datadoghq.com/integrations/lighttpd/