### PR TITLE
Remove `sudo: false` as required by Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 
 branches:
   only:


### PR DESCRIPTION
As per Travis CI blog post [Upcoming Required Linux Infrastructure Migration](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)
> If you currently specify `sudo: false` in your `.travis.yml`, we recommend removing that configuration soon.