### PR TITLE
Enable permission inheritance on Windows

### DIFF
--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -46,6 +46,11 @@ agent_start = node['datadog']['agent_start'] ? :start : :stop
 #
 if node['datadog']['agent6']
   include_recipe 'datadog::_agent6_config'
+  directory node['datadog']['config_dir'] do
+    if is_windows
+      inherits true # Agent 6/7 rely on inheritance being enabled. Reset it in case it was disabled when installing Agent 5.
+    end
+  end
 else
   # Agent 5 and lower
 

--- a/resources/monitor.rb
+++ b/resources/monitor.rb
@@ -19,7 +19,9 @@ action :add do
   template ::File.join(yaml_dir, "#{new_resource.name}.yaml") do
     # On Windows Agent v5, set the permissions on conf files to Administrators.
     if node['platform_family'] == 'windows'
-      unless node['datadog']['agent6']
+      if node['datadog']['agent6']
+        inherits true # Agent 6/7 rely on inheritance being enabled. Reset it in case it was disabled when installing Agent 5.
+      else
         owner 'Administrators'
         rights :full_control, 'Administrators'
         inherits false


### PR DESCRIPTION
Since we disable this for Agent 5, but it's needed for Agent 6. Agent upgrades were failing.

### Testing done
Reproduced the issue locally without the fix, applied the fix and checked the issue was gone.