### PR TITLE
Do not set DATADOG_HOST anymore.

### DIFF
--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -26,7 +26,6 @@ if Chef::Config[:why_run]
 end
 
 include_recipe 'chef_handler'
-ENV['DATADOG_HOST'] = node['datadog']['url']
 
 chef_gem 'chef-handler-datadog' do # ~FC009
   action :install


### PR DESCRIPTION
By using this PR in chef-handler-datadog, we don't need to set DATADOG_HOST anymore.

https://github.com/DataDog/chef-handler-datadog/pull/103/files