### PR TITLE
Add an example on how to use `extra_config`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ For general information on the Datadog Agent 6, please refer to the [datadog-age
 ### Extra configuration
 
 Should you wish to add additional elements to the Agent v6 configuration file
-(typically `/etc/datadog-agent/datadog.yaml`) that are not directly available
+(typically `datadog.yaml`) that are not directly available
 as attributes of the cookbook, you may use the `node['datadog']['extra_config']`
 attribute. This attribute is a hash and will be marshaled into the configuration
 file accordingly.
@@ -222,7 +222,7 @@ E.g.
  ```
 
 This example will set the field `secret_backend_command` in the configuration
-file `/etc/datadog-agent/datadog.yaml`.
+file `datadog.yaml`.
 
 ### Instructions
 

--- a/README.md
+++ b/README.md
@@ -199,9 +199,30 @@ Additional attributes are available to have finer control over how you install A
 
 Please review the [attributes/default.rb](https://github.com/DataDog/chef-datadog/blob/master/attributes/default.rb) file (at the version of the cookbook you use) for the list and usage of the attributes used by the cookbook.
 
-Should you wish to add additional elements to the agent6 configuration file (typically `/etc/datadog-agent/datadog.yaml`) that are not directly available as attributes of the cookbook, you may use the `node['datadog']['extra_config']` attribute. This attribute is a hash and will be marshaled into the configuration file accordingly.
-
 For general information on the Datadog Agent 6, please refer to the [datadog-agent](https://github.com/DataDog/datadog-agent/) repo.
+
+### Extra configuration
+
+Should you wish to add additional elements to the Agent v6 configuration file
+(typically `/etc/datadog-agent/datadog.yaml`) that are not directly available
+as attributes of the cookbook, you may use the `node['datadog']['extra_config']`
+attribute. This attribute is a hash and will be marshaled into the configuration
+file accordingly.
+
+E.g.
+
+ ```
+ default_attributes(
+   'datadog' => {
+     'extra_config' => {
+        'secret_backend_command' => '/sbin/local-secrets'
+     }
+   }
+ )
+ ```
+
+This example will set the field `secret_backend_command` in the configuration
+file `/etc/datadog-agent/datadog.yaml`.
 
 ### Instructions
 


### PR DESCRIPTION
Add a bit of documentation for the `node['datadog']['extra_config']` field in order to promote its usage.