### PR TITLE
Make sd_jmx_enable configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -336,6 +336,7 @@ default['datadog']['sd_backend_host'] = '127.0.0.1'
 default['datadog']['sd_backend_port'] = 4001
 default['datadog']['sd_config_backend'] = 'etcd'
 default['datadog']['sd_template_dir'] = '/datadog/check_configs'
+default['datadog']['sd_jmx_enable'] = 'no'
 default['datadog']['service_discovery_backend'] = nil
 
 # Trace functionality settings

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -85,6 +85,9 @@ sd_backend_port: <%= node['datadog']['sd_backend_port'] %>
 # `/datadog/check_configs` key in the back-end. If you wish otherwise, uncomment this option
 # and modify its value.
 sd_template_dir: <%= node['datadog']['sd_template_dir'] %>
+
+# Enable JMX checks for service discovery
+sd_jmx_enable: <%= node['datadog']['sd_jmx_enable'] %>
 <% end -%>
 
 <% if node['datadog']['dogstatsd'] -%>


### PR DESCRIPTION
Support configuring sd_jmx_enable via attributes, which allows us to
create JMX checks using Docker labels (or other SD config backends).

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>