### PR TITLE
Optional cmd_port & GUI_port on agentv6 due to port conflicts

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -66,6 +66,16 @@ default['datadog']['agent6_config_dir'] =
     '/etc/datadog-agent'
   end
 
+# The port on which the IPC api listens
+# cmd_port: 5001
+default['datadog']['agent6_cmd_port'] = nil
+
+# The port for the browser GUI to be served
+# Setting 'GUI_port: -1' turns off the GUI completely
+# Default is '5002' on Windows and macOS ; turned off on Linux
+# GUI_port: -1
+default['datadog']['agent6_gui_port'] = nil
+
 # Set a key to true to make the agent6 use the v2 api on that endpoint, false otherwise.
 # Leave key value to nil to use agent6 default for that endpoint.
 # Supported keys: "series", "events", "service checks"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'package@datadoghq.com'
 license          'Apache-2.0'
 description      'Installs/Configures datadog components'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.16.1'
+version          '2.16.2'
 chef_version     '>= 10.14' if respond_to? :chef_version
 source_url       'https://github.com/DataDog/chef-datadog' if respond_to? :source_url
 issues_url       'https://github.com/DataDog/chef-datadog/issues' if respond_to? :issues_url

--- a/templates/default/datadog.yaml.erb
+++ b/templates/default/datadog.yaml.erb
@@ -87,6 +87,8 @@ agent_config = @extra_config.merge({
   use_dogstatsd: node['datadog']['dogstatsd'],
   statsd_metric_namespace: node['datadog']['statsd_metric_namespace'],
   log_level: node['datadog']['log_level'],
+  cmd_port: node['datadog']['agent6_cmd_port'],
+  GUI_port: node['datadog']['agent6_gui_port'],
 
   # log agent options
   logs_enabled: node['datadog']['enable_logs_agent'],


### PR DESCRIPTION
https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml