### PR TITLE
Added index_stats parameter for Elasticsearch config

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -224,6 +224,7 @@ suites:
             password: somepass
             is_external: false
             pshard_stats: true
+            index_stats: true
             shard_level_metrics: true
             tags:
               - kitchen

--- a/recipes/elasticsearch.rb
+++ b/recipes/elasticsearch.rb
@@ -28,6 +28,10 @@ include_recipe 'datadog::dd-agent'
 # documents in your indexes WITHOUT counting duplicates due to the existence
 # of replica shards in your ES cluster
 #
+# If you enable the "index_stats" flag, the agent will send index level metrics.
+# This means that you will be able to get the "elasticsearch.index.*" metrics. For
+# more details, visit https://docs.datadoghq.com/integrations/elastic/
+#
 # The "shard_level_metrics" flag enables metrics and service checks on a per-
 # shard basis (all the information is fetched under the /_stats?level=shards
 # endpoint). The metrics and service check sent for each shard are named as
@@ -50,6 +54,7 @@ include_recipe 'datadog::dd-agent'
 #     :url => 'http://localhost:9200',
 #     :tags => ['env:test'],
 #     :pshard_stats => true,
+#     :index_stats => true,
 #     :shard_level_metrics: true
 #   }
 # ]

--- a/spec/integrations/elasticsearch_spec.rb
+++ b/spec/integrations/elasticsearch_spec.rb
@@ -8,6 +8,7 @@ describe 'datadog::elasticsearch' do
         username: testuser
         password: testpassword
         pshard_stats: true
+        index_stats: true
         tags:
           - 'env:test'
 
@@ -25,6 +26,7 @@ describe 'datadog::elasticsearch' do
               username: 'testuser',
               password: 'testpassword',
               pshard_stats: true,
+              index_stats: true,
               tags: ['env:test']
             }
           ]

--- a/templates/default/elastic.yaml.erb
+++ b/templates/default/elastic.yaml.erb
@@ -12,6 +12,9 @@ instances:
     <% unless i["cluster_stats"].nil? %>
     cluster_stats: <%= i["cluster_stats"] %>
     <% end %>
+    <% unless i["index_stats"].nil? %>
+    index_stats: <%= i["index_stats"] %>
+    <% end %> 
     <% unless i["is_external"].nil? %>
     is_external: <%= i["is_external"] %>
     <% end %>

--- a/test/integration/datadog_elasticsearch/serverspec/elasticsearch_spec.rb
+++ b/test/integration/datadog_elasticsearch/serverspec/elasticsearch_spec.rb
@@ -22,6 +22,7 @@ describe file(AGENT_CONFIG) do
           'password' => 'somepass',
           'is_external' => false,
           'pshard_stats' => true,
+          'index_stats' => true,
           'shard_level_metrics' => true,
           'tags' => ['kitchen', 'sink']
         }


### PR DESCRIPTION
From the [Datadog Elasticsearch integration documentation](https://docs.datadoghq.com/integrations/elastic/), it is possible now to get index level metrics `elasticsearch.index.*`, by enabling the `index_stats` flag in the Elasticsearch config file `elastic.yaml`.
