### PR TITLE
[repository] Trust new GPG key only when installing Agent 6 RPM

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -9,12 +9,12 @@ platforms:
   # and http://support.ntp.org/bin/view/Support/KnownOsIssues#Section_9.2.4.2.5.3.
   # - name: ubuntu-12.04
 
-  - name: ubuntu-14.04
-    driver_config:
-      require_chef_omnibus: 14.12
-  - name: centos-6.6
-    driver_config:
-      require_chef_omnibus: 14.12
+  #- name: ubuntu-14.04
+  #  driver_config:
+  #    require_chef_omnibus: 14.12
+  #- name: centos-6.6
+  #  driver_config:
+  #    require_chef_omnibus: 14.12
   - name: centos-7.7
     driver_config:
       require_chef_omnibus: 14.12

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -33,3 +33,13 @@ suites:
       agent6: false
       api_key: somenonnullapikeythats32charlong
       application_key: alsonotnil
+
+- name: dd-agent-handler-agent6
+  run_list:
+    - recipe[datadog::dd-handler]
+    - recipe[datadog::dd-agent]
+  attributes:
+    datadog:
+      agent6: true
+      api_key: somenonnullapikeythats32charlong
+      application_key: alsonotnil

--- a/Rakefile
+++ b/Rakefile
@@ -105,6 +105,7 @@ task :circle do
 
       # Scope the suites to only execute against the Agent+handler installer suites.
       commands.push "kitchen verify dd-agent-handler-#{name}"
+      commands.push "kitchen verify dd-agent-handler-agent6-#{name}"
     end
 
     commands.join(' && ')

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -48,7 +48,7 @@ when 'debian'
   end
 when 'rhel', 'fedora', 'amazon'
   # Import new RPM key if installing Agent 6
-  if node['datadog']['agent6']
+  if node['datadog']['yumrepo_gpgkey_new'] && node['datadog']['agent6']
     # gnupg is required to check the downloaded key's fingerprint
     package 'gnupg' do
       action :install
@@ -89,7 +89,7 @@ when 'rhel', 'fedora', 'amazon'
   end
 when 'suse'
   # Import new RPM key if installing Agent 6
-  if node['datadog']['agent6']
+  if node['datadog']['yumrepo_gpgkey_new'] && node['datadog']['agent6']
     # Download new RPM key
     new_key_local_path = ::File.join(Chef::Config[:file_cache_path], 'DATADOG_RPM_KEY_E09422B3.public')
     remote_file 'DATADOG_RPM_KEY_E09422B3.public' do

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -47,8 +47,8 @@ when 'debian'
     action :remove
   end
 when 'rhel', 'fedora', 'amazon'
-  # Import new RPM key
-  if node['datadog']['yumrepo_gpgkey_new']
+  # Import new RPM key if installing Agent 6
+  if node['datadog']['agent6']
     # gnupg is required to check the downloaded key's fingerprint
     package 'gnupg' do
       action :install
@@ -88,8 +88,8 @@ when 'rhel', 'fedora', 'amazon'
     action :create
   end
 when 'suse'
-  # Import new RPM key
-  if node['datadog']['yumrepo_gpgkey_new']
+  # Import new RPM key if installing Agent 6
+  if node['datadog']['agent6']
     # Download new RPM key
     new_key_local_path = ::File.join(Chef::Config[:file_cache_path], 'DATADOG_RPM_KEY_E09422B3.public')
     remote_file 'DATADOG_RPM_KEY_E09422B3.public' do

--- a/test/integration/dd-agent-agent6/serverspec/dd-agent6_spec.rb
+++ b/test/integration/dd-agent-agent6/serverspec/dd-agent6_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+# The new RPM key is imported
+describe command('rpm -q gpg-pubkey-e09422b3'), :if => os[:family] == 'redhat' do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should contain 'gpg-pubkey-e09422b3' }
+end

--- a/test/integration/dd-agent-handler-agent6/serverspec/dd-agent6_spec.rb
+++ b/test/integration/dd-agent-handler-agent6/serverspec/dd-agent6_spec.rb
@@ -1,0 +1,1 @@
+../../dd-agent-agent6/serverspec/dd-agent6_spec.rb

--- a/test/integration/dd-agent-handler-agent6/serverspec/dd-agent_spec.rb
+++ b/test/integration/dd-agent-handler-agent6/serverspec/dd-agent_spec.rb
@@ -1,0 +1,1 @@
+../../dd-agent/serverspec/dd-agent_spec.rb

--- a/test/integration/dd-agent-handler-agent6/serverspec/dd-handler_spec.rb
+++ b/test/integration/dd-agent-handler-agent6/serverspec/dd-handler_spec.rb
@@ -1,0 +1,1 @@
+../../dd-handler/serverspec/dd-handler_spec.rb

--- a/test/integration/dd-agent/serverspec/dd-agent_spec.rb
+++ b/test/integration/dd-agent/serverspec/dd-agent_spec.rb
@@ -20,8 +20,8 @@ describe command('apt-key list'), :if => ['debian', 'ubuntu'].include?(os[:famil
   its(:stdout) { should contain '382E94DE' }
 end
 
-# The new RPM key is imported
-describe command('rpm -q gpg-pubkey-e09422b3'), :if => os[:family] == 'redhat' do
+# The old RPM key is imported
+describe command('rpm -q gpg-pubkey-4172a230'), :if => os[:family] == 'redhat' do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should contain 'gpg-pubkey-e09422b3' }
+  its(:stdout) { should contain 'gpg-pubkey-4172a230' }
 end


### PR DESCRIPTION
In the near future, we're going to sign our RPM package with a
newer GPG key.
To make sure chef installs of Agent 6 work, the new key
should be installed if Agent 6 is installed.
However, since some OSes supported by Agent 5 (but not Agent 6)
are not able to import the new key, we shouldn't import it if Agent 5 is installed.
