### PR TITLE
Optional cmd_port & GUI_port on agentv6 due to port conflicts

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -71,6 +71,21 @@ default['datadog']['agent6_config_dir'] =
 # Defaults to 'datadoghq.com', set to 'datadoghq.eu' to send data to the EU site.
 default['datadog']['site'] = nil
 
+# The port on which the IPC api listens
+# cmd_port: 5001
+default['datadog']['agent6_cmd_port'] = nil
+
+# The port for the browser GUI to be served
+# Setting 'GUI_port: -1' turns off the GUI completely
+# Default is '5002' on Windows and macOS ; turned off on Linux
+# GUI_port: -1
+default['datadog']['agent6_gui_port'] = nil
+
+# Set a key to true to make the agent6 use the v2 api on that endpoint, false otherwise.
+# Leave key value to nil to use agent6 default for that endpoint.
+# Supported keys: "series", "events", "service checks"
+default['datadog']['use_v2_api'] = {}
+
 ###                 End of Agent6-only attributes                    ###
 ########################################################################
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -81,11 +81,6 @@ default['datadog']['agent6_cmd_port'] = nil
 # GUI_port: -1
 default['datadog']['agent6_gui_port'] = nil
 
-# Set a key to true to make the agent6 use the v2 api on that endpoint, false otherwise.
-# Leave key value to nil to use agent6 default for that endpoint.
-# Supported keys: "series", "events", "service checks"
-default['datadog']['use_v2_api'] = {}
-
 ###                 End of Agent6-only attributes                    ###
 ########################################################################
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -73,13 +73,13 @@ default['datadog']['site'] = nil
 
 # The port on which the IPC api listens
 # cmd_port: 5001
-default['datadog']['agent6_cmd_port'] = nil
+default['datadog']['cmd_port'] = nil
 
 # The port for the browser GUI to be served
 # Setting 'GUI_port: -1' turns off the GUI completely
 # Default is '5002' on Windows and macOS ; turned off on Linux
 # GUI_port: -1
-default['datadog']['agent6_gui_port'] = nil
+default['datadog']['gui_port'] = nil
 
 ###                 End of Agent6-only attributes                    ###
 ########################################################################

--- a/templates/default/datadog.yaml.erb
+++ b/templates/default/datadog.yaml.erb
@@ -90,6 +90,8 @@ agent_config = @extra_config.merge({
   use_dogstatsd: node['datadog']['dogstatsd'],
   statsd_metric_namespace: node['datadog']['statsd_metric_namespace'],
   log_level: node['datadog']['log_level'],
+  cmd_port: node['datadog']['agent6_cmd_port'],
+  GUI_port: node['datadog']['agent6_gui_port'],
 
   # log agent options
   logs_enabled: node['datadog']['enable_logs_agent'],

--- a/templates/default/datadog.yaml.erb
+++ b/templates/default/datadog.yaml.erb
@@ -90,8 +90,8 @@ agent_config = @extra_config.merge({
   use_dogstatsd: node['datadog']['dogstatsd'],
   statsd_metric_namespace: node['datadog']['statsd_metric_namespace'],
   log_level: node['datadog']['log_level'],
-  cmd_port: node['datadog']['agent6_cmd_port'],
-  GUI_port: node['datadog']['agent6_gui_port'],
+  cmd_port: node['datadog']['cmd_port'],
+  GUI_port: node['datadog']['gui_port'],
 
   # log agent options
   logs_enabled: node['datadog']['enable_logs_agent'],


### PR DESCRIPTION
I ran into a local port collision as well.
This is just the commit from https://github.com/DataDog/chef-datadog/pull/577 with the merge conflict resolved.

I tested agent5 and agent6 deployments to verify no issues with bringing up datadog agent after cooking.