### PR TITLE
Old windows cookbook does not support the `returns` attribute.

### DIFF
--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -82,5 +82,9 @@ windows_package 'Datadog Agent' do # ~FC009
   installer_type installer_type
   options install_options
   action :install
-  returns [0, 3010]
+  if respond_to?(:returns)
+    returns [0, 3010]
+  else
+    success_codes [0, 3010]
+  end
 end


### PR DESCRIPTION
We advice to use `windows ~> 1.38.0` for some setup, but this cookbook version does not  support the `returns` attribute yet.