### PR TITLE
[windows] add MSI max timeout knob

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -193,7 +193,7 @@ default['datadog']['windows_blacklist_silent_fail'] = false
 
 # Attribute to specify timeout in seconds on MSI operations (install/uninstall)
 # Default should suffice, but provides a knob in case instances with limited resources timeout.
-default['datadog']['windows_msi_timeout'] = 600
+default['datadog']['windows_msi_timeout'] = 900
 
 # Agent installer checksum
 # Expected checksum to validate correct agent installer is downloaded (Windows only)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -191,8 +191,8 @@ default['datadog']['yumrepo_gpgkey_new'] = "#{yum_protocol}://yum.datadoghq.com/
 # the blacklist will be resolved enabling this feature.
 default['datadog']['windows_blacklist_silent_fail'] = false
 
-# Attribute to specify timeout on MSI operations (install/uninstall)
-# Default should suffice, but provides a knob in case instances with limited resources time out.
+# Attribute to specify timeout in seconds on MSI operations (install/uninstall)
+# Default should suffice, but provides a knob in case instances with limited resources timeout.
 default['datadog']['windows_msi_timeout'] = 600
 
 # Agent installer checksum

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -191,6 +191,10 @@ default['datadog']['yumrepo_gpgkey_new'] = "#{yum_protocol}://yum.datadoghq.com/
 # the blacklist will be resolved enabling this feature.
 default['datadog']['windows_blacklist_silent_fail'] = false
 
+# Attribute to specify timeout on MSI operations (install/uninstall)
+# Default should suffice, but provides a knob in case instances with limited resources time out.
+default['datadog']['windows_msi_timeout'] = 600
+
 # Agent installer checksum
 # Expected checksum to validate correct agent installer is downloaded (Windows only)
 default['datadog']['windows_agent_checksum'] = nil

--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -68,6 +68,7 @@ end
 
 package 'Datadog Agent removal' do
   package_name 'Datadog Agent'
+  timeout node['datadog']['windows_msi_timeout']
   action :nothing
 end
 
@@ -118,6 +119,7 @@ windows_package 'Datadog Agent' do # ~FC009
   source temp_file
   installer_type installer_type
   options install_options
+  timeout node['datadog']['windows_msi_timeout']
   action :install
   # Before 3.0.0, we adviced users to use the windows cookbook ~> 1.38.0,
   # we should probably keep the compatibilty for some time.


### PR DESCRIPTION
MSI operations like install/uninstall might timeout on small cloud instances. Adding this knob to allow customers to work around the issue.