### PR TITLE
Fix beans description in tomcat config template.

### DIFF
--- a/templates/default/tomcat.yaml.erb
+++ b/templates/default/tomcat.yaml.erb
@@ -62,17 +62,19 @@ init_config:
             metric_type: counter
     - include:
         type: Cache
-        accessCount:
-          alias: tomcat.cache.access_count
-          metric_type: counter
-        hitsCounts:
-          alias: tomcat.cache.hits_count
-          metric_type: counter
+        attribute:
+          accessCount:
+            alias: tomcat.cache.access_count
+            metric_type: counter
+          hitsCounts:
+            alias: tomcat.cache.hits_count
+            metric_type: counter
     - include:
         type: JspMonitor
-        jspCount:
-          alias: tomcat.jsp.count
-          metric_type: counter
-        jspReloadCount:
-          alias: tomcat.jsp.reload_count
-          metric_type: counter
+        attribute:
+          jspCount:
+            alias: tomcat.jsp.count
+            metric_type: counter
+          jspReloadCount:
+            alias: tomcat.jsp.reload_count
+            metric_type: counter


### PR DESCRIPTION
Fixes https://github.com/DataDog/chef-datadog/issues/574

> The last 2 `include`s in the `tomcat` template are missing the `attribute` key, which makes JMXFetch log errors and fail to collect the related beans: [https://github.com/DataDog/chef-datadog/blob/v2.16.1/templates/default/tomcat.yaml.erb#L63-L78\](https://github.com/DataDog/chef-datadog/blob/v2.16.1/templates/default/tomcat.yaml.erb#L63-L78%5C)