### PR TITLE
[repository] Add dirmngr when installing from apt repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The following Opscode cookbooks are dependencies:
 * `chef_handler`
 * `yum`
 
+Version `7.1` or later of the `apt` cookbook is needed to install the Agent on Debian 9 or later.
+
 ### Chef support
 
 **Chef 13 users**

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -26,6 +26,12 @@ when 'debian'
     action :install
   end
 
+  package 'install-dirmngr' do
+    package_name 'dirmngr'
+    action :install
+    ignore_failure true # Can fail on older distros where the dirmngr package does not exist, but shouldn't prevent install.
+  end
+
   uri = node['datadog']['agent6'] ? node['datadog']['agent6_aptrepo'] : node['datadog']['aptrepo']
   distribution = node['datadog']['agent6'] ? node['datadog']['agent6_aptrepo_dist'] : node['datadog']['aptrepo_dist']
   components = node['datadog']['agent6'] ? ['main', '6'] : ['main']

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -26,12 +26,6 @@ when 'debian'
     action :install
   end
 
-  package 'install-dirmngr' do
-    package_name 'dirmngr'
-    action :install
-    ignore_failure true # Can fail on older distros where the dirmngr package does not exist, but shouldn't prevent install.
-  end
-
   uri = node['datadog']['agent6'] ? node['datadog']['agent6_aptrepo'] : node['datadog']['aptrepo']
   distribution = node['datadog']['agent6'] ? node['datadog']['agent6_aptrepo_dist'] : node['datadog']['aptrepo_dist']
   components = node['datadog']['agent6'] ? ['main', '6'] : ['main']


### PR DESCRIPTION
Since debian 9 doesn't package `dirmngr` by default, we have to
add it to be able to install the Agent from our 3rd-party repo.

Update: actually, using the newer versions of the `apt` cookbook is a better solution.