### PR TITLE
Automatically preppend "1:" and append "-1" to version num if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ If you had an Agent 6 installation, the same configuration will now look like th
 default_attributes(
   'datadog' => {
     'agent_major_version' => 6,          # was 'agent6' => true,
-    'agent_version' => '1:6.10.0-1',     # was 'agent6_version' => '1:6.10.0-1',
+    'agent_version' => '6.10.0',         # was 'agent6_version' => '6.10.0',
     'agent_package_action' => 'install', # was 'agent6_package_action' => 'install',
   }
 )
@@ -182,7 +182,7 @@ To upgrade from an already installed Agent v6 to Agent v7, you'll have to either
   default_attributes(
     'datadog' => {
       'agent_major_version' => 7,
-      'agent_version' => '1:7.15.0-1',
+      'agent_version' => '7.15.0',
       'agent_package_action' => 'install',
     }
   )
@@ -198,7 +198,7 @@ You will need to indicate that you want to setup an Agent v6 instead of v7, pin 
   default_attributes(
     'datadog' => {
       'agent_major_version' => 6,
-      'agent_version' => '1:6.10.0-1',
+      'agent_version' => '6.10.0',
       'agent_allow_downgrade' => true
     }
   )

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,15 +32,13 @@ default['datadog']['application_key'] = nil
 default['datadog']['agent_major_version'] = nil # nil to autodetect based on 'agent_version'
 
 # Agent Version
-# Default of `nil` will install latest version. On Windows, this will also upgrade to latest
-# This attribute accepts either a `string` or `hash` with the key as platform_name and value of package version
-# In the case of fedora and amazon linux, use platform_name of rhel
+# Default of `nil` will install latest version. On Windows, this will also upgrade to latest.
+# This attribute takes a `string` with a version number. For compatibiliy reasons it can also take a
+# hash with the platform_name as key and the version as value.
+# Starting with version 4.1.0, you no longer need to pass the "1:" prefix and "-1" suffix in versions
+# for Debian-based and SUSE.
 # Example:
-# default['datadog']['agent_version'] = {
-#  'rhel' => '5.9.0-1',
-#  'windows' => '5.9.0',
-#  'debian' => '1:5.9.0-1'
-# }
+# default['datadog']['agent_version'] = '7.16.0'
 default['datadog']['agent_version'] = nil # nil to install latest
 
 # Allow override with `upgrade` to get latest (Linux only)

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -12,9 +12,9 @@ class Chef
           end
           dd_agent_version = dd_agent_version[platform_family]
         end
-        if node['platform_family'] == 'suse' || node['platform_family'] == 'debian' then
+        if node['platform_family'] == 'suse' || node['platform_family'] == 'debian'
           if !dd_agent_version.nil? && dd_agent_version.match(/^[0-9]+\.[0-9]+\.[0-9]+((?:~|-)[^0-9\s-]+[^-\s]*)?$/)
-            dd_agent_version = "1:" + dd_agent_version + "-1"
+            dd_agent_version = '1:' + dd_agent_version + '-1'
           end
         end
         dd_agent_version

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -12,6 +12,11 @@ class Chef
           end
           dd_agent_version = dd_agent_version[platform_family]
         end
+        if node['platform_family'] == 'suse' || node['platform_family'] == 'debian' then
+          if !dd_agent_version.nil? && dd_agent_version.match(/^[0-9]+\.[0-9]+\.[0-9]+((?:~|-)[^0-9\s-]+[^-\s]*)?$/)
+            dd_agent_version = "1:" + dd_agent_version + "-1"
+          end
+        end
         dd_agent_version
       end
 

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -1271,4 +1271,21 @@ describe 'datadog::dd-agent' do
       end
     end
   end
+
+  context 'add prefix and suffix to version number in debian' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '14.04'
+      ) do |node|
+        node.normal['datadog'] = {
+          'api_key' => 'somethingnotnil',
+          'agent_version' => '6.16.0'
+        }
+      end.converge described_recipe
+    end
+    it 'installs the full version' do
+      expect(chef_run).to install_apt_package('datadog-agent').with_version('1:6.16.0-1')
+    end
+  end
 end


### PR DESCRIPTION
On Debian-based and SUSE, it's no longer needed to pass the full version.