### PR TITLE
Add standalone release process

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,5 @@
 source 'https://rubygems.org'
 
-group :release do
-  gem 'emeril'
-end
-
 gem 'rake'
 gem 'chef', '= 14.10.9'
 gem 'foodcritic', '~> 11.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,8 +115,6 @@ GEM
     diff-lcs (1.3)
     docile (1.1.5)
     ed25519 (1.2.4)
-    emeril (0.8.0)
-      chef (> 0.10.10)
     equatable (0.6.1)
     erubi (1.9.0)
     erubis (2.7.0)
@@ -382,7 +380,6 @@ DEPENDENCIES
   cookstyle
   coveralls (~> 0.8.19)
   cucumber-core (~> 3.2.1)
-  emeril
   foodcritic (~> 11.4.0)
   json_spec (~> 1.1.4)
   kitchen-docker (~> 2.3.0)

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 #!/usr/bin/env rake
 
-require 'emeril/rake' unless ENV['CI']
 require 'fileutils'
 require 'foodcritic'
 require 'kitchen/rake_tasks'
@@ -8,6 +7,8 @@ require 'rake/clean'
 require 'rspec/core/rake_task'
 require 'cookstyle'
 require 'rubocop/rake_task'
+
+Rake.add_rakelib 'tasks'
 
 task :default => %i[
   style

--- a/tasks/release.rake
+++ b/tasks/release.rake
@@ -1,0 +1,28 @@
+require 'rake'
+require 'chef'
+require 'chef/cookbook_uploader'
+require 'chef/cookbook_site_streaming_uploader'
+require 'chef/knife'
+require 'chef/knife/supermarket_share'
+
+COOKBOOK_PATH = File.join(File.dirname(__FILE__), '..').freeze
+METADATA_PATH = File.join(COOKBOOK_PATH, 'metadata.rb').freeze
+SUPERMARKET_URL = 'https://supermarket.chef.io'.freeze
+
+def load_metadata
+  Chef::Cookbook::Metadata.new.tap do |metadata|
+    metadata.from_file(METADATA_PATH)
+  end
+end
+
+desc 'Release the cookbook on the Chef supermarket'
+task :release, :key_path do
+  Chef::Knife.new.configure_chef
+  metadata = load_metadata
+
+  publisher = Chef::Knife::SupermarketShare.new
+  publisher.config[:cookbook_path] = File.join(COOKBOOK_PATH, '..')
+  publisher.config[:supermarket_site] = SUPERMARKET_URL
+  publisher.name_args = [metadata.name, metadata.category || 'Other']
+  publisher.run
+end


### PR DESCRIPTION
### What does this PR do?

It adds a Rake task to release the cookbook on the Chef supermarket. And it gets rid of emeril.

### Motivation

Getting rid of emeril so we can update our dependencies. Add an up to date release process based on knife supermarket share instead of the cookbook site share (that's what uses Emeril) that is deprecated and that will soon be closed for good.