### PR TITLE
 Integration resource converges only when the command is executed.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,6 +18,8 @@ platforms:
     chef_versions = %w(
       12.7.2
       13.11.3
+      14
+      15
     )
 
     test_platforms.product(chef_versions).each do |platform_version, chef_version|
@@ -34,6 +36,8 @@ windows_platform = 'windows-2012r2'
 windows_chef_versions = %w(
   12.7.2
   13.11.3
+  14
+  15
 )
 
 windows_chef_versions.each do |chef_version|
@@ -563,3 +567,12 @@ suites:
             ssl_verify: true
             tags: ['_default']
             timeout: 20
+
+# Integrations test of the datadog_integration resource
+- name: dd_integration_resource
+  run_list:
+    - recipe[datadog::dd-agent]
+    - recipe[test::dd_integration_resource]
+  attributes:
+    datadog:
+      <<: *DATADOG

--- a/Berksfile
+++ b/Berksfile
@@ -4,4 +4,5 @@ metadata
 
 group :integration do
   cookbook 'sudo'
+  cookbook 'test', path: './test/cookbooks/test' # Integration test
 end

--- a/resources/integration.rb
+++ b/resources/integration.rb
@@ -25,11 +25,11 @@ action :install do
 
     not_if {
       output = shell_out("#{agent_exe_filepath} integration show #{new_resource.property_name}").stdout
-      if output.match(/Installed version/) then
+      if output =~ /Installed version/
         property_name = output.match(/Package (.+):$/)[1].strip
         version       = output.match(/Installed version: (.+)$/)[1].strip
         # Same version already installed? Do not reinstall.
-        property_name == new_resource.property_name and version == new_resource.version
+        property_name == new_resource.property_name && version == new_resource.version
       else
         # Nothing installed yet, we want to install/
         false

--- a/resources/integration.rb
+++ b/resources/integration.rb
@@ -44,7 +44,7 @@ action :remove do
 
     not_if {
       output = shell_out("#{agent_exe_filepath} integration show -q #{new_resource.property_name}").stdout
-      output.empty?
+      output.strip.empty?
     }
   end
 end

--- a/resources/integration.rb
+++ b/resources/integration.rb
@@ -24,16 +24,8 @@ action :install do
     user      'dd-agent' unless node['platform_family'] == 'windows'
 
     not_if {
-      output = shell_out("#{agent_exe_filepath} integration show #{new_resource.property_name}").stdout
-      if output =~ /Installed version/
-        property_name = output.match(/Package (.+):$/)[1].strip
-        version       = output.match(/Installed version: (.+)$/)[1].strip
-        # Same version already installed? Do not reinstall.
-        property_name == new_resource.property_name && version == new_resource.version
-      else
-        # Nothing installed yet, we want to install/
-        false
-      end
+      output = shell_out("#{agent_exe_filepath} integration show -q #{new_resource.property_name}").stdout
+      output.strip == new_resource.version
     }
   end
 end
@@ -50,9 +42,9 @@ action :remove do
     command   "\"#{agent_exe_filepath}\" integration remove #{new_resource.property_name}"
     user      'dd-agent' unless node['platform_family'] == 'windows'
 
-    only_if {
-      output = shell_out("#{agent_exe_filepath} integration show #{new_resource.property_name}").stdout
-      output.match(/Installed version/)
+    not_if {
+      output = shell_out("#{agent_exe_filepath} integration show -q #{new_resource.property_name}").stdout
+      output.empty?
     }
   end
 end

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -116,7 +116,7 @@ describe 'datadog::dd-agent' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(
           :platform => 'fedora',
-          :version => '25'
+          :version => '26'
         ) do |node|
           node.normal['datadog'] = { 'api_key' => 'somethingnotnil' }
           node.normal['languages'] = { 'python' => { 'version' => '2.7.9' } }
@@ -298,7 +298,7 @@ describe 'datadog::dd-agent' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(
           :platform => 'fedora',
-          :version => '25'
+          :version => '26'
         ) do |node|
           node.normal['datadog'] = {
             'agent6' => true,
@@ -403,7 +403,7 @@ describe 'datadog::dd-agent' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(
           :platform => 'fedora',
-          :version => '25'
+          :version => '26'
         ) do |node|
           node.normal['datadog'] = {
             'agent6' => false,

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -69,7 +69,7 @@ describe 'datadog::repository' do
     context 'version 5' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(
-          platform: 'centos', version: '5.10'
+          platform: 'centos', version: '5.11'
         ).converge(described_recipe)
       end
 

--- a/test/cookbooks/test/metadata.rb
+++ b/test/cookbooks/test/metadata.rb
@@ -1,0 +1,7 @@
+name              'test'
+maintainer        'Datadog'
+maintainer_email  'package@datadoghq.com'
+license           'Apache-2.0'
+version           '0.0.1'
+description       'Tests cookbooks'
+depends           'datadog'

--- a/test/cookbooks/test/recipes/dd_integration_resource.rb
+++ b/test/cookbooks/test/recipes/dd_integration_resource.rb
@@ -8,7 +8,7 @@ datadog_integration 'datadog-aerospike' do
 end
 datadog_integration 'datadog-aerospike' do
   action :install
-  version  '1.2.0'
+  version '1.2.0'
 end
 # This time Chef should mention "up to date"
 datadog_integration 'datadog-aerospike' do

--- a/test/cookbooks/test/recipes/dd_integration_resource.rb
+++ b/test/cookbooks/test/recipes/dd_integration_resource.rb
@@ -1,0 +1,17 @@
+datadog_integration 'datadog-aerospike' do
+  action :remove
+  notifies :restart, 'service[datadog-agent]'
+end
+# This time Chef should mention "up to date"
+datadog_integration 'datadog-aerospike' do
+  action :remove
+end
+datadog_integration 'datadog-aerospike' do
+  action :install
+  version  '1.2.0'
+end
+# This time Chef should mention "up to date"
+datadog_integration 'datadog-aerospike' do
+  action :install
+  version '1.2.0'
+end

--- a/test/integration/dd_integration_resource/serverspec/Gemfile
+++ b/test/integration/dd_integration_resource/serverspec/Gemfile
@@ -1,0 +1,1 @@
+../../helpers/serverspec/Gemfile

--- a/test/integration/dd_integration_resource/serverspec/resource_integration_spec.rb
+++ b/test/integration/dd_integration_resource/serverspec/resource_integration_spec.rb
@@ -1,0 +1,15 @@
+# Encoding: utf-8
+
+require 'serverspec'
+
+set :backend, :exec
+set :path, '/sbin:/usr/local/sbin:$PATH'
+
+describe service('datadog-agent') do
+  it { should be_running }
+end
+
+# Checks that it's installed properly and with the good version
+describe command('/opt/datadog-agent/bin/agent/agent integration show datadog-aerospike') do
+  its(:stdout) { should match /Package datadog-aerospike:\nInstalled version:/ }
+end


### PR DESCRIPTION
Add `only_if`/`not_if` clauses to the execute resource used in the datadog integration resource in order to execute the command only when needed.

Sample run of the `resource_integration_spec.rb` recipe doing: `remove + remove + install + install` of the datadog-aerospike integration, which is already available at the start of the run.

```
       Recipe: test::dd_integration_resource
         * datadog_integration[datadog-aerospike] action remove
           * execute[integration remove] action run
             - execute "/opt/datadog-agent/bin/agent/agent" integration remove datadog-aerospike

         * datadog_integration[datadog-aerospike] action remove
           * execute[integration remove] action run (skipped due to not_if)
            (up to date)
         * datadog_integration[datadog-aerospike] action install
           * execute[integration install] action run
             - execute "/opt/datadog-agent/bin/agent/agent" integration install datadog-aerospike==1.2.0

         * datadog_integration[datadog-aerospike] action install
           * execute[integration install] action run (skipped due to not_if)
            (up to date)
```

Tested with Chef `12.7.2`, `13.11.3`, `14.12.9`, `15.0.300`.