### PR TITLE
allow_downgrade on SUSE

### DIFF
--- a/recipes/_install-linux.rb
+++ b/recipes/_install-linux.rb
@@ -78,6 +78,7 @@ when 'suse'
     retries package_retries unless package_retries.nil?
     retry_delay package_retry_delay unless package_retry_delay.nil?
     action package_action # default is :install
-    allow_downgrade node['datadog']['agent_allow_downgrade']
+    # allow_downgrade is only suported for zypper_package since Chef Client 13.6
+    allow_downgrade node['datadog']['agent_allow_downgrade'] if respond_to?(:allow_downgrade)
   end
 end

--- a/recipes/_install-linux.rb
+++ b/recipes/_install-linux.rb
@@ -79,6 +79,6 @@ when 'suse'
     retry_delay package_retry_delay unless package_retry_delay.nil?
     action package_action # default is :install
     # allow_downgrade is only suported for zypper_package since Chef Client 13.6
-    allow_downgrade node['datadog']['agent_allow_downgrade'] if respond_to?(:allow_downgrade)
+    allow_downgrade node['datadog']['agent_allow_downgrade'] if respond_to?(:allow_downgrade) # ~FC009
   end
 end

--- a/recipes/_install-linux.rb
+++ b/recipes/_install-linux.rb
@@ -73,12 +73,12 @@ when 'rhel', 'fedora', 'amazon'
     allow_downgrade node['datadog']['agent_allow_downgrade']
   end
 when 'suse'
-  zypper_package 'datadog-agent' do
+  zypper_package 'datadog-agent' do # ~FC009
     version dd_agent_version
     retries package_retries unless package_retries.nil?
     retry_delay package_retry_delay unless package_retry_delay.nil?
     action package_action # default is :install
     # allow_downgrade is only suported for zypper_package since Chef Client 13.6
-    allow_downgrade node['datadog']['agent_allow_downgrade'] if respond_to?(:allow_downgrade) # ~FC009
+    allow_downgrade node['datadog']['agent_allow_downgrade'] if respond_to?(:allow_downgrade)
   end
 end

--- a/recipes/_install-linux.rb
+++ b/recipes/_install-linux.rb
@@ -78,5 +78,6 @@ when 'suse'
     retries package_retries unless package_retries.nil?
     retry_delay package_retry_delay unless package_retry_delay.nil?
     action package_action # default is :install
+    allow_downgrade node['datadog']['agent_allow_downgrade']
   end
 end


### PR DESCRIPTION
### What does this PR do ?

Allow downgrading the agent on SLES and openSUSE. 

### Motivation

Tried to downgrade an agent, chef did not fail but the agent did not downgrade.

chef-client logs:

```
[2019-05-07T09:31:03+00:00] DEBUG: zypper_package[datadog-agent] datadog-agent 1:6.11.1~rc.3-1 needs updating to 1:6.11.0~six~1d20cc2d-1
Refreshing service 'SMT-http_smt-azure_susecloud_net'.
Loading repository data...
Reading installed packages...
The selected package 'datadog-agent-1:6.11.0~six~1d20cc2d-1.x86_64' from repository 'datadog' has lower version than the installed one. Use 'zypper install --oldpackage datadog-agent-1:6.11.0~six~1d20cc2d-1.x86_64' to force installation of the package.
Resolving package dependencies...

Nothing to do.
[2019-05-07T09:31:09+00:00] INFO: zypper_package[datadog-agent] installed datadog-agent at 1:6.11.0~six~1d20cc2d-1
``` 

### Notes 

`allow_downgrade` was not added initially because chef and/or zypper did not have this option. cf. https://github.com/DataDog/chef-datadog/pull/505#discussion_r167884797
Since then the `allow_downgrade` property was added to `zypper_package` https://docs.chef.io/resource_zypper_package.html