### PR TITLE
[windows] download fix powershell script with chef, then execute.

### DIFF
--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -106,7 +106,7 @@ remote_file temp_file do
 end
 
 remote_file temp_fix_file do
-  source fix_source
+  source "#{node['datadog']['windows_agent_url']}scripts/fix_6_14.ps1"
   retries package_retries unless package_retries.nil?
   retry_delay package_retry_delay unless package_retry_delay.nil?
   action :nothing

--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -99,14 +99,17 @@ remote_file temp_file do
     # verify will abort update if false
     !unsafe
   end unless node['datadog']['windows_blacklist_silent_fail']
+
+  # these are notified in order
+  notifies :create, "remote_file[#{temp_fix_file}]", :immediately
+  notifies :run, 'powershell_script[datadog_6.14.x_fix]', :immediately
 end
 
 remote_file temp_fix_file do
   source fix_source
   retries package_retries unless package_retries.nil?
   retry_delay package_retry_delay unless package_retry_delay.nil?
-
-  notifies :run, 'powershell_script[datadog_6.14.x_fix]', :immediately
+  action :nothing
 end
 
 powershell_script 'datadog_6.14.x_fix' do


### PR DESCRIPTION
Let's allow chef take care of the fix script downloading duties for better TLS behavior with cloudfront.