### PR TITLE
Fix warnings in tests

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -73,7 +73,6 @@ when 'rhel', 'fedora', 'amazon'
 
   # Add YUM repository
   yum_repository 'datadog' do
-    name 'datadog'
     description 'datadog'
     if node['datadog']['agent6']
       baseurl node['datadog']['agent6_yumrepo']
@@ -124,7 +123,6 @@ when 'suse'
 
   # Add YUM repository
   zypper_repository 'datadog' do
-    name 'datadog'
     description 'datadog'
     if node['datadog']['agent6']
       baseurl node['datadog']['agent6_yumrepo_suse']

--- a/resources/monitor.rb
+++ b/resources/monitor.rb
@@ -2,7 +2,6 @@
 
 default_action :add
 
-property :name, String, name_attribute: true
 property :cookbook, String, default: 'datadog'
 
 # checks have 3 sections: init_config, instances, logs

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -852,7 +852,10 @@ describe 'datadog::dd-agent' do
   context 'service action' do
     describe 'default' do
       cached(:chef_run) do
-        ChefSpec::SoloRunner.new do |node|
+        ChefSpec::SoloRunner.new(
+          platform: 'centos',
+          version: '6.9'
+        ) do |node|
           node.automatic['languages'] = { python: { version: '2.6.2' } }
           node.normal['datadog'] = { api_key: 'somethingnotnil' }
         end.converge described_recipe
@@ -863,7 +866,10 @@ describe 'datadog::dd-agent' do
 
     describe 'agent_enable & agent_start are set to disable, stop' do
       cached(:chef_run) do
