### PR TITLE
Agent v6 by default

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -4,16 +4,12 @@ driver:
   use_sudo: false
 
 platforms:
-  - name: ubuntu-16.04
   - name: ubuntu-14.04
   # Exclude this OS for now, due to some odd behavior with the NTP check on CircleCI systems.
   # See https://circleci.com/gh/DataDog/chef-datadog/19
   # and http://support.ntp.org/bin/view/Support/KnownOsIssues#Section_9.2.4.2.5.3.
   # - name: ubuntu-12.04
-  # Had to remove this one because the recipe tries to restart
-  # the Agent with Upstart (and that's correct) but Upstart is not supported
-  # in Docker containers.
-  # - name: centos-6.6
+  - name: centos-6.6
   - name: centos-7.7
   - name: debian-7.7
 

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -11,7 +11,7 @@ platforms:
   # - name: ubuntu-12.04
   - name: centos-6.6
   - name: centos-7.7
-  - name: debian-7.7
+  - name: debian-8.11
 
 suites:
 - name: dd-agent-handler

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -20,5 +20,7 @@ suites:
     - recipe[datadog::dd-agent]
   attributes:
     datadog:
+      # TODO(remy): run those tests with Agent v6 recipe.
+      agent6: false
       api_key: somenonnullapikeythats32charlong
       application_key: alsonotnil

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -4,12 +4,16 @@ driver:
   use_sudo: false
 
 platforms:
+  - name: ubuntu-16.04
   - name: ubuntu-14.04
   # Exclude this OS for now, due to some odd behavior with the NTP check on CircleCI systems.
   # See https://circleci.com/gh/DataDog/chef-datadog/19
   # and http://support.ntp.org/bin/view/Support/KnownOsIssues#Section_9.2.4.2.5.3.
   # - name: ubuntu-12.04
-  - name: centos-6.6
+  # Had to remove this one because the recipe tries to restart
+  # the Agent with Upstart (and that's correct) but Upstart is not supported
+  # in Docker containers.
+  # - name: centos-6.6
   - name: centos-7.7
   - name: debian-7.7
 

