### PR TITLE
Retry on failure when pulling the gpg key from keyserver.ubuntu.com

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -37,6 +37,7 @@ when 'debian'
     distribution distribution
     components components
     action :add
+    retries 4
   end
 
   # Previous versions of the cookbook could create this repo file, make sure we remove it now


### PR DESCRIPTION
# Motivation

the keyservers are a pool of sks servers with squid in front of them, we should probably retry on failures.