### PR TITLE
[windows] Use windows_agent_url to download script

### DIFF
--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -106,7 +106,7 @@ powershell_script 'datadog_6.14.x_fix' do
   # As of v1.37, the windows cookbook doesn't upgrade the package if a newer version is downloaded
   # As a workaround uninstall the package first if a new MSI is downloaded
   code <<-EOH
-((New-Object System.Net.WebClient).DownloadFile('https://s3.amazonaws.com/ddagent-windows-stable/scripts/fix_6_14.ps1', $env:temp + '\\fix_6_14.ps1')); &$env:temp\\fix_6_14.ps1
+((New-Object System.Net.WebClient).DownloadFile('#{node['datadog']['windows_agent_url']}scripts/fix_6_14.ps1', $env:temp + '\\fix_6_14.ps1')); &$env:temp\\fix_6_14.ps1
   EOH
 
   action :nothing


### PR DESCRIPTION
Use case: if our S3 bucket is mirrored, we should also pull the script from local mirror.

We should also probably mention in the readme and/or changelog that on windows the cookbook expects a script to be present on local mirror (if any is used).

Note: should be backported to `2.x` as well (and to the upcoming 4.x)