### PR TITLE
Add support for 'site' option.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -96,13 +96,10 @@ default['datadog']['tag_prefix'] = 'tag:'
 # Don't change these.
 # The host of the Datadog intake server to send Agent data to, only set this option
 # if you need the Agent to send data to a custom URL.
-# For Agent 6, defaults to nil because "url" overrides the site setting defined in "site".
-default['datadog']['url'] =
-  if node['datadog']['agent6'] == true
-    nil
-  else
-    'https://app.datadoghq.com'
-  end
+# The nil value will let the Agent 6 select the URL to send the data.
+# For Agent 5, the Agent 5 recipe will fallback on https://app.datadoghq.com
+# (see recipes/dd-agent.rb).
+default['datadog']['url'] = nil
 
 # Add tags as override attributes in your role
 # This can be a string of comma separated tags or a hash in this format:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -66,6 +66,10 @@ default['datadog']['agent6_config_dir'] =
     '/etc/datadog-agent'
   end
 
+# The site of the Datadog intake to send Agent data to.
+# Defaults to 'datadoghq.com', set to 'datadoghq.eu' to send data to the EU site.
+default['datadog']['site'] = 'datadoghq.com'
+
 # Set a key to true to make the agent6 use the v2 api on that endpoint, false otherwise.
 # Leave key value to nil to use agent6 default for that endpoint.
 # Supported keys: "series", "events", "service checks"
@@ -88,9 +92,16 @@ default['datadog']['extra_endpoints']['prod']['url'] = nil # optional
 # Set prefix to '' if you want Chef tags to be sent without prefix.
 default['datadog']['tag_prefix'] = 'tag:'
 
-# Don't change these
-# The host of the Datadog intake server to send agent data to
-default['datadog']['url'] = 'https://app.datadoghq.com'
+# Don't change these.
+# The host of the Datadog intake server to send Agent data to, only set this option
+# if you need the Agent to send data to a custom URL.
+# For Agent 6, defaults to nil because "url" overrides the site setting defined in "site".
+default['datadog']['url'] =
+  if node['datadog']['agent6'] == true
+    nil
+  else
+    'https://app.datadoghq.com'
+  end
 
 # Add tags as override attributes in your role
 # This can be a string of comma separated tags or a hash in this format:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -93,10 +93,11 @@ default['datadog']['extra_endpoints']['prod']['url'] = nil # optional
 # Set prefix to '' if you want Chef tags to be sent without prefix.
 default['datadog']['tag_prefix'] = 'tag:'
 
-# Don't change these.
 # The host of the Datadog intake server to send Agent data to, only set this option
 # if you need the Agent to send data to a custom URL.
 # The nil value will let the Agent 6 select the URL to send the data.
