### PR TITLE
Add domain socket support to postgres monitor

### DIFF
--- a/recipes/postgres.rb
+++ b/recipes/postgres.rb
@@ -5,6 +5,10 @@ include_recipe 'datadog::dd-agent'
 # @example
 #   node.override['datadog']['postgres']['instances'] = [
 #     {
+#       'host' => "/var/run/postgresql/.s.PGSQL.5432",
+#       'username' => "datadog"
+#     },
+#     {
 #       'host' => "localhost",
 #       'port' => "5432",
 #       'username' => "datadog",

--- a/spec/integrations/postgres_spec.rb
+++ b/spec/integrations/postgres_spec.rb
@@ -152,6 +152,48 @@ describe 'datadog::postgres' do
     end
   end
 
+  context 'default settings with a domain socket' do
+    expected_yaml = <<-EOF
+      logs: ~
+      instances:
+      - host: /var/run/postgresql/.s.PGSQL.5432
+        dbname: default_settings
+      init_config:
+    EOF
+
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+        node.automatic['languages'] = { python: { version: '2.7.2' } }
+
+        node.set['datadog'] = {
+          api_key: 'someapikey',
+          postgres: {
+            instances: [
+              {
+                dbname: 'default_settings',
+                server: '/var/run/postgresql/.s.PGSQL.5432'
+              }
+            ]
+          }
+        }
+      end.converge(described_recipe)
+    end
+
+    subject { chef_run }
+
+    it_behaves_like 'datadog-agent'
+
+    it { is_expected.to include_recipe('datadog::dd-agent') }
+
+    it { is_expected.to add_datadog_monitor('postgres') }
+
+    it 'renders expected YAML config file' do
+      expect(chef_run).to(render_file('/etc/dd-agent/conf.d/postgres.yaml').with_content { |content|
+        expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
+      })
+    end
+  end
+
   context 'relations' do
     expected_yaml = <<-EOF
       logs: ~

--- a/templates/default/postgres.yaml.erb
+++ b/templates/default/postgres.yaml.erb
@@ -11,8 +11,8 @@
     # using `host` as their key.
     instance['host'] = instance.delete 'server' if instance['server']
 
-    # If `port` is unspecified, set to 5432
-    instance['port'] = 5432 if instance['port'].nil?
+    # If `port` is unspecified and host is not a domain socket, set to 5432
+    instance['port'] = 5432 if (instance['port'].nil? and !instance['host'].start_with?('/'))
   end
 -%>
 <%= JSON.parse(({ 'instances' => instances, 'logs' => @logs }).to_json).to_yaml %>


### PR DESCRIPTION
Add an example.
Do not set 'port' in the config when using a domain socket.