### PR TITLE
Add a Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,17 @@
+source 'https://rubygems.org'
+
+# Gems here are used to run `rake release`.
+
+group :release do
+  gem 'emeril'
+  gem 'rake'
+  gem 'chef', '~> 12.22'
+  gem 'foodcritic'
+  gem 'chefspec'
+  gem 'cookstyle'
+  gem 'coveralls'
+  gem 'test-kitchen'
+  gem 'json_spec', '~> 1.1.0'
+  gem 'kitchen-vagrant'
+  gem 'berkshelf', '~> 6.3'
+end


### PR DESCRIPTION
Pin a version of chef that works with the (5-years-unmaintained) emeril gem we use to run `rake release`.