+# Any non-nil value overrides the 'site' value, prefer using 'site' unless your
+# use case isn't covered by 'site'.
 # For Agent 5, the Agent 5 recipe will fallback on https://app.datadoghq.com
 # (see recipes/dd-agent.rb).
 default['datadog']['url'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -67,8 +67,9 @@ default['datadog']['agent6_config_dir'] =
   end
 
 # The site of the Datadog intake to send Agent data to.
+# This configuration option is supported since Agent 6.6
 # Defaults to 'datadoghq.com', set to 'datadoghq.eu' to send data to the EU site.
-default['datadog']['site'] = 'datadoghq.com'
+default['datadog']['site'] = nil
 
 # Set a key to true to make the agent6 use the v2 api on that endpoint, false otherwise.
 # Leave key value to nil to use agent6 default for that endpoint.

--- a/recipes/_agent6_config.rb
+++ b/recipes/_agent6_config.rb
@@ -19,6 +19,15 @@
 
 is_windows = node['platform_family'] == 'windows'
 
+# use either the site option or the url one, the latter having priority.
+dd_url = 'https://app.datadoghq.com'
+if node['datadog']['site']
+  dd_url = 'https://app.' + node['datadog']['site']
+end
+if node['datadog']['url']
+  dd_url = node['datadog']['url']
+end
+
 agent6_config_file = ::File.join(node['datadog']['agent6_config_dir'], 'datadog.yaml')
 template agent6_config_file do
   def template_vars
@@ -28,7 +37,7 @@ template agent6_config_file do
       url = if endpoint['url']
               endpoint['url']
             else
-              node['datadog']['url']
+              dd_url
             end
       if additional_endpoints.key?(url)
         additional_endpoints[url] << endpoint['api_key']

--- a/recipes/_agent6_config.rb
+++ b/recipes/_agent6_config.rb
@@ -20,13 +20,9 @@
 is_windows = node['platform_family'] == 'windows'
 
 # use either the site option or the url one, the latter having priority.
-dd_url = 'https://app.datadoghq.com'
-if node['datadog']['site']
-  dd_url = 'https://app.' + node['datadog']['site']
-end
-if node['datadog']['url']
-  dd_url = node['datadog']['url']
-end
+node.run_state['dd_url'] = 'https://app.datadoghq.com'
+node.run_state['dd_url'] = 'https://app.' + node['datadog']['site'] unless node['datadog']['site'].nil?
+node.run_state['dd_url'] = node['datadog']['url'] unless node['datadog']['url'].nil?
 
 agent6_config_file = ::File.join(node['datadog']['agent6_config_dir'], 'datadog.yaml')
 template agent6_config_file do
@@ -37,7 +33,7 @@ template agent6_config_file do
       url = if endpoint['url']
               endpoint['url']
             else
-              dd_url
+              node.run_state['dd_url']
             end
       if additional_endpoints.key?(url)
         additional_endpoints[url] << endpoint['api_key']

--- a/recipes/_agent6_config.rb
+++ b/recipes/_agent6_config.rb
@@ -19,21 +19,22 @@
 
 is_windows = node['platform_family'] == 'windows'
 
-# use either the site option or the url one, the latter having priority.
-node.run_state['dd_url'] = 'https://app.datadoghq.com'
-node.run_state['dd_url'] = 'https://app.' + node['datadog']['site'] unless node['datadog']['site'].nil?
-node.run_state['dd_url'] = node['datadog']['url'] unless node['datadog']['url'].nil?
-
 agent6_config_file = ::File.join(node['datadog']['agent6_config_dir'], 'datadog.yaml')
 template agent6_config_file do
   def template_vars
+    # we need to always provide an URL value for additional endpoints.
+    # use either the site option or the url one, the latter having priority.
+    dd_url = 'https://app.datadoghq.com'
+    dd_url = 'https://app.' + node['datadog']['site'] unless node['datadog']['site'].nil?
+    dd_url = node['datadog']['url'] unless node['datadog']['url'].nil?
+
     additional_endpoints = {}
     node['datadog']['extra_endpoints'].each do |_, endpoint|
       next unless endpoint['enabled']
       url = if endpoint['url']
               endpoint['url']
             else
-              node.run_state['dd_url']
+              dd_url
             end
       if additional_endpoints.key?(url)
         additional_endpoints[url] << endpoint['api_key']

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -41,12 +41,8 @@ agent_start = node['datadog']['agent_start'] ? :start : :stop
 
 # use either the site option or the url one, the latter having priority.
 node.run_state['dd_url'] = 'https://app.datadoghq.com'
-if node['datadog']['site']
-  node.run_state['dd_url'] = 'https://app.' + node['datadog']['site']
-end
-if node['datadog']['url']
-  node.run_state['dd_url'] = node['datadog']['url']
-end
+node.run_state['dd_url'] = 'https://app.' + node['datadog']['site'] unless node['datadog']['site'].nil?
+node.run_state['dd_url'] = node['datadog']['url'] unless node['datadog']['url'].nil?
 
 #
 # Configures a basic agent

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -40,12 +40,12 @@ agent_enable = node['datadog']['agent_enable'] ? :enable : :disable
 agent_start = node['datadog']['agent_start'] ? :start : :stop
 
 # use either the site option or the url one, the latter having priority.
-dd_url = 'https://app.datadoghq.com'
+node.run_state['dd_url'] = 'https://app.datadoghq.com'
 if node['datadog']['site']
-  dd_url = 'https://app.' + node['datadog']['site']
+  node.run_state['dd_url'] = 'https://app.' + node['datadog']['site']
 end
 if node['datadog']['url']
-  dd_url = node['datadog']['url']
+  node.run_state['dd_url'] = node['datadog']['url']
 end
 
 #
@@ -75,14 +75,14 @@ else
   template agent_config_file do
     def template_vars
       api_keys = [Chef::Datadog.api_key(node)]
-      dd_urls = [dd_url]
+      dd_urls = [node.run_state['dd_url']]
       node['datadog']['extra_endpoints'].each do |_, endpoint|
         next unless endpoint['enabled']
         api_keys << endpoint['api_key']
         dd_urls << if endpoint['url']
                      endpoint['url']
                    else
-                     dd_url
+                     node.run_state['dd_url']
                    end
       end
       {

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -39,6 +39,15 @@ agent_enable = node['datadog']['agent_enable'] ? :enable : :disable
 # Set the correct Agent startup action
 agent_start = node['datadog']['agent_start'] ? :start : :stop
 
+# use either the site option or the url one, the latter having priority.
+dd_url = 'https://app.datadoghq.com'
+if node['datadog']['site']
+  dd_url = 'https://app.' + node['datadog']['site']
+end
+if node['datadog']['url']
+  dd_url = node['datadog']['url']
+end
+
 #
 # Configures a basic agent
 # To add integration-specific configurations, add 'datadog::config_name' to
@@ -66,14 +75,14 @@ else
   template agent_config_file do
     def template_vars
       api_keys = [Chef::Datadog.api_key(node)]
-      dd_urls = [node['datadog']['url']]
+      dd_urls = [dd_url]
       node['datadog']['extra_endpoints'].each do |_, endpoint|
         next unless endpoint['enabled']
         api_keys << endpoint['api_key']
         dd_urls << if endpoint['url']
                      endpoint['url']
                    else
-                     node['datadog']['url']
+                     dd_url
                    end
       end
       {

--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -28,7 +28,7 @@ end
 include_recipe 'chef_handler'
 
 if node['datadog']['chef_handler_version'] &&
-   Gem::Version.new(node['datadog']['chef_handler_version']) < Gem::Version.new('0.10.0')
+  Gem::Version.new(node['datadog']['chef_handler_version']) < Gem::Version.new('0.10.0')
   Chef::Log.error('We do not support chef_handler_version < v0.10.0 anymore, please use a more recent version.')
   return
 end

--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -27,16 +27,11 @@ end
 
 include_recipe 'chef_handler'
 
-# Since Agent 6 supports node['datadog']['url'] = nil, we need to fallback
-# on a default value here.
-# FIXME(remy): this logic has been duplicated below in this file, moreover,
-# the DATADOG_HOST is needed only until v0.9.0 of chef-agent-handler, we should
-# think of removing it in a major release. See
-# https://github.com/DataDog/chef-datadog/pull/582#discussion_r260004814
-dd_url = 'https://app.datadoghq.com'
-dd_url = node['datadog']['url'] unless node['datadog']['url'].nil?
-
-ENV['DATADOG_HOST'] = dd_url
+if node['datadog']['chef_handler_version'] &&
+   Gem::Version.new(node['datadog']['chef_handler_version']) < Gem::Version.new('0.10.0')
+  Chef::Log.error('We do not support chef_handler_version < v0.10.0 anymore, please use a more recent version.')
+  return
+end
 
 chef_gem 'chef-handler-datadog' do # ~FC009
   action :install

--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -29,12 +29,8 @@ include_recipe 'chef_handler'
 
 # use either the site option or the url one, the latter having priority.
 node.run_state['dd_url'] = 'https://app.datadoghq.com'
-if node['datadog']['site']
-  node.run_state['dd_url'] = 'https://app.' + node['datadog']['site']
-end
-if node['datadog']['url']
-  node.run_state['dd_url'] = node['datadog']['url']
-end
+node.run_state['dd_url'] = 'https://app.' + node['datadog']['site'] unless node['datadog']['site'].nil?
+node.run_state['dd_url'] = node['datadog']['url'] unless node['datadog']['url'].nil?
 
 ENV['DATADOG_HOST'] = node.run_state['dd_url']
 

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -815,7 +815,6 @@ describe 'datadog::dd-agent' do
           it 'contains expected YAML configuration' do
             expected_yaml = <<-EOF
             api_key: somethingnotnil
-            site: datadoghq.com
             tags: []
             use_dogstatsd: true
             bind_host: localhost
@@ -867,7 +866,6 @@ describe 'datadog::dd-agent' do
           it 'contains expected YAML configuration' do
             expected_yaml = <<-EOF
             api_key: somethingnotnil
-            site: datadoghq.com
             tags: []
             use_dogstatsd: true
             bind_host: localhost

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -815,7 +815,7 @@ describe 'datadog::dd-agent' do
           it 'contains expected YAML configuration' do
             expected_yaml = <<-EOF
             api_key: somethingnotnil
-            dd_url: https://app.datadoghq.com
+            site: datadoghq.com
             tags: []
             use_dogstatsd: true
             bind_host: localhost
@@ -867,7 +867,7 @@ describe 'datadog::dd-agent' do
           it 'contains expected YAML configuration' do
             expected_yaml = <<-EOF
             api_key: somethingnotnil
-            dd_url: https://app.datadoghq.com
+            site: datadoghq.com
             tags: []
             use_dogstatsd: true
             bind_host: localhost

--- a/templates/default/datadog.yaml.erb
+++ b/templates/default/datadog.yaml.erb
@@ -73,6 +73,7 @@ end
 ## Populate agent_config ##
 agent_config = @extra_config.merge({
   api_key: @api_key,
+  site: node['datadog']['site'],
   dd_url: node['datadog']['url'],
   hostname: node['datadog']['hostname'],
   bind_host: node['datadog']['bind_host'],


### PR DESCRIPTION
Agent 6.9.0 has a new option `site` to configure on which site (US/EU) the Agent data should be sent, simplifying the configuration process by avoiding to type complete URLs in the `url` configuration field.

This pull-requests adds the attribute `site` in the Chef cookbook in order to use this option by default instead of the `url` one.

Note that it doesn't remove anything about the `url` configuration field has it's still supported and has priority on the `site` value.

The use of `DATADOG_HOST` has been removed: it was used by the chef-handler-datadog recipe to set the datadog host to use, however, the ruby lib dogapi-rb used already has a correct default value if `DATADOG_HOST` was not set and on top of that: https://github.com/DataDog/chef-handler-datadog/pull/103 makes sure that a default value is set directly inside the recipe instead of in the ruby lib dogapi-rb.