-        ChefSpec::SoloRunner.new do |node|
+        ChefSpec::SoloRunner.new(
+          platform: 'centos',
+          version: '6.9'
+        ) do |node|
           node.automatic['languages'] = { python: { version: '2.6.2' } }
           node.normal['datadog'] = {
             api_key: 'somethingnotnil',

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'datadog::default' do
   context 'when converging this recipe' do
-    let(:chef_run) { ChefSpec::SoloRunner.converge described_recipe }
+    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04').converge described_recipe }
 
     it 'should do nothing' do
       expect(chef_run.resource_collection.resources.count).to eq 0

--- a/spec/integrations/activemq_spec.rb
+++ b/spec/integrations/activemq_spec.rb
@@ -64,7 +64,11 @@ describe 'datadog::activemq' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { python: { version: '2.7.11' } }
 
       node.normal['datadog'] = {

--- a/spec/integrations/cassandra_spec.rb
+++ b/spec/integrations/cassandra_spec.rb
@@ -63,7 +63,11 @@ describe 'datadog::cassandra' do
     EOF
 
     cached(:chef_run) do
-      ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '16.04',
+        step_into: ['datadog_monitor']
+      ) do |node|
         node.automatic['languages'] = { python: { version: '2.7.11' } }
 
         node.normal['datadog'] = {
@@ -262,7 +266,11 @@ describe 'datadog::cassandra' do
     EOF
 
     cached(:chef_run) do
-      ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '16.04',
+        step_into: ['datadog_monitor']
+      ) do |node|
         node.automatic['languages'] = { python: { version: '2.7.2' } }
 
         node.normal['datadog'] = {
@@ -801,7 +809,11 @@ describe 'datadog::cassandra' do
     EOF
 
     cached(:chef_run) do
-      ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '16.04',
+        step_into: ['datadog_monitor']
+      ) do |node|
         node.automatic['languages'] = { python: { version: '2.7.2' } }
 
         node.normal['datadog'] = {

--- a/spec/integrations/couchbase_spec.rb
+++ b/spec/integrations/couchbase_spec.rb
@@ -10,7 +10,11 @@ describe 'datadog::couchbase' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
       node.normal['datadog'] = {
         api_key: 'someapikey',

--- a/spec/integrations/directory_spec.rb
+++ b/spec/integrations/directory_spec.rb
@@ -13,7 +13,11 @@ describe 'datadog::directory' do
 EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { python: { version: '2.7.2' } }
 
       node.normal['datadog'] = {

--- a/spec/integrations/disk_spec.rb
+++ b/spec/integrations/disk_spec.rb
@@ -17,7 +17,11 @@ describe 'datadog::disk' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
       node.normal['datadog'] = {
         api_key: 'someapikey',

--- a/spec/integrations/dns_check_spec.rb
+++ b/spec/integrations/dns_check_spec.rb
@@ -16,7 +16,11 @@ describe 'datadog::dns_check' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
 
       node.normal['datadog'] = {

--- a/spec/integrations/docker_daemon_spec.rb
+++ b/spec/integrations/docker_daemon_spec.rb
@@ -39,7 +39,11 @@ describe 'datadog::docker_daemon' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
 
       node.normal['datadog'] = {

--- a/spec/integrations/elasticsearch_spec.rb
+++ b/spec/integrations/elasticsearch_spec.rb
@@ -15,7 +15,11 @@ describe 'datadog::elasticsearch' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
       node.normal['datadog'] = {
         api_key: 'someapikey',

--- a/spec/integrations/etcd_spec.rb
+++ b/spec/integrations/etcd_spec.rb
@@ -13,7 +13,11 @@ describe 'datadog::etcd' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { python: { version: '2.7.2' } }
 
       node.normal['datadog'] = {

--- a/spec/integrations/go-metro_spec.rb
+++ b/spec/integrations/go-metro_spec.rb
@@ -116,7 +116,9 @@ describe 'datadog::go-metro' do
 
     cached(:chef_run) do
       ChefSpec::SoloRunner.new(
-        step_into: ['datadog_monitor'], platform: 'ubuntu', version: '16.04'
+        platform: 'ubuntu',
+        version: '16.04',
+        step_into: ['datadog_monitor']
       ) do |node|
         node.automatic['languages'] = { python: { version: '2.7.2' } }
 

--- a/spec/integrations/go_expvar_spec.rb
+++ b/spec/integrations/go_expvar_spec.rb
@@ -19,7 +19,11 @@ describe 'datadog::go_expvar' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
 
       node.normal['datadog'] = {

--- a/spec/integrations/gunicorn_spec.rb
+++ b/spec/integrations/gunicorn_spec.rb
@@ -8,7 +8,11 @@ describe 'datadog::gunicorn' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { python: { version: '2.7.2' } }
 
       node.normal['datadog'] = {

--- a/spec/integrations/iis_spec.rb
+++ b/spec/integrations/iis_spec.rb
@@ -14,7 +14,11 @@ describe 'datadog::iis' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
       node.normal['datadog'] = {
         api_key: 'someapikey',

--- a/spec/integrations/integrations_spec.rb
+++ b/spec/integrations/integrations_spec.rb
@@ -7,7 +7,11 @@ describe 'datadog::integrations' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { python: { version: '2.7.2' } }
 
       node.normal['datadog'] = {

--- a/spec/integrations/jmx_spec.rb
+++ b/spec/integrations/jmx_spec.rb
@@ -38,7 +38,11 @@ describe 'datadog::jmx' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
 
       node.normal['datadog'] = {

--- a/spec/integrations/kafka_spec.rb
+++ b/spec/integrations/kafka_spec.rb
@@ -154,7 +154,11 @@ describe 'datadog::kafka' do
     EOF
 
     cached(:chef_run) do
-      ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '16.04',
+        step_into: ['datadog_monitor']
+      ) do |node|
         node.automatic['languages'] = { python: { version: '2.7.2' } }
 
         node.normal['datadog'] = {
@@ -578,7 +582,11 @@ describe 'datadog::kafka' do
     EOF
 
     cached(:chef_run) do
-      ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '16.04',
+        step_into: ['datadog_monitor']
+      ) do |node|
         node.automatic['languages'] = { python: { version: '2.7.2' } }
 
         node.normal['datadog'] = {

--- a/spec/integrations/kubernetes_spec.rb
+++ b/spec/integrations/kubernetes_spec.rb
@@ -12,7 +12,11 @@ describe 'datadog::kubernetes' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { python: { version: '2.7.2' } }
 
       node.normal['datadog'] = {

--- a/spec/integrations/mongo_spec.rb
+++ b/spec/integrations/mongo_spec.rb
@@ -11,7 +11,11 @@ describe 'datadog::mongo' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
       node.normal['datadog'] = {
         api_key: 'someapikey',

--- a/spec/integrations/nginx_spec.rb
+++ b/spec/integrations/nginx_spec.rb
@@ -16,7 +16,11 @@ describe 'datadog::nginx' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
       node.normal['datadog'] = {
         api_key: 'someapikey',

--- a/spec/integrations/php_fpm_spec.rb
+++ b/spec/integrations/php_fpm_spec.rb
@@ -20,7 +20,11 @@ describe 'datadog::php_fpm' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
 
       node.normal['datadog'] = {

--- a/spec/integrations/postfix_spec.rb
+++ b/spec/integrations/postfix_spec.rb
@@ -23,7 +23,11 @@ describe 'datadog::postfix' do
   end
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { python: { version: '2.7.2' } }
 
       node.normal['datadog'] = {

--- a/spec/integrations/postgres_spec.rb
+++ b/spec/integrations/postgres_spec.rb
@@ -43,7 +43,11 @@ describe 'datadog::postgres' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { python: { version: '2.7.2' } }
 
       node.normal['datadog'] = {
@@ -120,7 +124,11 @@ describe 'datadog::postgres' do
     EOF
 
     cached(:chef_run) do
-      ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '16.04',
+        step_into: ['datadog_monitor']
+      ) do |node|
         node.automatic['languages'] = { python: { version: '2.7.2' } }
 
         node.normal['datadog'] = {
@@ -162,7 +170,11 @@ describe 'datadog::postgres' do
     EOF
 
     cached(:chef_run) do
-      ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '16.04',
+        step_into: ['datadog_monitor']
+      ) do |node|
         node.automatic['languages'] = { python: { version: '2.7.2' } }
 
         node.normal['datadog'] = {
@@ -212,7 +224,11 @@ describe 'datadog::postgres' do
     EOF
 
     cached(:chef_run) do
-      ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '16.04',
+        step_into: ['datadog_monitor']
+      ) do |node|
         node.automatic['languages'] = { python: { version: '2.7.2' } }
 
         node.normal['datadog'] = {
@@ -283,7 +299,11 @@ describe 'datadog::postgres' do
     EOF
 
     cached(:chef_run) do
-      ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '16.04',
+        step_into: ['datadog_monitor']
+      ) do |node|
         node.automatic['languages'] = { python: { version: '2.7.2' } }
 
         node.normal['datadog'] = {

--- a/spec/integrations/rabbitmq_spec.rb
+++ b/spec/integrations/rabbitmq_spec.rb
@@ -29,7 +29,11 @@ describe 'datadog::rabbitmq' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
       node.normal['datadog'] = {
         api_key: 'someapikey',

--- a/spec/integrations/redis_spec.rb
+++ b/spec/integrations/redis_spec.rb
@@ -21,7 +21,11 @@ describe 'datadog::redisdb' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { python: { version: '2.7.2' } }
 
       node.normal['datadog'] = {

--- a/spec/integrations/snmp_spec.rb
+++ b/spec/integrations/snmp_spec.rb
@@ -48,7 +48,11 @@ describe 'datadog::snmp' do
   EOF
 
     cached(:chef_run) do
-      ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '16.04',
+        step_into: ['datadog_monitor']
+      ) do |node|
         node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
         node.normal['datadog'] = {
           api_key: 'someapikey',
@@ -173,7 +177,11 @@ describe 'datadog::snmp' do
   EOF
 
     cached(:chef_run) do
-      ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '16.04',
+        step_into: ['datadog_monitor']
+      ) do |node|
         node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
         node.normal['datadog'] = {
           api_key: 'someapikey',

--- a/spec/integrations/solr_spec.rb
+++ b/spec/integrations/solr_spec.rb
@@ -80,7 +80,11 @@ describe 'datadog::solr' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
 
       node.normal['datadog'] = {

--- a/spec/integrations/sqlserver_spec.rb
+++ b/spec/integrations/sqlserver_spec.rb
@@ -26,7 +26,11 @@ describe 'datadog::sqlserver' do
   EOF
 
     cached(:chef_run) do
-      ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '16.04',
+        step_into: ['datadog_monitor']
+      ) do |node|
         node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
         node.normal['datadog'] = {
           api_key: 'someapikey',
@@ -102,7 +106,11 @@ describe 'datadog::sqlserver' do
   EOF
 
     cached(:chef_run) do
-      ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '16.04',
+        step_into: ['datadog_monitor']
+      ) do |node|
         node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
         node.normal['datadog'] = {
           api_key: 'someapikey',

--- a/spec/integrations/system_core_spec.rb
+++ b/spec/integrations/system_core_spec.rb
@@ -13,7 +13,11 @@ describe 'datadog::system_core' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
       node.normal['datadog'] = { 'api_key' => 'someapikey' }
     end.converge(described_recipe)

--- a/spec/integrations/system_swap_spec.rb
+++ b/spec/integrations/system_swap_spec.rb
@@ -12,7 +12,11 @@ describe 'datadog::system_swap' do
  EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
       node.normal['datadog'] = { 'api_key' => 'someapikey' }
     end.converge(described_recipe)

--- a/spec/integrations/tokumx_spec.rb
+++ b/spec/integrations/tokumx_spec.rb
@@ -11,7 +11,11 @@ describe 'datadog::tokumx' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
       node.normal['datadog'] = {
         api_key: 'someapikey',

--- a/spec/integrations/win32_event_log_spec.rb
+++ b/spec/integrations/win32_event_log_spec.rb
@@ -19,7 +19,11 @@ describe 'datadog::win32_event_log' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
       node.normal['datadog'] = {
         api_key: 'someapikey',

--- a/spec/integrations/windows_service_spec.rb
+++ b/spec/integrations/windows_service_spec.rb
@@ -14,7 +14,11 @@ describe 'datadog::windows_service' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { python: { version: '2.7.2' } }
 
       node.normal['datadog'] = {
@@ -62,7 +66,11 @@ describe 'datadog::windows_service' do
   EOF
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
       node.automatic['languages'] = { python: { version: '2.7.2' } }
 
       node.normal['datadog'] = {

--- a/spec/integrations/wmi_check_spec.rb
+++ b/spec/integrations/wmi_check_spec.rb
@@ -37,7 +37,11 @@ describe 'datadog::wmi_check' do
     EOF
 
     cached(:chef_run) do
-      ChefSpec::SoloRunner.new(step_into: ['datadog_monitor']) do |node|
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '16.04',
+        step_into: ['datadog_monitor']
+      ) do |node|
         node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
         node.normal['datadog'] = {
           api_key: 'someapikey',


### PR DESCRIPTION
- Fixes linter warning about defining/assigning the "name" property, created by default and assigned by default by Chef.
- Fixes the following warning when running rspec tests:
```
WARNING: you must specify a 'platform' and optionally a 'version' for your
ChefSpec Runner and/or Fauxhai constructor, in the future omitting the
platform will become a hard error. A list of available platforms is available
at https://github.com/chefspec/fauxhai/blob/master/PLATFORMS.md
```