### PR TITLE
Allow users to set a custom user/password to run the Windows Datadog Agent service.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -197,14 +197,13 @@ else
 end
 
 # Since 6.11.0, the Datadog Agent creates/uses a custom user to run on Windows.
-# Set `windows_ddagentuser_name` using the format `<domain>/<user>` to provide a
+# Set `windows_ddagentuser_name` using the format `<domain>\<user>` to provide a
 # specific username and `windows_ddagentuser_password` to provide a specific password.
 # You can set those values here, in role/environment/node or set in your
 # node `run_state` under the keys `['datadog']['windows_ddagentuser_name']` and
 # `['datadog']['windows_ddagentuser_password']`.
 default['datadog']['windows_ddagentuser_name'] = nil
 default['datadog']['windows_ddagentuser_password'] = nil
-
 
 # DEPRECATED, will be removed after the release of datadog-agent 6.0
 # Set to true to always install datadog-agent-base (usually only installed on

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -196,6 +196,16 @@ else
   default['datadog']['agent_name'] = 'datadog-agent'
 end
 
+# Since 6.11.0, the Datadog Agent creates/uses a custom user to run on Windows.
+# Set `windows_ddagentuser_name` using the format `<domain>/<user>` to provide a
+# specific username and `windows_ddagentuser_password` to provide a specific password.
+# You can set those values here, in role/environment/node or set in your
+# node `run_state` under the keys `['datadog']['windows_ddagentuser_name']` and
+# `['datadog']['windows_ddagentuser_password']`.
+default['datadog']['windows_ddagentuser_name'] = nil
+default['datadog']['windows_ddagentuser_password'] = nil
+
+
 # DEPRECATED, will be removed after the release of datadog-agent 6.0
 # Set to true to always install datadog-agent-base (usually only installed on
 # systems with a version of Python lower than 2.6) instead of datadog-agent

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -10,6 +10,14 @@ class Chef
         run_state_or_attribute(node, 'application_key')
       end
 
+      def ddagentuser_name(node)
+        run_state_or_attribute(node, 'windows_ddagentuser_name')
+      end
+
+      def ddagentuser_password(node)
+        run_state_or_attribute(node, 'windows_ddagentuser_password')
+      end
+
       private
 
       def run_state_or_attribute(node, attribute)

--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -57,7 +57,8 @@ else
   install_options = '/norestart ALLUSERS=1'
 
   # Since 6.11.0, the core and APM/trace components of the Windows Agent run under
-  # the ddagentuser account.
+  # a specific user instead of LOCAL_SYSTEM, check whether the user has provided
+  # custom credentials and use them if that's the case.
   install_options.concat(' DDAGENTUSER_NAME=').concat(Chef::Datadog.ddagentuser_name(node)) if Chef::Datadog.ddagentuser_name(node)
   install_options.concat(' DDAGENTUSER_PASSWORD=').concat(Chef::Datadog.ddagentuser_password(node)) if Chef::Datadog.ddagentuser_password(node)
 end

--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -55,6 +55,11 @@ else
   installer_type = :msi
   # Agent >= 5.12.0 installs per-machine by default, but specifying ALLUSERS=1 shouldn't affect the install
   install_options = '/norestart ALLUSERS=1'
+
+  # Since 6.11.0, the core and APM/trace components of the Windows Agent run under
+  # the ddagentuser account.
+  install_options.concat(' DDAGENTUSER_NAME=').concat(Chef::Datadog.ddagentuser_name(node)) if Chef::Datadog.ddagentuser_name(node)
+  install_options.concat(' DDAGENTUSER_PASSWORD=').concat(Chef::Datadog.ddagentuser_password(node)) if Chef::Datadog.ddagentuser_password(node)
 end
 
 # Use a separate resource without a `source` so that it looks in the Registry to find the MSI to use


### PR DESCRIPTION
Let the user of the cookbook provide custom credentials for the Datadog Agent service. It only makes sense for Agents >= `6.11.0` (the feature appeared in the Agent in `6.11.0`).

Note that this PR targets `v2.x` and will later be cherry-picked in `master` for 3.x versions