### PR TITLE
Use Chef 14 in CircleCI + fix some specs tests.

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -4,14 +4,23 @@ driver:
   use_sudo: false
 
 platforms:
-  - name: ubuntu-14.04
   # Exclude this OS for now, due to some odd behavior with the NTP check on CircleCI systems.
   # See https://circleci.com/gh/DataDog/chef-datadog/19
   # and http://support.ntp.org/bin/view/Support/KnownOsIssues#Section_9.2.4.2.5.3.
   # - name: ubuntu-12.04
+
+  - name: ubuntu-14.04
+    driver_config:
+      require_chef_omnibus: 12.7.2
   - name: centos-6.6
+    driver_config:
+      require_chef_omnibus: 12.7.2
   - name: centos-7.7
+    driver_config:
+      require_chef_omnibus: 12.7.2
   - name: debian-8.11
+    driver_config:
+      require_chef_omnibus: 12.7.2
 
 suites:
 - name: dd-agent-handler

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -11,16 +11,16 @@ platforms:
 
   - name: ubuntu-14.04
     driver_config:
-      require_chef_omnibus: 12.7.2
+      require_chef_omnibus: 14.12
   - name: centos-6.6
     driver_config:
-      require_chef_omnibus: 12.7.2
+      require_chef_omnibus: 14.12
   - name: centos-7.7
     driver_config:
-      require_chef_omnibus: 12.7.2
+      require_chef_omnibus: 14.12
   - name: debian-8.11
     driver_config:
-      require_chef_omnibus: 12.7.2
+      require_chef_omnibus: 14.12
 
 suites:
 - name: dd-agent-handler

--- a/recipes/dd-handler.rb
+++ b/recipes/dd-handler.rb
@@ -26,7 +26,7 @@ if Chef::Config[:why_run]
 end
 
 if node['datadog']['chef_handler_version'] &&
-  Gem::Version.new(node['datadog']['chef_handler_version']) < Gem::Version.new('0.10.0')
+   Gem::Version.new(node['datadog']['chef_handler_version']) < Gem::Version.new('0.10.0')
   Chef::Log.error('We do not support chef_handler_version < v0.10.0 anymore, please use a more recent version.')
   return
 end

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -232,6 +232,9 @@ describe 'datadog::dd-agent' do
     end
   end
 
+  # Allow a hash for Agent version 6
+  # ----------------------
+
   context 'allows a hash for agent version' do
     context 'when ubuntu' do
       cached(:chef_run) do
@@ -240,7 +243,7 @@ describe 'datadog::dd-agent' do
           :version => '14.04'
         ) do |node|
           node.normal['datadog'] = {
-            'agent6' => false,
+            'agent6' => true,
             'api_key' => 'somethingnotnil',
             'agent6_version' => {
               'debian' => '1:6.9.0-1',
@@ -298,7 +301,7 @@ describe 'datadog::dd-agent' do
           :version => '25'
         ) do |node|
           node.normal['datadog'] = {
-            'agent6' => false,
+            'agent6' => true,
             'api_key' => 'somethingnotnil',
             'agent6_version' => {
               'debian' => '1:6.9.0-1',
@@ -321,7 +324,7 @@ describe 'datadog::dd-agent' do
           :version => '6.9'
         ) do |node|
           node.normal['datadog'] = {
-            'agent6' => false,
+            'agent6' => true,
             'api_key' => 'somethingnotnil',
             'agent6_version' => {
               'debian' => '1:6.9.0-1',
@@ -335,6 +338,107 @@ describe 'datadog::dd-agent' do
       end
 
       it_behaves_like 'rhellions datadog-agent'
+    end
+  end
+
+  # Allow a hash for Agent version 5
+  # ----------------------
+
+  context 'allows a hash for agent version v5' do
+    context 'when ubuntu' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(
+          :platform => 'ubuntu',
+          :version => '14.04'
+        ) do |node|
+          node.normal['datadog'] = {
+            'agent6' => false,
+            'api_key' => 'somethingnotnil',
+            'agent_version' => {
+              'debian' => '1:5.32.2-1',
+              'rhel' => '5.32.2-1',
+              'windows' => '5.4.0'
+            },
+          }
+        end.converge described_recipe
+      end
+
+      it_behaves_like 'debianoids datadog-agent v5'
+    end
+
+    context 'when windows' do
+      cached(:chef_run) do
+        set_env_var('ProgramData', 'C:\ProgramData')
+        ChefSpec::SoloRunner.new(
+          :platform => 'windows',
+          :version => '2012R2',
+          :file_cache_path => 'C:/chef/cache'
+        ) do |node|
+          node.normal['datadog'] = {
+            'agent6' => false,
+            'api_key' => 'somethingnotnil',
+            'agent_version' => {
+              'debian' => '1:5.32.2-1',
+              'rhel' => '5.32.2-1',
+              'windows' => '5.4.0'
+            },
+          }
+        end.converge described_recipe
+      end
+
+      temp_file = ::File.join('C:/chef/cache', 'ddagent-cli.msi')
+
+      it_behaves_like 'windows Datadog Agent v5', :msi
+      # remote_file source gets converted to an array, so we need to do
+      # some tricky things to be able to regex against it
+      # Relevant: http://stackoverflow.com/a/12325983
+      # But we should probably assert the full default attribute somewhere...
+      it 'installs agent 5.4.0' do
+        expect(chef_run.remote_file(temp_file).source.to_s)
+          .to match(/ddagent-cli-5.4.0.msi/)
+      end
+    end
+
+    context 'when fedora' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(
+          :platform => 'fedora',
+          :version => '25'
+        ) do |node|
+          node.normal['datadog'] = {
+            'agent6' => false,
+            'api_key' => 'somethingnotnil',
+            'agent6_version' => {
+              'debian' => '1:5.32.2-1',
+              'rhel' => '5.32.2-1',
+              'windows' => '5.4.0'
+            },
+          }
+        end.converge described_recipe
+      end
+
+      it_behaves_like 'rhellions datadog-agent v5'
+    end
+
+    context 'when rhel' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(
+          :platform => 'redhat',
+          :version => '6.9'
+        ) do |node|
+          node.normal['datadog'] = {
+            'agent6' => false,
+            'api_key' => 'somethingnotnil',
+            'agent_version' => {
+              'debian' => '1:5.32.2-1',
+              'rhel' => '5.32.2-1',
+              'windows' => '5.4.0'
+            },
+          }
+        end.converge described_recipe
+      end
+
+      it_behaves_like 'rhellions datadog-agent v5'
     end
   end
 

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -46,8 +46,20 @@ shared_examples_for 'common linux resources' do
   end
 end
 
+shared_examples_for 'datadog-agent v5' do
+  it_behaves_like 'common linux resources v5'
+end
+
 shared_examples_for 'datadog-agent' do
   it_behaves_like 'common linux resources'
+end
+
+shared_examples_for 'debianoids datadog-agent v5' do
+  it_behaves_like 'datadog-agent v5'
+
+  it 'installs the datadog-agent' do
+    expect(chef_run).to install_apt_package 'datadog-agent'
+  end
 end
 
 shared_examples_for 'debianoids datadog-agent' do
@@ -55,6 +67,14 @@ shared_examples_for 'debianoids datadog-agent' do
 
   it 'installs the datadog-agent' do
     expect(chef_run).to install_apt_package 'datadog-agent'
+  end
+end
+
+shared_examples_for 'rhellions datadog-agent v5' do
+  it_behaves_like 'datadog-agent v5'
+
+  it 'installs the datadog-agent' do
+    expect(chef_run).to install_yum_package 'datadog-agent'
   end
 end
 


### PR DESCRIPTION
Chef 15 currently has a prompt to accept the license that we can't automate, force Chef 14 on CircleCI for now.

Also, fix some spec tests bugs that were introduced while removing Agent v4 support in https://github.com/DataDog/chef-datadog/commit/efdee6e6f727a48bb06e764d00b7349e6d7c1958