--- a/README.md
+++ b/README.md
@@ -200,8 +200,6 @@ Attributes are available to have finer control over how you install Agent v6:
 
 Please review the [attributes/default.rb](https://github.com/DataDog/chef-datadog/blob/master/attributes/default.rb) file (at the version of the cookbook you use) for the list and usage of the attributes used by the cookbook.
 
-Should you wish to add additional elements to the agent6 configuration file (typically `/etc/datadog-agent/datadog.yaml`) that are not directly available as attributes of the cookbook, you may use the `node['datadog']['extra_config']` attribute. This attribute is a hash and will be marshaled into the configuration file accordingly.
-
 For general information on the Datadog Agent v6, please refer to the [datadog-agent](https://github.com/DataDog/datadog-agent/) repo.
 
 ### Agent v5

--- a/README.md
+++ b/README.md
@@ -194,9 +194,9 @@ Attributes are available to have finer control over how you install Agent v6:
 
  * `agent6_version`: allows you to pin the agent version (recommended).
  * `agent6_package_action`: defaults to `'install'`, may be set to `'upgrade'` to automatically upgrade to latest (not recommended, we recommend pinning to a version with `agent6_version` and change that version to upgrade).
- * `aptrepo`: desired APT repo for the agent. Defaults to `http://apt.datadoghq.com`
- * `aptrepo_dist`: desired distribution for the APT repo. Defaults to `stable`
- * `yumrepo`: desired YUM repo for the agent. Defaults to `https://yum.datadoghq.com/stable/6/x86_64/`
+ * `agent6_aptrepo`: desired APT repo for the agent. Defaults to `http://apt.datadoghq.com`
+ * `agent6_aptrepo_dist`: desired distribution for the APT repo. Defaults to `stable`
+ * `agent6_yumrepo`: desired YUM repo for the agent. Defaults to `https://yum.datadoghq.com/stable/6/x86_64/`
 
 Please review the [attributes/default.rb](https://github.com/DataDog/chef-datadog/blob/master/attributes/default.rb) file (at the version of the cookbook you use) for the list and usage of the attributes used by the cookbook.
 

--- a/README.md
+++ b/README.md
@@ -194,9 +194,9 @@ Attributes are available to have finer control over how you install Agent v6:
 
  * `agent6_version`: allows you to pin the agent version (recommended).
  * `agent6_package_action`: defaults to `'install'`, may be set to `'upgrade'` to automatically upgrade to latest (not recommended, we recommend pinning to a version with `agent6_version` and change that version to upgrade).
- * `agent6_aptrepo`: desired APT repo for the agent. Defaults to `http://apt.datadoghq.com`
- * `agent6_aptrepo_dist`: desired distribution for the APT repo. Defaults to `stable`
- * `agent6_yumrepo`: desired YUM repo for the agent. Defaults to `https://yum.datadoghq.com/stable/6/x86_64/`
+ * `aptrepo`: desired APT repo for the agent. Defaults to `http://apt.datadoghq.com`
+ * `aptrepo_dist`: desired distribution for the APT repo. Defaults to `stable`
+ * `yumrepo`: desired YUM repo for the agent. Defaults to `https://yum.datadoghq.com/stable/6/x86_64/`
 
 Please review the [attributes/default.rb](https://github.com/DataDog/chef-datadog/blob/master/attributes/default.rb) file (at the version of the cookbook you use) for the list and usage of the attributes used by the cookbook.
 
@@ -206,7 +206,7 @@ For general information on the Datadog Agent v6, please refer to the [datadog-ag
 
 ### Agent v5
 
-Since `3.0.0`, this cookbook defaults installing Agent v6. You can still setup the Agent v5 by setting `node['datadog']['agent6']` to false.
+Since `3.0.0`, the cookbook defaults installing Agent v6. You can still setup the Agent v5 by setting `node['datadog']['agent6']` to false.
 
 ```
   default_attributes(
@@ -218,11 +218,9 @@ Since `3.0.0`, this cookbook defaults installing Agent v6. You can still setup t
 
 ### Agent v5 transitions
 
-Note that there are Agent v6 counterparts to several well known Agent v5 attributes (code [here](https://github.com/DataDog/chef-datadog/blob/master/attributes/default.rb#L31-L75))
-
 #### Upgrade from Agent v5 to Agent v6
 
-To upgrade from an already installed Agent 5 to Agent 6, you'll have to set the `agent6_package_action` to `upgrade` and we recommend to pin to a specific version:
+To upgrade from an already installed Agent v5 to Agent v6, you'll have to set the `agent6_package_action` to `upgrade` and we recommend to pin to a specific version:
 
 ```ruby
   default_attributes(
@@ -233,6 +231,8 @@ To upgrade from an already installed Agent 5 to Agent 6, you'll have to set the 
     }
   )
 ```
+
+Note that there are Agent v6 counterparts to several well known Agent v5 attributes (code [here](https://github.com/DataDog/chef-datadog/blob/master/attributes/default.rb#L31-L75))
 
 #### Downgrade from an installed Agent v6 to an Agent v5
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Chef recipes to deploy Datadog's components and configuration automatically.
 This cookbook includes support for:
 
 * Datadog Agent version 6.0 and up: please refer to
-the [dedicated section](#agent-v6) and the [inline docs](https://github.com/DataDog/chef-datadog/blob/v2.15.0/attributes/default.rb#L31-L75)
+the [dedicated section](#agent-v6) and the [inline docs](https://github.com/DataDog/chef-datadog/blob/v3.0.0/attributes/default.rb#L42-L76)
 for more details on how to use it
 * Datadog Agent version 5.x
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,10 @@ Chef recipes to deploy Datadog's components and configuration automatically.
 
 This cookbook includes support for:
 
-* Datadog Agent version 6.0 and up: please refer to
-the [dedicated section](#agent-v6) and the [inline docs](https://github.com/DataDog/chef-datadog/blob/v3.0.0/attributes/default.rb#L42-L76)
-for more details on how to use it
+* Datadog Agent version 6.x
 * Datadog Agent version 5.x
 
-**Log collection is now available with Agent v6, please refer to the [inline docs](https://github.com/DataDog/chef-datadog/blob/v2.15.0/attributes/default.rb#L383-L388) to enable it.**
+**Log collection is available with Agent v6, please refer to the [inline docs](https://github.com/DataDog/chef-datadog/blob/v3.0.0/attributes/default.rb#L401-L406) to enable it.**
 
 *Note: This README may refer to features that are not released yet. Please check the README of the
 git tag/the gem version you're using for your version's documentation*
@@ -164,7 +162,7 @@ This example enables the ElasticSearch integration by using the `datadog_monitor
 
 Note that the Agent installation needs to be earlier in the run list.
 
-```ruby
+```
 include_recipe 'datadog::dd-agent'
 
 datadog_monitor 'elastic'
@@ -174,14 +172,6 @@ end
 ```
 
 See `recipes/` for many examples using the `datadog_monitor` resource.
-
-Cookbook history
-================
-
-  - `>= 3.0.0`: the cookbook supports installing either Agent v5 or v6, defaulting to Agent v6.
-  - `>= 2.15.0`: add support to install either Agent v5 or Agent v6 on Windows, defaulting to Agent v5.
-  - `>= 2.14.0`: the cookbook supports installing either Agent v5 or Agent v6 on Linux, defaulting to Agent v5.
-  - `< 2.14.0`: the cookbook only supports Agent v5.
 
 Usage
 =====
@@ -201,6 +191,38 @@ Attributes are available to have finer control over how you install Agent v6:
 Please review the [attributes/default.rb](https://github.com/DataDog/chef-datadog/blob/master/attributes/default.rb) file (at the version of the cookbook you use) for the list and usage of the attributes used by the cookbook.
 
 For general information on the Datadog Agent v6, please refer to the [datadog-agent](https://github.com/DataDog/datadog-agent/) repo.
+
+#### Windows Agent v6 installation
+
+Starting with version `>= 6.11`, the Windows Agent v6 must be installed with datadog
+cookbook version `>= 2.18.0`.
+
+This is due to the Agent v6 running with an unprivileged user on Windows
+since 6.11. However, prior to 2.18.0, the datadog cookbook was enforcing
+Administrators privileges to the Datadog Agent directories and files.
+
+#### Extra configuration
+
+Should you wish to add additional elements to the Agent v6 configuration file
+(typically `datadog.yaml`) that are not directly available
+as attributes of the cookbook, you may use the `node['datadog']['extra_config']`
+attribute. This attribute is a hash and will be marshaled into the configuration
+file accordingly.
+
+E.g.
+
+ ```
+ default_attributes(
+   'datadog' => {
+     'extra_config' => {
+        'secret_backend_command' => '/sbin/local-secrets'
+     }
+   }
+ )
+ ```
+
+This example will set the field `secret_backend_command` in the configuration
+file `datadog.yaml`.
 
 ### Agent v5
 
@@ -225,7 +247,7 @@ To upgrade from an already installed Agent v5 to Agent v6, you'll have to set th
     'datadog' => {
       'agent6' => true,
       'agent6_version' => '1:6.10.0-1', # optional but recommended
-      'agent6_package_action' => 'upgrade',
+      'agent6_package_action' => 'install',
     }
   )
 ```
@@ -236,7 +258,7 @@ Note that there are Agent v6 counterparts to several well known Agent v5 attribu
 
 You will need to indicate that you want to setup an Agent v5 instead of v6, pin the Agent v5 version that you want to install and allow downgrade:
 
-```ruby
+```
   default_attributes(
     'datadog' => {
       'agent6' => false,
@@ -245,38 +267,6 @@ You will need to indicate that you want to setup an Agent v5 instead of v6, pin 
     }
   )
 ```
-
-#### Windows Agent v6 installation
-
-Starting with version `>= 6.11`, the Windows Agent v6 must be installed with datadog
-cookbook version `>= 2.18.0`.
-
-This is due to the Agent v6 running with an unprivileged user on Windows
-since 6.11. However, prior to 2.18.0, the datadog cookbook was enforcing
-Administrators privileges to the Datadog Agent directories and files.
-
-### Extra configuration
-
-Should you wish to add additional elements to the Agent v6 configuration file
-(typically `datadog.yaml`) that are not directly available
-as attributes of the cookbook, you may use the `node['datadog']['extra_config']`
-attribute. This attribute is a hash and will be marshaled into the configuration
-file accordingly.
-
-E.g.
-
- ```
- default_attributes(
-   'datadog' => {
-     'extra_config' => {
-        'secret_backend_command' => '/sbin/local-secrets'
-     }
-   }
- )
- ```
-
-This example will set the field `secret_backend_command` in the configuration
-file `datadog.yaml`.
 
 ### Instructions
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Chef recipes to deploy Datadog's components and configuration automatically.
 This cookbook includes support for:
 
 * Datadog Agent version 6.0 and up: please refer to
-the [dedicated section](#agent-6-support) and the [inline docs](https://github.com/DataDog/chef-datadog/blob/v2.15.0/attributes/default.rb#L31-L75)
+the [dedicated section](#agent-v6) and the [inline docs](https://github.com/DataDog/chef-datadog/blob/v2.15.0/attributes/default.rb#L31-L75)
 for more details on how to use it
 * Datadog Agent version 5.x
 
@@ -175,22 +175,23 @@ end
 
 See `recipes/` for many examples using the `datadog_monitor` resource.
 
+Cookbook history
+================
+
+  - `>= 3.0.0`: the cookbook supports installing either Agent v5 or v6, defaulting to Agent v6.
+  - `>= 2.15.0`: add support to install either Agent v5 or Agent v6 on Windows, defaulting to Agent v5.
+  - `>= 2.14.0`: the cookbook supports installing either Agent v5 or Agent v6 on Linux, defaulting to Agent v5.
+  - `< 2.14.0`: the cookbook only supports Agent v5.
+
 Usage
 =====
 
-### Agent 6 Support
-Please note the cookbook now supports installing both Agent v5 and Agent v6 of the Datadog Agent on Linux (since v2.14.0) and Windows (since v2.15.0). By default versions `<=2.x` of the cookbook will default to install Agent5, you may however override this behavior with the `node['datadog']['agent6']` attribute.
-  ```
-  default_attributes(
-    'datadog' => {
-      'agent6' => true
-    }
-  )
-  ```
+### Agent v6
 
-Note: to _upgrade_ to Agent 6 on a node with Agent 5 already installed, you also have to pin `agent6_version` to a v6 version (recommended), or set `agent6_package_action` to `'upgrade'`.
+By default, this cookbook installs Agent v6, if you want to install Agent v5, please refer to the Agent v5 section below.
 
-Additional attributes are available to have finer control over how you install Agent 6. These are Agent 6 counterparts to several well known Agent 5 attributes (code [here](https://github.com/DataDog/chef-datadog/blob/master/attributes/default.rb#L31-L75)):
+Attributes are available to have finer control over how you install Agent v6:
+
  * `agent6_version`: allows you to pin the agent version (recommended).
  * `agent6_package_action`: defaults to `'install'`, may be set to `'upgrade'` to automatically upgrade to latest (not recommended, we recommend pinning to a version with `agent6_version` and change that version to upgrade).
  * `agent6_aptrepo`: desired APT repo for the agent. Defaults to `http://apt.datadoghq.com`
@@ -201,13 +202,57 @@ Please review the [attributes/default.rb](https://github.com/DataDog/chef-datado
 
 Should you wish to add additional elements to the agent6 configuration file (typically `/etc/datadog-agent/datadog.yaml`) that are not directly available as attributes of the cookbook, you may use the `node['datadog']['extra_config']` attribute. This attribute is a hash and will be marshaled into the configuration file accordingly.
 
-For general information on the Datadog Agent 6, please refer to the [datadog-agent](https://github.com/DataDog/datadog-agent/) repo.
+For general information on the Datadog Agent v6, please refer to the [datadog-agent](https://github.com/DataDog/datadog-agent/) repo.
+
+### Agent v5
+
+Since `3.0.0`, this cookbook defaults installing Agent v6. You can still setup the Agent v5 by setting `node['datadog']['agent6']` to false.
+
+```
+  default_attributes(
+    'datadog' => {
+      'agent6' => false
+    }
+  )
+```
+
+### Agent v5 transitions
+
+Note that there are Agent v6 counterparts to several well known Agent v5 attributes (code [here](https://github.com/DataDog/chef-datadog/blob/master/attributes/default.rb#L31-L75))
+
+#### Upgrade from Agent v5 to Agent v6
+
+To upgrade from an already installed Agent 5 to Agent 6, you'll have to set the `agent6_package_action` to `upgrade` and we recommend to pin to a specific version:
+
+```ruby
+  default_attributes(
+    'datadog' => {
+      'agent6' => true,
+      'agent6_version' => '1:6.10.0-1', # optional but recommended
+      'agent6_package_action' => 'upgrade',
+    }
+  )
+```
+
+#### Downgrade from an installed Agent v6 to an Agent v5
+
+You will need to indicate that you want to setup an Agent v5 instead of v6, pin the Agent v5 version that you want to install and allow downgrade:
+
+```ruby
+  default_attributes(
+    'datadog' => {
+      'agent6' => false,
+      'agent_version' => '1:5.32.0-1',
+      'agent_allow_downgrade' => true
+    }
+  )
+```
 
 ### Instructions
 
 1. Add this cookbook to your Chef Server, either by installing with knife or by adding it to your Berksfile:
   ```
-  cookbook 'datadog', '~> 2.14.0'
+  cookbook 'datadog', '~> 3.0.0'
   ```
 2. Add your API Key either:
   * as a node attribute via an `environment` or `role`, or

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -52,13 +52,6 @@ default['datadog']['agent6'] = true
 default['datadog']['agent6_version'] = nil
 default['datadog']['agent6_package_action'] = 'install' # set to `upgrade` to always upgrade to latest
 
-# repos where datadog-agent v6 packages are available
-default['datadog']['agent6_aptrepo'] = 'http://apt.datadoghq.com'
-default['datadog']['agent6_aptrepo_dist'] = 'stable'
-# RPMs are only available for RHEL >= 6 (-> use https protocol) and x86_64 arch
-default['datadog']['agent6_yumrepo'] = 'https://yum.datadoghq.com/stable/6/x86_64/'
-default['datadog']['agent6_yumrepo_suse'] = 'https://yum.datadoghq.com/suse/stable/6/x86_64/'
-
 # Values that differ on Windows
 # The location of the config folder (containing conf.d)
 default['datadog']['agent6_config_dir'] =

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,15 +37,13 @@ default['datadog']['application_key'] = nil
 # * set node['datadog']['agent6'] to false, and
 # * pin node['datadog']['agent_version'] to an existing agent5 version, and
 # * set node['datadog']['agent_allow_downgrade'] to true
+# If you're installing a pre-release version of Agent 6 (beta or RC), you need to:
+# * on debian: set node['datadog']['agent6_aptrepo_dist'] to 'beta' instead of 'stable'
+# * on RHEL: set node['datadog']['agent6_yumrepo'] to 'https://yum.datadoghq.com/beta/x86_64/'
 default['datadog']['agent6'] = true
 
 ########################################################################
 ###                  Agent6-only attributes                          ###
-
-# If you're installing a pre-release version of Agent 6 (beta or RC), you need to:
-# * on debian: set node['datadog']['agent6_aptrepo_dist'] to 'beta' instead of 'stable'
-# * on RHEL: set node['datadog']['agent6_yumrepo'] to 'https://yum.datadoghq.com/beta/x86_64/'
-# In all cases, follow the instructions below:
 
 # Default of `nil` will install latest version, applies to agent6 only.
 # See documentation of `agent_version` attribute for allowed configuration format.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,15 +28,7 @@ default['datadog']['api_key'] = nil
 # Set it as an attribute, or on your node `run_state` under the key `['datadog']['application_key']`
 default['datadog']['application_key'] = nil
 
-########################################################################
-###                  Agent6-only attributes                          ###
-
-# If you're installing a pre-release version of Agent 6 (beta or RC), you need to:
-# * on debian: set node['datadog']['agent6_aptrepo_dist'] to 'beta' instead of 'stable'
-# * on RHEL: set node['datadog']['agent6_yumrepo'] to 'https://yum.datadoghq.com/beta/x86_64/'
-# In all cases, follow the instructions below:
-
-# Set node['datadog']['agent6'] to true to install an agent6 instead of agent5.
+# Set node['datadog']['agent6'] to false to install an agent5 instead of agent6.
 # To upgrade from agent5 to agent6, you need to:
 # * set node['datadog']['agent6'] to true, and
 # * either set node['datadog']['agent6_version'] to an existing agent6 version (recommended), or
@@ -45,7 +37,16 @@ default['datadog']['application_key'] = nil
 # * set node['datadog']['agent6'] to false, and
 # * pin node['datadog']['agent_version'] to an existing agent5 version, and
 # * set node['datadog']['agent_allow_downgrade'] to true
-default['datadog']['agent6'] = false
+default['datadog']['agent6'] = true
+
+########################################################################
+###                  Agent6-only attributes                          ###
+
+# If you're installing a pre-release version of Agent 6 (beta or RC), you need to:
+# * on debian: set node['datadog']['agent6_aptrepo_dist'] to 'beta' instead of 'stable'
+# * on RHEL: set node['datadog']['agent6_yumrepo'] to 'https://yum.datadoghq.com/beta/x86_64/'
+# In all cases, follow the instructions below:
+
 # Default of `nil` will install latest version, applies to agent6 only.
 # See documentation of `agent_version` attribute for allowed configuration format.
 default['datadog']['agent6_version'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -52,6 +52,13 @@ default['datadog']['agent6'] = true
 default['datadog']['agent6_version'] = nil
 default['datadog']['agent6_package_action'] = 'install' # set to `upgrade` to always upgrade to latest
 
+# repos where datadog-agent v6 packages are available
+default['datadog']['agent6_aptrepo'] = 'http://apt.datadoghq.com'
+default['datadog']['agent6_aptrepo_dist'] = 'stable'
+# RPMs are only available for RHEL >= 6 (-> use https protocol) and x86_64 arch
+default['datadog']['agent6_yumrepo'] = 'https://yum.datadoghq.com/stable/6/x86_64/'
+default['datadog']['agent6_yumrepo_suse'] = 'https://yum.datadoghq.com/suse/stable/6/x86_64/'
+
 # Values that differ on Windows
 # The location of the config folder (containing conf.d)
 default['datadog']['agent6_config_dir'] =

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -17,6 +17,28 @@
 # limitations under the License.
 #
 
+# agent6_aptrepo is not mentioned in the default attributes or in the README anymore
+# but it was a documented field prior to chef-datadog 3.0.0 so we have to support it
+# for a while.
+# The same goes for agent6_aptrepo_dist, agent6_yumrepo and agent6_yumrepo_suse.
+# Change done for chef-datadog 3.0.0
+apturi = node['datadog']['agent6_aptrepo'] ?
+                node['datadog']['agent6_aptrepo'] : node['datadog']['aptrepo']
+aptdist = node['datadog']['agent6_aptrepo_dist'] ?
+                node['datadog']['agent6_aptrepo_dist'] : node['datadog']['aptrepo_dist']
+
+yumrepo = node['datadog']['agent6'] ?
+                'https://yum.datadoghq.com/stable/6/x86_64/' :
+                '#{yum_protocol}://yum.datadoghq.com/rpm/#{architecture_map[node['kernel']['machine']]}/'
+yumrepo = node['datadog']['yumrepo'] unless node['datadog']['yumrepo'].nil?
+yumrepo = node['datadog']['agent6_yumrepo'] unless node['datadog']['agent6_yumrepo'].nil?
+
+yumrepo_suse = node['datadog']['agent6'] ?
+                'https://yum.datadoghq.com/suse/stable/6/x86_64/' :
+                '#{yum_protocol}://yum.datadoghq.com/suse/rpm/#{architecture_map[node['kernel']['machine']]}/'
+yumrepo_suse = node['datadog']['yumrepo_suse'] unless node['datadog']['yumrepo_suse'].nil?
+yumrepo_suse = node['datadog']['agent6_yumrepo_suse'] unless node['datadog']['agent6_yumrepo_suse'].nil?
+
 case node['platform_family']
 when 'debian'
   include_recipe 'apt'
@@ -26,8 +48,8 @@ when 'debian'
     action :install
   end
 
-  uri = node['datadog']['agent6'] ? node['datadog']['agent6_aptrepo'] : node['datadog']['aptrepo']
-  distribution = node['datadog']['agent6'] ? node['datadog']['agent6_aptrepo_dist'] : node['datadog']['aptrepo_dist']
+  uri = apturi
+  distribution = aptdist
   components = node['datadog']['agent6'] ? ['main', '6'] : ['main']
   retries = node['datadog']['aptrepo_retries']
   keyserver = node['datadog']['aptrepo_use_backup_keyserver'] ? node['datadog']['aptrepo_backup_keyserver'] : node['datadog']['aptrepo_keyserver']
@@ -75,11 +97,7 @@ when 'rhel', 'fedora', 'amazon'
   yum_repository 'datadog' do
     name 'datadog'
     description 'datadog'
-    if node['datadog']['agent6']
-      baseurl node['datadog']['agent6_yumrepo']
-    else
-      baseurl node['datadog']['yumrepo']
-    end
+    baseurl yumrepo
     proxy node['datadog']['yumrepo_proxy']
     proxy_username node['datadog']['yumrepo_proxy_username']
     proxy_password node['datadog']['yumrepo_proxy_password']
@@ -126,11 +144,7 @@ when 'suse'
   zypper_repository 'datadog' do
     name 'datadog'
     description 'datadog'
-    if node['datadog']['agent6']
-      baseurl node['datadog']['agent6_yumrepo_suse']
-    else
-      baseurl node['datadog']['yumrepo_suse']
-    end
+    baseurl yumrepo_suse
     gpgkey node['datadog']['yumrepo_gpgkey']
     gpgcheck false
     action :create

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -7,19 +7,20 @@ module EnvVar
   end
 end
 
-shared_examples_for 'datadog-agent-base' do
-  it_behaves_like 'common linux resources'
-
-  it 'installs the datadog-agent-base package' do
-    expect(chef_run).to install_package 'datadog-agent-base'
-  end
-
-  it 'does not install the datadog-agent package' do
-    expect(chef_run).not_to install_package 'datadog-agent'
-    expect(chef_run).not_to install_apt_package 'datadog-agent'
-    expect(chef_run).not_to install_yum_package 'datadog-agent'
-  end
-end
+# TODO(remy): remove this
+#shared_examples_for 'datadog-agent-base' do
+#  it_behaves_like 'common linux resources'
+#
+#  it 'installs the datadog-agent-base package' do
+#    expect(chef_run).to install_package 'datadog-agent-base'
+#  end
+#
+#  it 'does not install the datadog-agent package' do
+#    expect(chef_run).not_to install_package 'datadog-agent'
+#    expect(chef_run).not_to install_apt_package 'datadog-agent'
+#    expect(chef_run).not_to install_yum_package 'datadog-agent'
+#  end
+#end
 
 shared_examples_for 'repo recipe' do
   it 'includes the repository recipe' do
@@ -40,9 +41,11 @@ shared_examples_for 'rhellions no version set' do
 end
 
 shared_examples_for 'version set below 4.x' do
-  it_behaves_like 'common linux resources'
+  it_behaves_like 'common linux resources v5'
 
-  it_behaves_like 'datadog-agent-base'
+  # TODO(remy): remove this, we don't want to support Agent v4 for chef-d 3.0
+
+  # it_behaves_like 'datadog-agent-base'
 end
 
 describe 'datadog::dd-agent' do
@@ -184,6 +187,7 @@ describe 'datadog::dd-agent' do
         :version => '14.04'
       ) do |node|
         node.set['datadog'] = {
+          'agent6' => false,
           'api_key' => 'somethingnotnil',
           'agent_version' => '1:5.1.0-440'
         }
@@ -192,7 +196,10 @@ describe 'datadog::dd-agent' do
     end
 
     it_behaves_like 'repo recipe'
-    it_behaves_like 'debianoids no version set'
+    it_behaves_like 'common linux resources v5'
+    it 'installs the datadog-agent' do
+      expect(chef_run).to install_apt_package 'datadog-agent'
+    end
   end
 
   context 'version 4.x is set' do
@@ -202,6 +209,7 @@ describe 'datadog::dd-agent' do
         :version => '14.04'
       ) do |node|
         node.set['datadog'] = {
+          'agent6' => false,
           'api_key' => 'somethingnotnil',
           'agent_version' => '4.4.0-200'
         }
@@ -221,6 +229,7 @@ describe 'datadog::dd-agent' do
           :version => '14.04'
         ) do |node|
           node.set['datadog'] = {
+            'agent6' => false,
             'api_key' => 'somethingnotnil',
             'agent_version' => '1:5.9.0-1'
           }
@@ -241,6 +250,7 @@ describe 'datadog::dd-agent' do
           :file_cache_path => 'C:/chef/cache'
         ) do |node|
           node.set['datadog'] = {
+            'agent6' => false,
             'api_key' => 'somethingnotnil',
             'agent_version' => '5.10.1'
           }
@@ -249,7 +259,7 @@ describe 'datadog::dd-agent' do
 
       temp_file = ::File.join('C:/chef/cache', 'ddagent-cli.msi')
 
-      it_behaves_like 'windows Datadog Agent', :msi
+      it_behaves_like 'windows Datadog Agent v5', :msi
       # remote_file source gets converted to an array, so we need to do
       # some tricky things to be able to regex against it
       # Relevant: http://stackoverflow.com/a/12325983
@@ -260,6 +270,7 @@ describe 'datadog::dd-agent' do
     end
   end
 
+  # TODO(remy): something to do here?
   context 'allows a hash for agent version' do
     context 'when ubuntu' do
       cached(:chef_run) do
@@ -268,6 +279,7 @@ describe 'datadog::dd-agent' do
           :version => '14.04'
         ) do |node|
           node.set['datadog'] = {
+            'agent6' => false,
             'api_key' => 'somethingnotnil',
             'agent_version' => {
               'debian' => '1:5.9.0-1',
@@ -292,6 +304,7 @@ describe 'datadog::dd-agent' do
           :file_cache_path => 'C:/chef/cache'
         ) do |node|
           node.set['datadog'] = {
+            'agent6' => false,
             'api_key' => 'somethingnotnil',
             'agent_version' => {
               'debian' => '1:5.9.0-1',
@@ -304,7 +317,7 @@ describe 'datadog::dd-agent' do
 
       temp_file = ::File.join('C:/chef/cache', 'ddagent-cli.msi')
 
-      it_behaves_like 'windows Datadog Agent', :msi
+      it_behaves_like 'windows Datadog Agent v5', :msi
       # remote_file source gets converted to an array, so we need to do
       # some tricky things to be able to regex against it
       # Relevant: http://stackoverflow.com/a/12325983
@@ -322,6 +335,7 @@ describe 'datadog::dd-agent' do
           :version => '25'
         ) do |node|
           node.set['datadog'] = {
+            'agent6' => false,
             'api_key' => 'somethingnotnil',
             'agent_version' => {
               'debian' => '1:5.9.0-1',
@@ -344,6 +358,7 @@ describe 'datadog::dd-agent' do
           :version => '6.9'
         ) do |node|
           node.set['datadog'] = {
+            'agent6' => false,
             'api_key' => 'somethingnotnil',
             'agent_version' => {
               'debian' => '1:5.9.0-1',
@@ -367,7 +382,10 @@ describe 'datadog::dd-agent' do
           platform: 'ubuntu',
           version: '14.04'
         ) do |node|
-          node.set['datadog'] = { 'api_key' => 'somethingnotnil' }
+          node.set['datadog'] = { 
+            'agent6_version' => '1:6.8.0-1',
+            'api_key' => 'somethingnotnil'
+          }
           node.set['languages'] = { 'python' => { 'version' => '2.6.2' } }
         end.converge described_recipe
       end
@@ -382,7 +400,10 @@ describe 'datadog::dd-agent' do
           platform: 'ubuntu',
           version: '14.04'
         ) do |node|
-          node.set['datadog'] = { 'api_key' => 'somethingnotnil', 'agent_package_action' => :upgrade }
+          node.set['datadog'] = {
+            'api_key' => 'somethingnotnil',
+            'agent6_package_action' => :upgrade
+          }
           node.set['languages'] = { 'python' => { 'version' => '2.6.2' } }
         end.converge described_recipe
       end
@@ -395,6 +416,9 @@ describe 'datadog::dd-agent' do
     end
   end
 
+  # ----------------------
+  # Agent v5 configuration tests
+
   context 'datadog.conf configuration' do
     context 'allows a string for tags' do
       cached(:chef_run) do
@@ -403,6 +427,7 @@ describe 'datadog::dd-agent' do
           version: '14.04'
         ) do |node|
           node.set['datadog'] = {
+            'agent6' => false,
             'api_key' => 'somethingnotnil',
             'tags' => 'datacenter:us-foo,database:bar'
           }
@@ -410,7 +435,7 @@ describe 'datadog::dd-agent' do
         end.converge described_recipe
       end
 
-      it_behaves_like 'common linux resources'
+      it_behaves_like 'common linux resources v5'
 
       it 'sets tags from the tags attribute' do
         expect(chef_run).to render_file('/etc/dd-agent/datadog.conf')
@@ -425,6 +450,7 @@ describe 'datadog::dd-agent' do
           version: '14.04'
         ) do |node|
           node.set['datadog'] = {
+            'agent6' => false,
             'api_key' => 'somethingnotnil',
             'tags' => { 'datacenter' => 'us-foo', 'database' => 'bar' }
           }
@@ -432,7 +458,7 @@ describe 'datadog::dd-agent' do
         end.converge described_recipe
       end
 
-      it_behaves_like 'common linux resources'
+      it_behaves_like 'common linux resources v5'
 
       it 'sets tags from the tags attribute' do
         expect(chef_run).to render_file('/etc/dd-agent/datadog.conf')
@@ -447,6 +473,7 @@ describe 'datadog::dd-agent' do
           version: '14.04'
         ) do |node|
           node.set['datadog'] = {
+            'agent6' => false,
             'api_key' => 'somethingnotnil',
             'tags' => { 'datacenter' => 'us-foo', 'database' => '' }
           }
@@ -454,7 +481,7 @@ describe 'datadog::dd-agent' do
         end.converge described_recipe
       end
 
-      it_behaves_like 'common linux resources'
+      it_behaves_like 'common linux resources v5'
 
       it 'sets tags from the tags attribute' do
         expect(chef_run).to render_file('/etc/dd-agent/datadog.conf')
@@ -469,6 +496,7 @@ describe 'datadog::dd-agent' do
           version: '14.04'
         ) do |node|
           node.set['datadog'] = {
+            'agent6' => false,
             'api_key' => 'something1',
             'url' => 'https://app.example.com',
             'extra_endpoints' => {
@@ -483,7 +511,7 @@ describe 'datadog::dd-agent' do
         end.converge described_recipe
       end
 
-      it_behaves_like 'common linux resources'
+      it_behaves_like 'common linux resources v5'
 
       it 'uses the multiples apikeys and urls' do
         expect(chef_run).to render_file('/etc/dd-agent/datadog.conf')
@@ -499,6 +527,7 @@ describe 'datadog::dd-agent' do
           version: '14.04'
         ) do |node|
           node.set['datadog'] = {
+            'agent6' => false,
             'api_key' => 'something1',
             'url' => 'https://app.example.com',
             'extra_endpoints' => {
@@ -512,7 +541,7 @@ describe 'datadog::dd-agent' do
         end.converge described_recipe
       end
 
-      it_behaves_like 'common linux resources'
+      it_behaves_like 'common linux resources v5'
 
       it 'uses the multiples apikeys and urls' do
         expect(chef_run).to render_file('/etc/dd-agent/datadog.conf')
@@ -543,6 +572,7 @@ describe 'datadog::dd-agent' do
           version: '14.04'
         ) do |node|
           node.set['datadog'] = {
+            'agent6' => false,
             'api_key' => 'as_node_attribute',
             'url' => 'https://app.example.com'
           }
@@ -551,7 +581,7 @@ describe 'datadog::dd-agent' do
         end.converge described_recipe
       end
 
-      it_behaves_like 'common linux resources'
+      it_behaves_like 'common linux resources v5'
 
       it 'uses the api_key from the run_state' do
         expect(chef_run).to render_file('/etc/dd-agent/datadog.conf')
@@ -569,11 +599,14 @@ describe 'datadog::dd-agent' do
           version: '14.04'
         ) do |node|
           node.set['languages'] = { 'python' => { 'version' => '2.6.2' } }
-          node.run_state['datadog'] = { 'api_key' => 'on_run_state' }
+          node.set['datadog'] = { 'agent6' => false }
+          node.run_state['datadog'] = {
+            'api_key' => 'on_run_state'
+          }
         end.converge described_recipe
       end
 
-      it_behaves_like 'common linux resources'
+      it_behaves_like 'common linux resources v5'
 
       it 'uses the api_key from the run_state' do
         expect(chef_run).to render_file('/etc/dd-agent/datadog.conf')
@@ -589,6 +622,7 @@ describe 'datadog::dd-agent' do
         version: '14.04'
       ) do |node|
         node.set['datadog'] = {
+          'agent6' => false,
           'api_key' => 'something1',
           'url' => 'https://app.example.com',
           'extra_config' => {
@@ -601,7 +635,7 @@ describe 'datadog::dd-agent' do
       end.converge described_recipe
     end
 
-    it_behaves_like 'common linux resources'
+    it_behaves_like 'common linux resources v5'
 
     it 'uses the multiples apikeys and urls' do
       expect(chef_run).to render_file('/etc/dd-agent/datadog.conf')
@@ -613,6 +647,9 @@ describe 'datadog::dd-agent' do
         .with_content(/^no_example_key:/)
     end
   end
+
+  # End of Agent v5 configuration tests
+  # ----------------------
 
   context 'package downgrade' do
     context 'left to default' do

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -8,19 +8,17 @@ module EnvVar
 end
 
 # TODO(remy): remove this
-#shared_examples_for 'datadog-agent-base' do
-#  it_behaves_like 'common linux resources'
-#
-#  it 'installs the datadog-agent-base package' do
-#    expect(chef_run).to install_package 'datadog-agent-base'
+#  shared_examples_for 'datadog-agent-base' do
+#    it_behaves_like 'common linux resources'
+#    it 'installs the datadog-agent-base package' do
+#      expect(chef_run).to install_package 'datadog-agent-base'
+#    end
+#    it 'does not install the datadog-agent package' do
+#      expect(chef_run).not_to install_package 'datadog-agent'
+#      expect(chef_run).not_to install_apt_package 'datadog-agent'
+#      expect(chef_run).not_to install_yum_package 'datadog-agent'
+#    end
 #  end
-#
-#  it 'does not install the datadog-agent package' do
-#    expect(chef_run).not_to install_package 'datadog-agent'
-#    expect(chef_run).not_to install_apt_package 'datadog-agent'
-#    expect(chef_run).not_to install_yum_package 'datadog-agent'
-#  end
-#end
 
 shared_examples_for 'repo recipe' do
   it 'includes the repository recipe' do
@@ -42,10 +40,6 @@ end
 
 shared_examples_for 'version set below 4.x' do
   it_behaves_like 'common linux resources v5'
-
-  # TODO(remy): remove this, we don't want to support Agent v4 for chef-d 3.0
-
-  # it_behaves_like 'datadog-agent-base'
 end
 
 describe 'datadog::dd-agent' do
@@ -382,7 +376,7 @@ describe 'datadog::dd-agent' do
           platform: 'ubuntu',
           version: '14.04'
         ) do |node|
-          node.set['datadog'] = { 
+          node.set['datadog'] = {
             'agent6_version' => '1:6.8.0-1',
             'api_key' => 'somethingnotnil'
           }

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -264,7 +264,7 @@ describe 'datadog::dd-agent' do
     end
   end
 
-  # TODO(remy): remove Agent v4 occurrences + needs some clean-up
+  # TODO(remy): something to do here?
   context 'allows a hash for agent version' do
     context 'when ubuntu' do
       cached(:chef_run) do
@@ -277,12 +277,9 @@ describe 'datadog::dd-agent' do
             'api_key' => 'somethingnotnil',
             'agent_version' => {
               'debian' => '1:5.9.0-1',
+              'rhel' => '4.4.0-200',
               'windows' => '4.4.0'
-            },
-            'agent6_version' => {
-              'rhel' => '1:6.9.0-1'
             }
-
           }
         end.converge described_recipe
       end
@@ -305,12 +302,9 @@ describe 'datadog::dd-agent' do
             'api_key' => 'somethingnotnil',
             'agent_version' => {
               'debian' => '1:5.9.0-1',
+              'rhel' => '4.4.0-200',
               'windows' => '4.4.0'
-            },
-            'agent6_version' => {
-              'rhel' => '1:6.9.0-1'
             }
-
           }
         end.converge described_recipe
       end
@@ -335,21 +329,19 @@ describe 'datadog::dd-agent' do
           :version => '25'
         ) do |node|
           node.set['datadog'] = {
-            'agent6' => true,
+            'agent6' => false,
             'api_key' => 'somethingnotnil',
             'agent_version' => {
               'debian' => '1:5.9.0-1',
+              'rhel' => '4.4.0-200',
               'windows' => '4.4.0'
-            },
-            'agent6_version' => {
-              'rhel' => '1:6.9.0-1'
             }
           }
         end.converge described_recipe
       end
 
       it 'installs agent 4.4.0-200' do
-        expect(chef_run).to install_package('datadog-agent').with(version: '1:6.9.0-1')
+        expect(chef_run).to install_package('datadog-agent').with(version: '4.4.0-200')
       end
     end
 
@@ -360,22 +352,19 @@ describe 'datadog::dd-agent' do
           :version => '6.9'
         ) do |node|
           node.set['datadog'] = {
-            'agent6' => true,
+            'agent6' => false,
             'api_key' => 'somethingnotnil',
             'agent_version' => {
               'debian' => '1:5.9.0-1',
+              'rhel' => '4.4.0-200',
               'windows' => '4.4.0'
-            },
-            'agent6_version' => {
-              'rhel' => '1:6.9.0-1'
             }
-
           }
         end.converge described_recipe
       end
 
       it 'installs agent 4.4.0-200' do
-        expect(chef_run).to install_package('datadog-agent').with(version: '1:6.9.0-1')
+        expect(chef_run).to install_package('datadog-agent').with(version: '4.4.0-200')
       end
     end
   end

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -264,7 +264,7 @@ describe 'datadog::dd-agent' do
     end
   end
 
-  # TODO(remy): something to do here?
+  # TODO(remy): remove Agent v4 occurrences + needs some clean-up
   context 'allows a hash for agent version' do
     context 'when ubuntu' do
       cached(:chef_run) do
@@ -277,9 +277,12 @@ describe 'datadog::dd-agent' do
             'api_key' => 'somethingnotnil',
             'agent_version' => {
               'debian' => '1:5.9.0-1',
-              'rhel' => '4.4.0-200',
               'windows' => '4.4.0'
+            },
+            'agent6_version' => {
+              'rhel' => '1:6.9.0-1'
             }
+
           }
         end.converge described_recipe
       end
@@ -302,9 +305,12 @@ describe 'datadog::dd-agent' do
             'api_key' => 'somethingnotnil',
             'agent_version' => {
               'debian' => '1:5.9.0-1',
-              'rhel' => '4.4.0-200',
               'windows' => '4.4.0'
+            },
+            'agent6_version' => {
+              'rhel' => '1:6.9.0-1'
             }
+
           }
         end.converge described_recipe
       end
