### PR TITLE
Missing comma in the example for RabbitMQ

### DIFF
--- a/recipes/rabbitmq.rb
+++ b/recipes/rabbitmq.rb
@@ -12,7 +12,7 @@ include_recipe 'datadog::dd-agent'
 #       "api_url" => "http://localhost:15672/api/",
 #       "user" => "guest",
 #       "pass" => "guest",
-#       "ssl_verify" => "true"
+#       "ssl_verify" => "true",
 #       "tag_families" => "false"
 #     }
 #   ]


### PR DESCRIPTION
Small typo fix - missing comma :)