### PR TITLE
Put monitors default configuration into a dir

### DIFF
--- a/resources/monitor.rb
+++ b/resources/monitor.rb
@@ -16,7 +16,7 @@ property :logs, [Array, nil], required: false, default: []
 action :add do
   Chef::Log.debug("Adding monitoring for #{new_resource.name}")
 
-  template ::File.join(config_file_path(new_resource.name), 'conf.yaml') do
+  template config_file_path(new_resource.name) do
     # On Windows Agent v5, set the permissions on conf files to Administrators.
     if node['platform_family'] == 'windows'
       if node['datadog']['agent6']
@@ -59,8 +59,17 @@ end
 
 def config_file_path(resource_name)
   if node['datadog']['agent6']
-    ::File.join(node['datadog']['agent6_config_dir'], 'conf.d', "#{resource_name}.d")
+    ::File.join(
+      node['datadog']['agent6_config_dir'],
+      'conf.d',
+      "#{resource_name}.d",
+      'conf.yaml'
+    )
   else
-    ::File.join(node['datadog']['config_dir'], 'conf.d', "#{resource_name}.d")
+    ::File.join(
+      node['datadog']['config_dir'],
+      'conf.d',
+      "#{resource_name}.yaml"
+    )
   end
 end

--- a/resources/monitor.rb
+++ b/resources/monitor.rb
@@ -46,6 +46,13 @@ action :add do
     cookbook new_resource.cookbook
     sensitive true
   end
+
+  if agent6?
+    file old_mono_config_file_path(new_resource.name) do
+      action :delete
+      sensitive true
+    end
+  end
 end
 
 action :remove do
@@ -58,7 +65,7 @@ action :remove do
 end
 
 def config_file_path(resource_name)
-  if node['datadog']['agent6']
+  if agent6?
     ::File.join(
       node['datadog']['agent6_config_dir'],
       'conf.d',
@@ -72,4 +79,16 @@ def config_file_path(resource_name)
       "#{resource_name}.yaml"
     )
   end
+end
+
+def old_mono_config_file_path(resource_name)
+  ::File.join(
+    node['datadog']['agent6_config_dir'],
+    'conf.d',
+    "#{resource_name}.yaml"
+  )
+end
+
+def agent6?
+  node['datadog']['agent6']
 end

--- a/spec/integrations/activemq_spec.rb
+++ b/spec/integrations/activemq_spec.rb
@@ -97,7 +97,7 @@ describe 'datadog::activemq' do
   it { is_expected.to add_datadog_monitor('activemq') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/activemq.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/activemq.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/cassandra_spec.rb
+++ b/spec/integrations/cassandra_spec.rb
@@ -161,7 +161,7 @@ describe 'datadog::cassandra' do
     it { is_expected.to add_datadog_monitor('cassandra') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/cassandra.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/cassandra.d/conf.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end
@@ -365,7 +365,7 @@ describe 'datadog::cassandra' do
     it { is_expected.to add_datadog_monitor('cassandra') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/cassandra.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/cassandra.d/conf.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end
@@ -843,7 +843,7 @@ describe 'datadog::cassandra' do
     it { is_expected.to add_datadog_monitor('cassandra') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/cassandra.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/cassandra.d/conf.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end

--- a/spec/integrations/couchbase_spec.rb
+++ b/spec/integrations/couchbase_spec.rb
@@ -40,7 +40,7 @@ describe 'datadog::couchbase' do
   it { is_expected.to add_datadog_monitor('couchbase') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/couchbase.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/couchbase.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/directory_spec.rb
+++ b/spec/integrations/directory_spec.rb
@@ -48,7 +48,7 @@ EOF
   it { is_expected.to add_datadog_monitor('directory') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/directory.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/directory.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/disk_spec.rb
+++ b/spec/integrations/disk_spec.rb
@@ -51,7 +51,7 @@ describe 'datadog::disk' do
   it { is_expected.to add_datadog_monitor('disk') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/disk.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/disk.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(
         YAML.safe_load(expected_yaml).to_json
       )

--- a/spec/integrations/dns_check_spec.rb
+++ b/spec/integrations/dns_check_spec.rb
@@ -56,7 +56,7 @@ describe 'datadog::dns_check' do
   it { is_expected.to add_datadog_monitor('dns_check') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/dns_check.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/dns_check.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/docker_daemon_spec.rb
+++ b/spec/integrations/docker_daemon_spec.rb
@@ -110,7 +110,7 @@ describe 'datadog::docker_daemon' do
   it { is_expected.to manage_group('docker').with(append: true, members: ['dd-agent']) }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/docker_daemon.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/docker_daemon.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/elasticsearch_spec.rb
+++ b/spec/integrations/elasticsearch_spec.rb
@@ -48,7 +48,7 @@ describe 'datadog::elasticsearch' do
   it { is_expected.to add_datadog_monitor('elastic') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/elastic.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/elastic.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/etcd_spec.rb
+++ b/spec/integrations/etcd_spec.rb
@@ -47,7 +47,7 @@ describe 'datadog::etcd' do
   it { is_expected.to add_datadog_monitor('etcd') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/etcd.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/etcd.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/go-metro_spec.rb
+++ b/spec/integrations/go-metro_spec.rb
@@ -80,7 +80,7 @@ describe 'datadog::go-metro' do
 
     it 'renders expected YAML config file' do
       expect(chef_run).to(
-        render_file('/etc/datadog-agent/conf.d/go-metro.yaml')
+        render_file('/etc/datadog-agent/conf.d/go-metro.d/conf.yaml')
         .with_content { |content|
           expect(YAML.safe_load(content).to_json).to be_json_eql(
             YAML.safe_load(expected_yaml).to_json
@@ -176,7 +176,7 @@ describe 'datadog::go-metro' do
 
     it 'renders expected YAML config file' do
       expect(chef_run).to(
-        render_file('/etc/datadog-agent/conf.d/go-metro.yaml')
+        render_file('/etc/datadog-agent/conf.d/go-metro.d/conf.yaml')
         .with_content { |content|
           expect(YAML.safe_load(content).to_json).to be_json_eql(
             YAML.safe_load(expected_yaml).to_json

--- a/spec/integrations/go_expvar_spec.rb
+++ b/spec/integrations/go_expvar_spec.rb
@@ -57,7 +57,7 @@ describe 'datadog::go_expvar' do
   it { is_expected.to add_datadog_monitor('go_expvar') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/go_expvar.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/go_expvar.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/gunicorn_spec.rb
+++ b/spec/integrations/gunicorn_spec.rb
@@ -37,7 +37,7 @@ describe 'datadog::gunicorn' do
   it { is_expected.to add_datadog_monitor('gunicorn') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/gunicorn.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/gunicorn.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/iis_spec.rb
+++ b/spec/integrations/iis_spec.rb
@@ -46,7 +46,7 @@ describe 'datadog::iis' do
   it { is_expected.to add_datadog_monitor('iis') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/iis.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/iis.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/integrations_spec.rb
+++ b/spec/integrations/integrations_spec.rb
@@ -38,7 +38,7 @@ describe 'datadog::integrations' do
   it { is_expected.to add_datadog_monitor('twemproxy') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/twemproxy.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/twemproxy.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/jmx_spec.rb
+++ b/spec/integrations/jmx_spec.rb
@@ -95,7 +95,7 @@ describe 'datadog::jmx' do
   it { is_expected.to add_datadog_monitor('jmx') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/jmx.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/jmx.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/kafka_spec.rb
+++ b/spec/integrations/kafka_spec.rb
@@ -188,7 +188,7 @@ describe 'datadog::kafka' do
     it { is_expected.to add_datadog_monitor('kafka') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/kafka.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/kafka.d/conf.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end
@@ -617,7 +617,7 @@ describe 'datadog::kafka' do
     it { is_expected.to add_datadog_monitor('kafka') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/kafka.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/kafka.d/conf.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end

--- a/spec/integrations/kubernetes_spec.rb
+++ b/spec/integrations/kubernetes_spec.rb
@@ -47,7 +47,7 @@ describe 'datadog::kubernetes' do
   it { is_expected.to add_datadog_monitor('kubernetes') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/kubernetes.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/kubernetes.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/mesos_master_spec.rb
+++ b/spec/integrations/mesos_master_spec.rb
@@ -45,7 +45,7 @@ describe 'datadog::mesos_master' do
   it { is_expected.to add_datadog_monitor('mesos_master') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/mesos_master.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/mesos_master.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/mesos_slave_spec.rb
+++ b/spec/integrations/mesos_slave_spec.rb
@@ -45,7 +45,7 @@ describe 'datadog::mesos_slave' do
   it { is_expected.to add_datadog_monitor('mesos_slave') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/mesos_slave.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/mesos_slave.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/mongo_spec.rb
+++ b/spec/integrations/mongo_spec.rb
@@ -41,7 +41,7 @@ describe 'datadog::mongo' do
   it { is_expected.to add_datadog_monitor('mongo') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/mongo.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/mongo.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/nginx_spec.rb
+++ b/spec/integrations/nginx_spec.rb
@@ -52,7 +52,7 @@ describe 'datadog::nginx' do
   it { is_expected.to add_datadog_monitor('nginx') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/nginx.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/nginx.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/php_fpm_spec.rb
+++ b/spec/integrations/php_fpm_spec.rb
@@ -65,7 +65,7 @@ describe 'datadog::php_fpm' do
   it { is_expected.to add_datadog_monitor('php_fpm') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/php_fpm.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/php_fpm.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/postfix_spec.rb
+++ b/spec/integrations/postfix_spec.rb
@@ -58,7 +58,7 @@ describe 'datadog::postfix' do
   it { is_expected.to add_datadog_monitor('postfix') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/postfix.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/postfix.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/postgres_spec.rb
+++ b/spec/integrations/postgres_spec.rb
@@ -106,7 +106,7 @@ describe 'datadog::postgres' do
   it { is_expected.to add_datadog_monitor('postgres') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/postgres.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/postgres.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end
@@ -154,7 +154,7 @@ describe 'datadog::postgres' do
     it { is_expected.to add_datadog_monitor('postgres') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/postgres.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/postgres.d/conf.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end
@@ -200,7 +200,7 @@ describe 'datadog::postgres' do
     it { is_expected.to add_datadog_monitor('postgres') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/postgres.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/postgres.d/conf.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end
@@ -259,7 +259,7 @@ describe 'datadog::postgres' do
     it { is_expected.to add_datadog_monitor('postgres') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/postgres.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/postgres.d/conf.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end
@@ -352,7 +352,7 @@ describe 'datadog::postgres' do
     it { is_expected.to add_datadog_monitor('postgres') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/postgres.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/postgres.d/conf.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end

--- a/spec/integrations/rabbitmq_spec.rb
+++ b/spec/integrations/rabbitmq_spec.rb
@@ -65,7 +65,7 @@ describe 'datadog::rabbitmq' do
   it { is_expected.to add_datadog_monitor('rabbitmq') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/rabbitmq.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/rabbitmq.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/redis_spec.rb
+++ b/spec/integrations/redis_spec.rb
@@ -62,7 +62,7 @@ describe 'datadog::redisdb' do
   it { is_expected.to add_datadog_monitor('redisdb') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/redisdb.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/redisdb.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/snmp_spec.rb
+++ b/spec/integrations/snmp_spec.rb
@@ -143,7 +143,7 @@ describe 'datadog::snmp' do
     it { is_expected.to add_datadog_monitor('snmp') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/snmp.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/snmp.d/conf.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end
@@ -227,7 +227,7 @@ describe 'datadog::snmp' do
     it { is_expected.to add_datadog_monitor('snmp') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/snmp.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/snmp.d/conf.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end

--- a/spec/integrations/solr_spec.rb
+++ b/spec/integrations/solr_spec.rb
@@ -115,7 +115,7 @@ describe 'datadog::solr' do
   it { is_expected.to add_datadog_monitor('solr') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/solr.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/solr.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/sqlserver_spec.rb
+++ b/spec/integrations/sqlserver_spec.rb
@@ -80,7 +80,7 @@ describe 'datadog::sqlserver' do
     it { is_expected.to add_datadog_monitor('sqlserver') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/sqlserver.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/sqlserver.d/conf.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end
@@ -141,7 +141,7 @@ describe 'datadog::sqlserver' do
     it { is_expected.to add_datadog_monitor('sqlserver') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/sqlserver.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/sqlserver.d/conf.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end

--- a/spec/integrations/system_core_spec.rb
+++ b/spec/integrations/system_core_spec.rb
@@ -32,7 +32,7 @@ describe 'datadog::system_core' do
   it { is_expected.to add_datadog_monitor('system_core') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/system_core.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/system_core.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/system_swap_spec.rb
+++ b/spec/integrations/system_swap_spec.rb
@@ -31,7 +31,7 @@ describe 'datadog::system_swap' do
   it { is_expected.to add_datadog_monitor('system_swap') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/system_swap.yaml')
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/system_swap.d/conf.yaml')
       .with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })

--- a/spec/integrations/tokumx_spec.rb
+++ b/spec/integrations/tokumx_spec.rb
@@ -41,7 +41,7 @@ describe 'datadog::tokumx' do
   it { is_expected.to add_datadog_monitor('tokumx') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/tokumx.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/tokumx.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/win32_event_log_spec.rb
+++ b/spec/integrations/win32_event_log_spec.rb
@@ -54,7 +54,7 @@ describe 'datadog::win32_event_log' do
   it { is_expected.to add_datadog_monitor('win32_event_log') }
 
   it 'renders expected YAML config file' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/win32_event_log.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/win32_event_log.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/windows_service_spec.rb
+++ b/spec/integrations/windows_service_spec.rb
@@ -46,7 +46,7 @@ describe 'datadog::windows_service' do
   it { is_expected.to add_datadog_monitor('windows_service') }
 
   it 'renders expected YAML config file for remote host service monitoring' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/windows_service.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/windows_service.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end
@@ -96,7 +96,7 @@ describe 'datadog::windows_service' do
   it { is_expected.to add_datadog_monitor('windows_service') }
 
   it 'renders expected YAML config file for local host service monitoring' do
-    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/windows_service.yaml').with_content { |content|
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/windows_service.d/conf.yaml').with_content { |content|
       expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
     })
   end

--- a/spec/integrations/wmi_check_spec.rb
+++ b/spec/integrations/wmi_check_spec.rb
@@ -156,7 +156,7 @@ describe 'datadog::wmi_check' do
     it { is_expected.to add_datadog_monitor('wmi_check') }
 
     it 'renders expected YAML config file' do
-      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/wmi_check.yaml').with_content { |content|
+      expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/wmi_check.d/conf.yaml').with_content { |content|
         expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
       })
     end

--- a/test/integration/datadog_apache/serverspec/apache_spec.rb
+++ b/test/integration/datadog_apache/serverspec/apache_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/apache.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/apache.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_cacti/serverspec/cacti_spec.rb
+++ b/test/integration/datadog_cacti/serverspec/cacti_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/cacti.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/cacti.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_cassandra/serverspec/cassandra_spec.rb
+++ b/test/integration/datadog_cassandra/serverspec/cassandra_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/cassandra.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/cassandra.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_cassandra_greater_22/serverspec/cassandra_spec.rb
+++ b/test/integration/datadog_cassandra_greater_22/serverspec/cassandra_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/cassandra.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/cassandra.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_consul/serverspec/consul_spec.rb
+++ b/test/integration/datadog_consul/serverspec/consul_spec.rb
@@ -8,7 +8,7 @@ require 'yaml'
 set :backend, :exec
 set :path, '/sbin:/usr/local/sbin:$PATH'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/consul.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/consul.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_couchdb/serverspec/couchdb_spec.rb
+++ b/test/integration/datadog_couchdb/serverspec/couchdb_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/couch.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/couch.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_docker/serverspec/docker_spec.rb
+++ b/test/integration/datadog_docker/serverspec/docker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/docker.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/docker.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_elasticsearch/serverspec/elasticsearch_spec.rb
+++ b/test/integration/datadog_elasticsearch/serverspec/elasticsearch_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/elastic.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/elastic.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_etcd/serverspec/etcd_spec.rb
+++ b/test/integration/datadog_etcd/serverspec/etcd_spec.rb
@@ -8,7 +8,7 @@ require 'yaml'
 set :backend, :exec
 set :path, '/sbin:/usr/local/sbin:$PATH'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/etcd.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/etcd.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_fluentd/serverspec/fluentd_spec.rb
+++ b/test/integration/datadog_fluentd/serverspec/fluentd_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/fluentd.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/fluentd.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_haproxy/serverspec/haproxy_spec.rb
+++ b/test/integration/datadog_haproxy/serverspec/haproxy_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/haproxy.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/haproxy.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_http_check/serverspec/http_check_spec.rb
+++ b/test/integration/datadog_http_check/serverspec/http_check_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/http_check.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/http_check.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_integrations/serverspec/integrations_spec.rb
+++ b/test/integration/datadog_integrations/serverspec/integrations_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/twemproxy.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/twemproxy.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_jmx/serverspec/dd-agent-jmx_spec.rb
+++ b/test/integration/datadog_jmx/serverspec/dd-agent-jmx_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-JMX_CONFIG = File.join(@agent_config_dir, 'conf.d/jmx.yaml')
+JMX_CONFIG = File.join(@agent_config_dir, 'conf.d/jmx.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_kafka/serverspec/kafka_spec.rb
+++ b/test/integration/datadog_kafka/serverspec/kafka_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/kafka.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/kafka.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_mesos_master/serverspec/mesos_spec.rb
+++ b/test/integration/datadog_mesos_master/serverspec/mesos_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/mesos_master.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/mesos_master.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_mesos_slave/serverspec/mesos_spec.rb
+++ b/test/integration/datadog_mesos_slave/serverspec/mesos_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/mesos_slave.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/mesos_slave.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_mongo/serverspec/mongo_spec.rb
+++ b/test/integration/datadog_mongo/serverspec/mongo_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/mongo.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/mongo.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_mysql/serverspec/mysql_spec.rb
+++ b/test/integration/datadog_mysql/serverspec/mysql_spec.rb
@@ -8,7 +8,7 @@ require 'yaml'
 set :backend, :exec
 set :path, '/sbin:/usr/local/sbin:$PATH'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/mysql.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/mysql.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_ntp/serverspec/ntp_spec.rb
+++ b/test/integration/datadog_ntp/serverspec/ntp_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/ntp.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/ntp.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_pgbouncer/serverspec/pgbouncer_spec.rb
+++ b/test/integration/datadog_pgbouncer/serverspec/pgbouncer_spec.rb
@@ -8,7 +8,7 @@ require 'yaml'
 set :backend, :exec
 set :path, '/sbin:/usr/local/sbin:$PATH'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/pgbouncer.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/pgbouncer.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_postfix/serverspec/postfix_spec.rb
+++ b/test/integration/datadog_postfix/serverspec/postfix_spec.rb
@@ -8,7 +8,7 @@ require 'yaml'
 set :backend, :exec
 set :path, '/sbin:/usr/local/sbin:$PATH'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/postfix.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/postfix.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_process/serverspec/dd-agent-process_spec.rb
+++ b/test/integration/datadog_process/serverspec/dd-agent-process_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-PROCESS_CONFIG = File.join(@agent_config_dir, 'conf.d/process.yaml')
+PROCESS_CONFIG = File.join(@agent_config_dir, 'conf.d/process.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_ssh_check/serverspec/ssh_check_spec.rb
+++ b/test/integration/datadog_ssh_check/serverspec/ssh_check_spec.rb
@@ -8,7 +8,7 @@ require 'yaml'
 set :backend, :exec
 set :path, '/sbin:/usr/local/sbin:$PATH'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/ssh_check.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/ssh_check.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_supervisord/serverspec/supervisord_spec.rb
+++ b/test/integration/datadog_supervisord/serverspec/supervisord_spec.rb
@@ -8,7 +8,7 @@ require 'yaml'
 set :backend, :exec
 set :path, '/sbin:/usr/local/sbin:$PATH'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/supervisord.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/supervisord.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_tcp_check/serverspec/tcp_check_spec.rb
+++ b/test/integration/datadog_tcp_check/serverspec/tcp_check_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/tcp_check.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/tcp_check.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/datadog_vault/serverspec/vault_spec.rb
+++ b/test/integration/datadog_vault/serverspec/vault_spec.rb
@@ -8,7 +8,7 @@ require 'yaml'
 set :backend, :exec
 set :path, '/sbin:/usr/local/sbin:$PATH'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/vault.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/vault.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }

--- a/test/integration/helpers/serverspec/spec_template.rb
+++ b/test/integration/helpers/serverspec/spec_template.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/REPLACEME.yaml')
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/REPLACEME.d/conf.yaml')
 
 describe service(@agent_service_name) do
   it { should be_running }


### PR DESCRIPTION
### What does this PR do?

When generating the default configuration for a monitor, using the monitor resource, the generated file is now put into a specific folder relevant to the monitored resource instead of just creating a file in `/etc/datadog-agent/conf.d`.

For example for mysql, instead of having one generated file at `/etc/datadog-agent/conf.d/mysql.yaml`, the generated file will be put into `/etc/datadog-agent/conf.d/mysql.d/conf.yaml`. 

Special thanks to @iancward who inspired this PR with his contribution on #558.

### Motivation

In reference to #558, the main idea is to allow users and client cookbooks to define several configuration files for their agent's integrations. Generating a file into a specific folder known by the agent will allow it to read the whole folder, thus allowing users to add more files into that specific folder.

### Known Problems

Today, the mesos integration is not working as the generated file in /etc/datadog-agent/conf.d/mesos.yaml is not interpreter as there is now two integrations, `mesos_slave` and `mesos_master` (and their relevant folders `mesos_slave.d` and `mesos_master.d`). This PR breaks the logic as it base itself on the fact that there is a folder having the integration's name. This breaks the mesos-integration kitchen tests.

I will fix the mesos integration very soon in another PR and fix the relevant kitchen tests.
