### PR TITLE
Add datadog_integration resource to install integrations.

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -11,7 +11,7 @@ platforms:
   # - name: ubuntu-12.04
   - name: centos-6.6
   - name: centos-7.7
-  - name: debian-7.7
+  - name: debian-8.11
 
 suites:
 - name: dd-agent-handler

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The `:remove` action disables an integration.
 
 ### Syntax
 
-```ruby
+```
 datadog_monitor 'name' do
   init_config                       Hash # default value: {}
   instances                         Array # default value: []
@@ -164,7 +164,7 @@ This example enables the ElasticSearch integration by using the `datadog_monitor
 
 Note that the Agent installation needs to be earlier in the run list.
 
-```ruby
+```
 include_recipe 'datadog::dd-agent'
 
 datadog_monitor 'elastic'
@@ -174,6 +174,56 @@ end
 ```
 
 See `recipes/` for many examples using the `datadog_monitor` resource.
+
+datadog_integration
+---------------
+
+The `datadog_integration` resource will help you to install specific versions
+of Datadog integrations.
+
+The default action `:install` installs the integration on the node using the
+`agent integration install` command.
+
+The `:remove` action removes an integration from the node using the `agent
+integration remove` command.
+
+### Syntax
+
+```
+datadog_integration 'name' do
+  version                           String # version to install for :install action.
+  action                            Symbol # defaults to :install if not specified
+end
+```
+
+#### Actions
+
+* `:install` Default. Installs an integration in the given version.
+* `:remove` Removes an integration.
+
+#### Properties
+
+* `'name'` is the name of the Agent integration to install, e.g. `datadog-apache`
+* `version` is the version of the integration that you want to install. Only needed
+with the `:install` action.
+
+### Example
+
+This example installs version `1.11.0` of the ElasticSearch integration by
+using the `datadog_integration` resource.
+
+Note that the Agent installation needs to be earlier in the run list.
+
+```
+include_recipe 'datadog::dd-agent'
+
+datadog_integration 'datadog-elastic'
+  version '1.11.0'
+end
+```
+
+In order to get the available versions of the integrations, please refer to
+their `CHANGELOG.md` file in the [integrations-core repository](https://github.com/DataDog/integrations-core).
 
 Usage
 =====

--- a/README.md
+++ b/README.md
@@ -225,6 +225,10 @@ end
 In order to get the available versions of the integrations, please refer to
 their `CHANGELOG.md` file in the [integrations-core repository](https://github.com/DataDog/integrations-core).
 
+**Note for Chef Windows users**: as the datadog-agent binary available on the
+node is used by this resource, the chef-client must have read access to the
+`datadog.yaml` file.
+
 Usage
 =====
 

--- a/resources/integration.rb
+++ b/resources/integration.rb
@@ -7,7 +7,6 @@
 default_action :install
 
 property :name, String, name_attribute: true
-property :cookbook, String, default: 'datadog'
 
 property :version, String, required: true
 

--- a/resources/integration.rb
+++ b/resources/integration.rb
@@ -1,0 +1,58 @@
+# Install/remove a Datadog integration
+# This resource basically wraps the datadog-agent integration command to be able
+# to install and remove integrations from a Chef recipe.
+# The datadog_resource must be used on a system where the datadog-agent has
+# already been setup.
+
+default_action :install
+
+property :name, String, name_attribute: true
+property :cookbook, String, default: 'datadog'
+
+property :version, String, required: true
+
+action :install do
+  unless node['datadog']['agent6']
+    log "The datadog_integration resource is only available with Agent v6." do
+      level :error
+    end
+    return
+  end
+
+  log "Getting integration #{new_resource.name}" do
+    level :debug
+  end
+
+  execute 'integration install' do
+    command   "\"#{agent_exe_filepath}\" integration install #{new_resource.name}==#{new_resource.version}"
+    user      'dd-agent' unless node['platform_family'] == 'windows'
+  end
+end
+
+action :remove do
+  unless node['datadog']['agent6']
+    log "The datadog_integration resource is only available with Agent v6." do
+      level :error
+    end
+    return
+  end
+
+  log "Removing integration #{new_resource.name}" do
+    level :debug
+  end
+
+  execute 'integration remove' do
+    command   "\"#{agent_exe_filepath}\" integration remove #{new_resource.name}"
+    user      'dd-agent' unless node['platform_family'] == 'windows'
+  end
+end
+
+def agent_exe_filepath
+  if node['platform_family'] == 'windows'
+    # The Windows Agent will always be setup in this path if the _install-windows.rb
+    # has been used to install it.
+    "C:\\Program\ Files\\Datadog\\Datadog\ Agent\\embedded\\agent.exe"
+  else
+    '/opt/datadog-agent/bin/agent/agent'
+  end
+end

--- a/resources/integration.rb
+++ b/resources/integration.rb
@@ -12,7 +12,7 @@ property :version, String, required: true
 
 action :install do
   unless node['datadog']['agent6']
-    log "The datadog_integration resource is only available with Agent v6." do
+    log 'The datadog_integration resource is only available with Agent v6.' do
       level :error
     end
     return
@@ -30,7 +30,7 @@ end
 
 action :remove do
   unless node['datadog']['agent6']
-    log "The datadog_integration resource is only available with Agent v6." do
+    log 'The datadog_integration resource is only available with Agent v6.' do
       level :error
     end
     return


### PR DESCRIPTION
This PR adds the `datadog_integration` resource to be able to setup Agent integrations directly from a Chef recipe.