@@ -329,19 +335,21 @@ describe 'datadog::dd-agent' do
           :version => '25'
         ) do |node|
           node.set['datadog'] = {
-            'agent6' => false,
+            'agent6' => true,
             'api_key' => 'somethingnotnil',
             'agent_version' => {
               'debian' => '1:5.9.0-1',
-              'rhel' => '4.4.0-200',
               'windows' => '4.4.0'
+            },
+            'agent6_version' => {
+              'rhel' => '1:6.9.0-1'
             }
           }
         end.converge described_recipe
       end
 
       it 'installs agent 4.4.0-200' do
-        expect(chef_run).to install_package('datadog-agent').with(version: '4.4.0-200')
+        expect(chef_run).to install_package('datadog-agent').with(version: '1:6.9.0-1')
       end
     end
 
@@ -352,19 +360,22 @@ describe 'datadog::dd-agent' do
           :version => '6.9'
         ) do |node|
           node.set['datadog'] = {
-            'agent6' => false,
+            'agent6' => true,
             'api_key' => 'somethingnotnil',
             'agent_version' => {
               'debian' => '1:5.9.0-1',
-              'rhel' => '4.4.0-200',
               'windows' => '4.4.0'
+            },
+            'agent6_version' => {
+              'rhel' => '1:6.9.0-1'
             }
+
           }
         end.converge described_recipe
       end
 
       it 'installs agent 4.4.0-200' do
