### PR TITLE
Support jmx_custom_jars datadog.conf option

### DIFF
--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -90,6 +90,12 @@ sd_template_dir: <%= node['datadog']['sd_template_dir'] %>
 
 # Enable JMX checks for service discovery
 sd_jmx_enable: <%= node['datadog']['sd_jmx_enable'] %>
+
+<% if node['datadog']['jmx_custom_jars'] %>
+# If you require custom jars to be loaded for JMX checks, you can set their paths here
+# instead of setting them in the checks' custom_jar_paths option
+jmx_custom_jars: <%= node['datadog']['jmx_custom_jars'] %>
+<% end -%>
 <% end -%>
 
 <% if node['datadog']['dogstatsd'] -%>


### PR DESCRIPTION
As remediation for DataDog support ticket #209172, I was pointed at
DataDog/dd-agent/pull/3648 to set `jmx_custom_jars` in `datadog.conf`,
which is not supported by the current template. Patch the template to
support this option.

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>