### PR TITLE
Add a note on the future update to dependencies to remove chef-handler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ cookbook 'yum', '~> 3.0'
 
 (in Berkshelf/Librarian format)
 
+Please note that the `chef_handler` dependency **will be removed in chef-datadog
+4.0** because it has been included in Chef 14 itself.
+Thus, to continue using the datadog cookbook with Chef < 14, you will need
+to manually add the `chef_handler` cookbook in your dependencies.
+
 Recipes
 =======
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ cookbook 'yum', '~> 3.0'
 
 (in Berkshelf/Librarian format)
 
-Please note that the `chef_handler` dependency **will be removed in chef-datadog
-4.0** because it has been included in Chef 14 itself.
+Please note that the `chef_handler` dependency **has been removed in version
+4.0 of this cookbook** because it's included in Chef 14 itself.
 Thus, to continue using the datadog cookbook with Chef < 14, you will need
 to manually add the `chef_handler` cookbook in your dependencies.
 


### PR DESCRIPTION
`chef-handler` has been included in Chef 14 itself. As we'll still support Chef 13 in chef-datadog 3.0.0, we just add a notice about the future removal of the chef-handler dependency.