-        expect(chef_run).to install_package('datadog-agent').with(version: '4.4.0-200')
+        expect(chef_run).to install_package('datadog-agent').with(version: '1:6.9.0-1')
       end
     end
   end

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -7,19 +7,6 @@ module EnvVar
   end
 end
 
-# TODO(remy): remove this
-#  shared_examples_for 'datadog-agent-base' do
-#    it_behaves_like 'common linux resources'
-#    it 'installs the datadog-agent-base package' do
-#      expect(chef_run).to install_package 'datadog-agent-base'
-#    end
-#    it 'does not install the datadog-agent package' do
-#      expect(chef_run).not_to install_package 'datadog-agent'
-#      expect(chef_run).not_to install_apt_package 'datadog-agent'
-#      expect(chef_run).not_to install_yum_package 'datadog-agent'
-#    end
-#  end
-
 shared_examples_for 'repo recipe' do
   it 'includes the repository recipe' do
     expect(chef_run).to include_recipe('datadog::repository')
@@ -264,7 +251,7 @@ describe 'datadog::dd-agent' do
     end
   end
 
-  # TODO(remy): something to do here?
+  # TODO(remy): removes occurrences of Agent V4 + add some tests for Agent v6
   context 'allows a hash for agent version' do
     context 'when ubuntu' do
       cached(:chef_run) do

