### PR TITLE
Support Agent package installation on RHEL 8 / Fedora 28+

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Platforms
 * Amazon Linux
 * CentOS
 * Debian
-* RedHat
+* RedHat (RHEL 8 requires chef >= 15)
 * Scientific Linux
 * Ubuntu
 * Windows

--- a/recipes/_install-linux.rb
+++ b/recipes/_install-linux.rb
@@ -68,6 +68,7 @@ when 'rhel', 'fedora', 'amazon'
   if node['platform_family'] == 'rhel' && node['platform_version'].to_i >= 8 ||
      node['platform_family'] == 'fedora' && node['platform_version'].to_i >= 28
     # yum_package doesn't work on RHEL 8 and Fedora >= 28
+    # dnf_package only works on RHEL 8 / Fedora >= 28 if Chef 15+ is used
     dnf_package 'datadog-agent' do
       version dd_agent_version
       retries package_retries unless package_retries.nil?

--- a/recipes/_install-linux.rb
+++ b/recipes/_install-linux.rb
@@ -65,12 +65,22 @@ when 'debian'
     options '--force-yes' if node['datadog']['agent_allow_downgrade']
   end
 when 'rhel', 'fedora', 'amazon'
-  yum_package 'datadog-agent' do
-    version dd_agent_version
-    retries package_retries unless package_retries.nil?
-    retry_delay package_retry_delay unless package_retry_delay.nil?
-    action package_action # default is :install
-    allow_downgrade node['datadog']['agent_allow_downgrade']
+  if node['platform_family'] == 'rhel' && node['platform_version'].to_i >= 8
+    # yum_package doesn't work on RHEL 8
+    dnf_package 'datadog-agent' do
+      version dd_agent_version
+      retries package_retries unless package_retries.nil?
+      retry_delay package_retry_delay unless package_retry_delay.nil?
+      action package_action # default is :install
+    end
+  else
+    yum_package 'datadog-agent' do
+      version dd_agent_version
+      retries package_retries unless package_retries.nil?
+      retry_delay package_retry_delay unless package_retry_delay.nil?
+      action package_action # default is :install
+      allow_downgrade node['datadog']['agent_allow_downgrade']
+    end
   end
 when 'suse'
   zypper_package 'datadog-agent' do # ~FC009

--- a/recipes/_install-linux.rb
+++ b/recipes/_install-linux.rb
@@ -65,8 +65,9 @@ when 'debian'
     options '--force-yes' if node['datadog']['agent_allow_downgrade']
   end
 when 'rhel', 'fedora', 'amazon'
-  if node['platform_family'] == 'rhel' && node['platform_version'].to_i >= 8
-    # yum_package doesn't work on RHEL 8
+  if node['platform_family'] == 'rhel' && node['platform_version'].to_i >= 8  ||
+    node['platform_family'] == 'fedora' && node['platform_version'].to_i >= 28
+    # yum_package doesn't work on RHEL 8 and Fedora >= 28
     dnf_package 'datadog-agent' do
       version dd_agent_version
       retries package_retries unless package_retries.nil?

--- a/recipes/_install-linux.rb
+++ b/recipes/_install-linux.rb
@@ -65,8 +65,8 @@ when 'debian'
     options '--force-yes' if node['datadog']['agent_allow_downgrade']
   end
 when 'rhel', 'fedora', 'amazon'
-  if node['platform_family'] == 'rhel' && node['platform_version'].to_i >= 8  ||
-    node['platform_family'] == 'fedora' && node['platform_version'].to_i >= 28
+  if node['platform_family'] == 'rhel' && node['platform_version'].to_i >= 8 ||
+     node['platform_family'] == 'fedora' && node['platform_version'].to_i >= 28
     # yum_package doesn't work on RHEL 8 and Fedora >= 28
     dnf_package 'datadog-agent' do
       version dd_agent_version

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -66,7 +66,7 @@ when 'rhel', 'fedora', 'amazon'
     # Import key if fingerprint matches
     execute 'rpm-import datadog key e09422b3' do
       command "rpm --import #{key_local_path}"
-      only_if "gpg --dry-run --quiet --with-fingerprint #{key_local_path} | grep 'A4C0 B90D 7443 CF6E 4E8A  A341 F106 8E14 E094 22B3'"
+      only_if "gpg --dry-run --quiet --with-fingerprint #{key_local_path} | grep 'A4C0 B90D 7443 CF6E 4E8A  A341 F106 8E14 E094 22B3' || gpg --dry-run --import --import-options import-show #{key_local_path} | grep 'A4C0B90D7443CF6E4E8AA341F1068E14E09422B3'"
       action :nothing
     end
   end


### PR DESCRIPTION
### What does this PR do?

Support Agent package installation on RHEL 8 / Fedora 28+.

### Motivation

`yum_package` and `dnf_package` are broken on RHEL 8 ([Chef issue](https://github.com/chef/chef/issues/7988)): `package` resources fail on RHEL 8 due to python not being bundled the same way.

This was [fixed](https://github.com/chef/chef/pull/8003) for the `dnf_resource`, but not for the `yum_resource` ([a PR was merged](https://github.com/chef/chef/pull/8005) but doesn't fix the problem). Thus, `dnf_package` needs to be used.

The minimal Chef version which supports RHEL 8 is [`v15.0.293`](https://github.com/chef/chef/blob/master/CHANGELOG.md#v150293-2019-05-14) (which is the first public Chef 15 version), so this should be added as a requirement if users want to use the cookbook on RHEL 8

### Additional Notes

I didn't confirm that Fedora 28+ is affected (no kitchen tests on Fedora), but:
- it probably is, as Fedora 28 is the version which corresponds to RHEL 8,
- using `dnf` on Fedora is not a problem (it's the default package manager on this platform)..