### PR TITLE
Let the Windows installer set the correct rights on config files and directories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,19 @@ Should you wish to add additional elements to the agent6 configuration file (typ
 
 For general information on the Datadog Agent 6, please refer to the [datadog-agent](https://github.com/DataDog/datadog-agent/) repo.
 
+#### Windows Agent v6 installation
+
+Starting with version `>= 6.11`, the Agent v6 must be installed with a chef-datadog
+cookbook version `>= 2.18.0`.
+
+For Agent v6 versions `< 6.11`, previous versions of the datadog cookbook
+could still be used, even if we recommend in most of the case to use the
+latest one.
+
+This is due to the Agent v6 running with an unprivileged user on Windows
+since 6.11. However, prior to chef-datadog 2.18.0, the datadog cookbook was
+enforcing Administrators privileges to the Datadog Agent directories and files.
+
 ### Instructions
 
 1. Add this cookbook to your Chef Server, either by installing with knife or by adding it to your Berksfile:

--- a/README.md
+++ b/README.md
@@ -203,16 +203,12 @@ For general information on the Datadog Agent 6, please refer to the [datadog-age
 
 #### Windows Agent v6 installation
 
-Starting with version `>= 6.11`, the Agent v6 must be installed with a chef-datadog
+Starting with version `>= 6.11`, the Windows Agent v6 must be installed with datadog
 cookbook version `>= 2.18.0`.
 
-For Agent v6 versions `< 6.11`, previous versions of the datadog cookbook
-could still be used, even if we recommend in most of the case to use the
-latest one.
-
 This is due to the Agent v6 running with an unprivileged user on Windows
-since 6.11. However, prior to chef-datadog 2.18.0, the datadog cookbook was
-enforcing Administrators privileges to the Datadog Agent directories and files.
+since 6.11. However, prior to 2.18.0, the datadog cookbook was enforcing
+Administrators privileges to the Datadog Agent directories and files.
 
 ### Extra configuration
 

--- a/providers/monitor.rb
+++ b/providers/monitor.rb
@@ -10,7 +10,7 @@ end
 action :add do
   Chef::Log.debug "Adding monitoring for #{new_resource.name}"
   template ::File.join(yaml_dir, "#{new_resource.name}.yaml") do
-    # On Windows Agent v5, set the permissions on files an dirs to Administrators.
+    # On Windows Agent v5, set the permissions on conf files to Administrators.
     if node['platform_family'] == 'windows'
       unless node['datadog']['agent6']
         owner 'Administrators'

--- a/providers/monitor.rb
+++ b/providers/monitor.rb
@@ -10,7 +10,14 @@ end
 action :add do
   Chef::Log.debug "Adding monitoring for #{new_resource.name}"
   template ::File.join(yaml_dir, "#{new_resource.name}.yaml") do
-    unless node['platform_family'] == 'windows'
+    # On Windows Agent v5, set the permissions on files an dirs to Administrators.
+    if node['platform_family'] == 'windows'
+      unless node['datadog']['agent6']
+        owner 'Administrators'
+        rights :full_control, 'Administrators'
+        inherits false
+      end
+    else
       owner 'dd-agent'
       mode '600'
     end

--- a/providers/monitor.rb
+++ b/providers/monitor.rb
@@ -10,11 +10,7 @@ end
 action :add do
   Chef::Log.debug "Adding monitoring for #{new_resource.name}"
   template ::File.join(yaml_dir, "#{new_resource.name}.yaml") do
-    if node['platform_family'] == 'windows'
-      owner 'Administrators'
-      rights :full_control, 'Administrators'
-      inherits false
-    else
+    unless node['platform_family'] == 'windows'
       owner 'dd-agent'
       mode '600'
     end

--- a/recipes/_agent6_config.rb
+++ b/recipes/_agent6_config.rb
@@ -48,11 +48,7 @@ template agent6_config_file do
     }
   end
 
-  if is_windows
-    owner 'Administrators'
-    rights :full_control, 'Administrators'
-    inherits false
-  else
+  unless is_windows
     owner 'dd-agent'
     group 'dd-agent'
     mode '640'


### PR DESCRIPTION
The .MSI to setup the Agent on Windows will soon run the Agent in a custom user with less privileges (than Administrator).

This commit removes the permissions change on `datadog.yaml` on Windows to let the installer set it itself.

I've tested that the Agent still runs while installing `6.8.0` and `6.10.0`.

Note that this PR doesn't change the behavior for the Agent 5.