--- a/spec/integrations/activemq_spec.rb
+++ b/spec/integrations/activemq_spec.rb
@@ -93,7 +93,7 @@ describe 'datadog::activemq' do
   it { is_expected.to add_datadog_monitor('activemq') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/activemq.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/activemq.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/cassandra_spec.rb
+++ b/spec/integrations/cassandra_spec.rb
@@ -157,7 +157,7 @@ describe 'datadog::cassandra' do
     it { is_expected.to add_datadog_monitor('cassandra') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/dd-agent/conf.d/cassandra.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/cassandra.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end
@@ -357,7 +357,7 @@ describe 'datadog::cassandra' do
     it { is_expected.to add_datadog_monitor('cassandra') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/dd-agent/conf.d/cassandra.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/cassandra.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end
@@ -831,7 +831,7 @@ describe 'datadog::cassandra' do
     it { is_expected.to add_datadog_monitor('cassandra') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/dd-agent/conf.d/cassandra.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/cassandra.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end

--- a/spec/integrations/couchbase_spec.rb
+++ b/spec/integrations/couchbase_spec.rb
@@ -36,7 +36,7 @@ describe 'datadog::couchbase' do
   it { is_expected.to add_datadog_monitor('couchbase') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/couchbase.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/couchbase.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/directory_spec.rb
+++ b/spec/integrations/directory_spec.rb
@@ -44,7 +44,7 @@ EOF
   it { is_expected.to add_datadog_monitor('directory') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/directory.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/directory.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/disk_spec.rb
+++ b/spec/integrations/disk_spec.rb
@@ -47,7 +47,7 @@ describe 'datadog::disk' do
   it { is_expected.to add_datadog_monitor('disk') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/disk.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/disk.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(
         YAML.safe_load(expected_yaml).to_json
       )

--- a/spec/integrations/dns_check_spec.rb
+++ b/spec/integrations/dns_check_spec.rb
@@ -52,7 +52,7 @@ describe 'datadog::dns_check' do
   it { is_expected.to add_datadog_monitor('dns_check') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/dns_check.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/dns_check.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/docker_daemon_spec.rb
+++ b/spec/integrations/docker_daemon_spec.rb
@@ -106,7 +106,7 @@ describe 'datadog::docker_daemon' do
   it { is_expected.to manage_group('docker').with(append: true, members: ['dd-agent']) }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/docker_daemon.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/docker_daemon.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/elasticsearch_spec.rb
+++ b/spec/integrations/elasticsearch_spec.rb
@@ -44,7 +44,7 @@ describe 'datadog::elasticsearch' do
   it { is_expected.to add_datadog_monitor('elastic') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/elastic.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/elastic.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/etcd_spec.rb
+++ b/spec/integrations/etcd_spec.rb
@@ -43,7 +43,7 @@ describe 'datadog::etcd' do
   it { is_expected.to add_datadog_monitor('etcd') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/etcd.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/etcd.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/go-metro_spec.rb
+++ b/spec/integrations/go-metro_spec.rb
@@ -80,7 +80,7 @@ describe 'datadog::go-metro' do
 
     it 'renders expected YAML config file' do
       expect(chef_run).to(
-        render_file('/etc/dd-agent/conf.d/go-metro.yaml')
+        render_file('/etc/datadog-agent/conf.d/go-metro.yaml')
         .with_content { |content|
           expect(YAML.safe_load(content).to_json).to be_json_eql(
             YAML.safe_load(expected_yaml).to_json
@@ -174,7 +174,7 @@ describe 'datadog::go-metro' do
 
     it 'renders expected YAML config file' do
       expect(chef_run).to(
-        render_file('/etc/dd-agent/conf.d/go-metro.yaml')
+        render_file('/etc/datadog-agent/conf.d/go-metro.yaml')
         .with_content { |content|
           expect(YAML.safe_load(content).to_json).to be_json_eql(
             YAML.safe_load(expected_yaml).to_json

--- a/spec/integrations/go_expvar_spec.rb
+++ b/spec/integrations/go_expvar_spec.rb
@@ -53,7 +53,7 @@ describe 'datadog::go_expvar' do
   it { is_expected.to add_datadog_monitor('go_expvar') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/go_expvar.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/go_expvar.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/gunicorn_spec.rb
+++ b/spec/integrations/gunicorn_spec.rb
@@ -33,7 +33,7 @@ describe 'datadog::gunicorn' do
   it { is_expected.to add_datadog_monitor('gunicorn') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/gunicorn.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/gunicorn.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/iis_spec.rb
+++ b/spec/integrations/iis_spec.rb
@@ -42,7 +42,7 @@ describe 'datadog::iis' do
   it { is_expected.to add_datadog_monitor('iis') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/iis.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/iis.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/integrations_spec.rb
+++ b/spec/integrations/integrations_spec.rb
@@ -34,7 +34,7 @@ describe 'datadog::integrations' do
   it { is_expected.to add_datadog_monitor('twemproxy') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/twemproxy.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/twemproxy.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/jmx_spec.rb
+++ b/spec/integrations/jmx_spec.rb
@@ -91,7 +91,7 @@ describe 'datadog::jmx' do
   it { is_expected.to add_datadog_monitor('jmx') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/jmx.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/jmx.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/kafka_spec.rb
+++ b/spec/integrations/kafka_spec.rb
@@ -184,7 +184,7 @@ describe 'datadog::kafka' do
     it { is_expected.to add_datadog_monitor('kafka') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/dd-agent/conf.d/kafka.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/kafka.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end
@@ -609,7 +609,7 @@ describe 'datadog::kafka' do
     it { is_expected.to add_datadog_monitor('kafka') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/dd-agent/conf.d/kafka.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/kafka.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end

--- a/spec/integrations/kubernetes_spec.rb
+++ b/spec/integrations/kubernetes_spec.rb
@@ -43,7 +43,7 @@ describe 'datadog::kubernetes' do
   it { is_expected.to add_datadog_monitor('kubernetes') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/kubernetes.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/kubernetes.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/mongo_spec.rb
+++ b/spec/integrations/mongo_spec.rb
@@ -37,7 +37,7 @@ describe 'datadog::mongo' do
   it { is_expected.to add_datadog_monitor('mongo') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/mongo.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/mongo.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/nginx_spec.rb
+++ b/spec/integrations/nginx_spec.rb
@@ -48,7 +48,7 @@ describe 'datadog::nginx' do
   it { is_expected.to add_datadog_monitor('nginx') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/nginx.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/nginx.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/php_fpm_spec.rb
+++ b/spec/integrations/php_fpm_spec.rb
@@ -61,7 +61,7 @@ describe 'datadog::php_fpm' do
   it { is_expected.to add_datadog_monitor('php_fpm') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/php_fpm.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/php_fpm.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/postfix_spec.rb
+++ b/spec/integrations/postfix_spec.rb
@@ -54,7 +54,7 @@ describe 'datadog::postfix' do
   it { is_expected.to add_datadog_monitor('postfix') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/postfix.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/postfix.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/postgres_spec.rb
+++ b/spec/integrations/postgres_spec.rb
@@ -102,7 +102,7 @@ describe 'datadog::postgres' do
   it { is_expected.to add_datadog_monitor('postgres') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/postgres.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/postgres.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end
@@ -146,7 +146,7 @@ describe 'datadog::postgres' do
     it { is_expected.to add_datadog_monitor('postgres') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/dd-agent/conf.d/postgres.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/postgres.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end
@@ -201,7 +201,7 @@ describe 'datadog::postgres' do
     it { is_expected.to add_datadog_monitor('postgres') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/dd-agent/conf.d/postgres.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/postgres.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end
@@ -290,7 +290,7 @@ describe 'datadog::postgres' do
     it { is_expected.to add_datadog_monitor('postgres') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/dd-agent/conf.d/postgres.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/postgres.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end

--- a/spec/integrations/rabbitmq_spec.rb
+++ b/spec/integrations/rabbitmq_spec.rb
@@ -61,7 +61,7 @@ describe 'datadog::rabbitmq' do
   it { is_expected.to add_datadog_monitor('rabbitmq') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/rabbitmq.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/rabbitmq.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/redis_spec.rb
+++ b/spec/integrations/redis_spec.rb
@@ -58,7 +58,7 @@ describe 'datadog::redisdb' do
   it { is_expected.to add_datadog_monitor('redisdb') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/redisdb.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/redisdb.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/snmp_spec.rb
+++ b/spec/integrations/snmp_spec.rb
@@ -139,7 +139,7 @@ describe 'datadog::snmp' do
     it { is_expected.to add_datadog_monitor('snmp') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/dd-agent/conf.d/snmp.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/snmp.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end
@@ -219,7 +219,7 @@ describe 'datadog::snmp' do
     it { is_expected.to add_datadog_monitor('snmp') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/dd-agent/conf.d/snmp.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/snmp.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end

--- a/spec/integrations/solr_spec.rb
+++ b/spec/integrations/solr_spec.rb
@@ -111,7 +111,7 @@ describe 'datadog::solr' do
   it { is_expected.to add_datadog_monitor('solr') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/solr.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/solr.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/sqlserver_spec.rb
+++ b/spec/integrations/sqlserver_spec.rb
@@ -76,7 +76,7 @@ describe 'datadog::sqlserver' do
     it { is_expected.to add_datadog_monitor('sqlserver') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/dd-agent/conf.d/sqlserver.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/sqlserver.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end
@@ -133,7 +133,7 @@ describe 'datadog::sqlserver' do
     it { is_expected.to add_datadog_monitor('sqlserver') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/dd-agent/conf.d/sqlserver.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/sqlserver.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end

--- a/spec/integrations/system_core_spec.rb
+++ b/spec/integrations/system_core_spec.rb
@@ -28,7 +28,7 @@ describe 'datadog::system_core' do
   it { is_expected.to add_datadog_monitor('system_core') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/system_core.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/system_core.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/system_swap_spec.rb
+++ b/spec/integrations/system_swap_spec.rb
@@ -27,7 +27,7 @@ describe 'datadog::system_swap' do
   it { is_expected.to add_datadog_monitor('system_swap') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/system_swap.yaml')
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/system_swap.yaml')
       .with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })

--- a/spec/integrations/tokumx_spec.rb
+++ b/spec/integrations/tokumx_spec.rb
@@ -37,7 +37,7 @@ describe 'datadog::tokumx' do
   it { is_expected.to add_datadog_monitor('tokumx') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/tokumx.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/tokumx.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/win32_event_log_spec.rb
+++ b/spec/integrations/win32_event_log_spec.rb
@@ -50,7 +50,7 @@ describe 'datadog::win32_event_log' do
   it { is_expected.to add_datadog_monitor('win32_event_log') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/win32_event_log.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/win32_event_log.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/windows_service_spec.rb
+++ b/spec/integrations/windows_service_spec.rb
@@ -42,7 +42,7 @@ describe 'datadog::windows_service' do
   it { is_expected.to add_datadog_monitor('windows_service') }
 
   it 'renders expected YAML config file for remote host service monitoring' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/windows_service.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/windows_service.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end
@@ -88,7 +88,7 @@ describe 'datadog::windows_service' do
   it { is_expected.to add_datadog_monitor('windows_service') }
 
   it 'renders expected YAML config file for local host service monitoring' do
-    expect(chef_run).to(render_file('/etc/dd-agent/conf.d/windows_service.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/windows_service.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/wmi_check_spec.rb
+++ b/spec/integrations/wmi_check_spec.rb
@@ -152,7 +152,7 @@ describe 'datadog::wmi_check' do
     it { is_expected.to add_datadog_monitor('wmi_check') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/dd-agent/conf.d/wmi_check.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/wmi_check.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -46,14 +46,8 @@ shared_examples_for 'common linux resources' do
   end
 end
 
-
 shared_examples_for 'datadog-agent' do
   it_behaves_like 'common linux resources'
-
-  # TODO(remy): should we test this?
-  #it 'removes the datadog-agent-base package' do
-  #  expect(chef_run).to remove_package 'datadog-agent-base'
-  #end
 end
 
 shared_examples_for 'debianoids datadog-agent' do

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -14,7 +14,8 @@ shared_examples_for 'datadog conf' do
   end
 end
 
-shared_examples_for 'common linux resources' do
+# Common linux resources for Agent v5, see 'common linux resources' for Agent v6
+shared_examples_for 'common linux resources v5' do
   it_behaves_like 'datadog-agent service'
   it_behaves_like 'datadog conf'
 
@@ -31,12 +32,28 @@ shared_examples_for 'common linux resources' do
   end
 end
 
+# Common linux resources for Agent v6, see 'common linux resource v5' for Agent v5
+shared_examples_for 'common linux resources' do
+  it_behaves_like 'datadog-agent service'
+  it_behaves_like 'datadog conf'
+
+  it 'includes the repository recipe' do
+    expect(chef_run).to include_recipe('datadog::repository')
+  end
+
+  it 'drops an agent config file' do
+    expect(chef_run).to create_template '/etc/datadog-agent/datadog.yaml'
+  end
+end
+
+
 shared_examples_for 'datadog-agent' do
   it_behaves_like 'common linux resources'
 
-  it 'removes the datadog-agent-base package' do
-    expect(chef_run).to remove_package 'datadog-agent-base'
-  end
+  # TODO(remy): should we test this?
+  #it 'removes the datadog-agent-base package' do
+  #  expect(chef_run).to remove_package 'datadog-agent-base'
+  #end
 end
 
 shared_examples_for 'debianoids datadog-agent' do
@@ -59,6 +76,19 @@ shared_examples_for 'common windows resources' do
   it_behaves_like 'datadog-agent service'
   it_behaves_like 'datadog conf'
 
+  it 'drops an agent config file' do
+    expect(chef_run).to create_template 'C:\ProgramData/Datadog/datadog.yaml'
+  end
+
+  it 'does not render a go-metro log config' do
+    expect(chef_run).to_not render_file('C:\ProgramData/Datadog/datadog.yaml').with_content(/^go-metro_log_file.*$/)
+  end
+end
+
+shared_examples_for 'common windows resources v5' do
+  it_behaves_like 'datadog-agent service'
+  it_behaves_like 'datadog conf'
+
   it 'ensures the Datadog config directory exists' do
     expect(chef_run).to create_directory 'C:\ProgramData/Datadog'
   end
@@ -69,6 +99,29 @@ shared_examples_for 'common windows resources' do
 
   it 'does not render a go-metro log config' do
     expect(chef_run).to_not render_file('C:\ProgramData/Datadog/datadog.conf').with_content(/^go-metro_log_file.*$/)
+  end
+end
+
+shared_examples_for 'windows Datadog Agent v5' do |installer_extension|
+  it_behaves_like 'common windows resources v5'
+
+  agent_installer = "C:/chef/cache/ddagent-cli.#{installer_extension}"
+
+  it 'downloads the remote file only if it\'s changed' do
+    expect(chef_run).to create_remote_file(agent_installer)
+  end
+
+  it 'doesn\'t remove existing version of the Datadog Agent by default' do
+    expect(chef_run.package('Datadog Agent removal')).to do_nothing
+  end
+
+  it 'notifies the removal of the Datadog Agent when a remote file is downloaded' do
+    expect(chef_run.remote_file(agent_installer)).to notify('package[Datadog Agent removal]').to(:remove)
+  end
+
+  it 'installs Datadog Agent' do
+    installer_type = installer_extension == :msi ? :msi : :custom
+    expect(chef_run).to install_windows_package('Datadog Agent').with(installer_type: installer_type)
   end
 end
 


### PR DESCRIPTION
Agent v6 will now be installed by default.
  - README updated (for example a complete section on how to v5 -> v6 or v6 -> v5 has been added)
  - Some things moved/changed in `default/attributes.rb` to reflect this changes.
  - Update the tests:
      - CircleCI will still run for Agent v5
      - Spec tests have been partially updated: some were testing Agent v5 only, an extra effort could be done to add some for Agent v6, some were already added for Agent v6 directly.