### PR TITLE
Do not use the `log` resource to emit some execution log.

### DIFF
--- a/resources/integration.rb
+++ b/resources/integration.rb
@@ -12,15 +12,11 @@ property :version, String, required: true
 
 action :install do
   unless node['datadog']['agent6']
-    log 'The datadog_integration resource is only available with Agent v6.' do
-      level :error
-    end
+    Chef::Log.error('The datadog_integration resource is only available with Agent v6.')
     return
   end
 
-  log "Getting integration #{new_resource.name}" do
-    level :debug
-  end
+  Chef::Log.debug("Getting integration #{new_resource.name}")
 
   execute 'integration install' do
     command   "\"#{agent_exe_filepath}\" integration install #{new_resource.name}==#{new_resource.version}"
@@ -30,15 +26,11 @@ end
 
 action :remove do
   unless node['datadog']['agent6']
-    log 'The datadog_integration resource is only available with Agent v6.' do
-      level :error
-    end
+    Chef::Log.error('The datadog_integration resource is only available with Agent v6.')
     return
   end
 
-  log "Removing integration #{new_resource.name}" do
-    level :debug
-  end
+  Chef::Log.debug("Removing integration #{new_resource.name}")
 
   execute 'integration remove' do
     command   "\"#{agent_exe_filepath}\" integration remove #{new_resource.name}"

--- a/resources/monitor.rb
+++ b/resources/monitor.rb
@@ -15,9 +15,7 @@ property :use_integration_template, [TrueClass, FalseClass], required: false, de
 property :logs, [Array, nil], required: false, default: []
 
 action :add do
-  log "Adding monitoring for #{new_resource.name}" do
-    level :debug
-  end
+  Chef::Log.debug("Adding monitoring for #{new_resource.name}")
 
   template ::File.join(yaml_dir, "#{new_resource.name}.yaml") do
     # On Windows Agent v5, set the permissions on conf files to Administrators.

--- a/resources/monitor.rb
+++ b/resources/monitor.rb
@@ -44,9 +44,7 @@ action :add do
 end
 
 action :remove do
-  log "Removing #{new_resource.name} from #{yaml_dir}" do
-    level :debug
-  end
+  Chef::Log.debug("Removing #{new_resource.name} from #{yaml_dir}")
 
   file ::File.join(yaml_dir, "#{new_resource.name}.yaml") do
     action :delete


### PR DESCRIPTION
Using the Chef `log` resource invalidate our custom resources each time they've called, for example restarting the datadog-agent each time the `datadog_monitor` resource is called.