### PR TITLE
Make kitchen docker tests compatible with agent >5

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -96,19 +96,11 @@ task :circle do
   end
 
   def command
-    commands = []
-
-    kitchen_config.platforms.sort_by(&:name).each_with_index do |platform, index|
+    kitchen_config.instances.sort_by(&:name).each_with_object([]).with_index do |(instance, commands), index|
       next unless index % total_workers == current_worker
-      # Escape the platform name to somehting the CLI will understand.
-      # TODO: This could likely be pulled from kitchen_config.instances somehow
-      name = platform.name.delete('.')
 
-      # Scope the suites to only execute against the Agent+handler installer suites.
-      commands.push "kitchen verify dd-agent-handler-#{name}"
-    end
-
-    commands.join(' && ')
+      commands << "kitchen verify #{instance}"
+    end.join(' && ')
   end
 
   sh command unless command.empty?

--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -17,6 +17,9 @@ platforms:
       require_chef_omnibus: 14.12
       image: 'datadog/docker-library:chef_kitchen_systemd_centos_6'
       run_command: /root/start.sh
+    attributes:
+      datadog:
+        service_provider: Systemd
   - name: centos-7.7
     driver_config:
       require_chef_omnibus: 14.12

--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -48,7 +48,7 @@ suites:
       agent_major_version: <%= agent_major_version %>
       api_key: somenonnullapikeythats32charlong
       application_key: alsonotnil
-      chef_handler_enable: false
+      chef_handler_enable: true
   <% if %w(6 7).include?(agent_major_version) %>
   excludes:
     - ubuntu-14.04

--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -49,4 +49,9 @@ suites:
       api_key: somenonnullapikeythats32charlong
       application_key: alsonotnil
       chef_handler_enable: false
+  <% if %w(6 7).include?(agent_major_version) %>
+  excludes:
+    - ubuntu-14.04
+    - debian-8.11
+  <% end %>
 <% end %>

--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -15,21 +15,35 @@ platforms:
   - name: centos-6.6
     driver_config:
       require_chef_omnibus: 14.12
+      image: 'datadog/docker-library:chef_kitchen_systemd_centos_6'
+      run_command: /root/start.sh
   - name: centos-7.7
     driver_config:
       require_chef_omnibus: 14.12
+      image: 'datadog/docker-library:chef_kitchen_systemd_centos_7'
+      run_command: /root/start.sh
   - name: debian-8.11
     driver_config:
       require_chef_omnibus: 14.12
 
 suites:
-- name: dd-agent-handler
+<%
+  agent_major_versions = %w(
+    5
+    6
+    7
+  )
+
+  agent_major_versions.each do |agent_major_version|
+%>
+- name: dd-agent-handler<%= agent_major_version %>
   run_list:
-    - recipe[datadog::dd-handler]
     - recipe[datadog::dd-agent]
+    - recipe[datadog::dd-handler]
   attributes:
     datadog:
-      # TODO(remy): run those tests with Agent v6 recipe.
-      agent_major_version: 5
+      agent_major_version: <%= agent_major_version %>
       api_key: somenonnullapikeythats32charlong
       application_key: alsonotnil
+      chef_handler_enable: false
+<% end %>

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -131,6 +131,14 @@ if Chef::Datadog.agent_major_version(node) > 5 &&
   service_provider = Chef::Provider::Service::Upstart
 end
 
+if node['datadog']['service_provider']
+  specified_provider = node['datadog']['service_provider']
+
+  if Chef::Provider::Service.constants.include?(specified_provider.to_sym)
+    service_provider = Chef::Provider::Service.const_get(specified_provider)
+  end
+end
+
 service_name = is_windows ? 'DatadogAgent' : 'datadog-agent'
 
 service 'datadog-agent' do

--- a/test/integration/dd-agent-handler5/serverspec/dd-agent_spec.rb
+++ b/test/integration/dd-agent-handler5/serverspec/dd-agent_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe package(@agent_package_name) do
+  it { should be_installed }
+end
+
+describe service(@agent_service_name) do
+  it { should be_running }
+end
+
+describe command('/etc/init.d/datadog-agent info | grep -v "API Key is invalid"'), :if => os[:family] != 'windows' do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should contain 'OK' }
+  its(:stdout) { should_not contain 'ERROR' }
+end
+
+# The new APT key is imported
+describe command('apt-key list'), :if => ['debian', 'ubuntu'].include?(os[:family]) do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should contain '382E94DE' }
+end
+
+# The new RPM key is imported
+describe command('rpm -q gpg-pubkey-e09422b3'), :if => os[:family] == 'redhat' do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should contain 'gpg-pubkey-e09422b3' }
+end

--- a/test/integration/dd-agent-handler5/serverspec/dd-handler_spec.rb
+++ b/test/integration/dd-agent-handler5/serverspec/dd-handler_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+# the be_installed.by('gem') check is not implemented for Windows as of v2.24 of Serverspec
+describe package('chef-handler-datadog'), :if => os[:family] != 'windows' do
+  it { should be_installed.by('gem') }
+end

--- a/test/integration/dd-agent-handler6/serverspec/dd-agent_spec.rb
+++ b/test/integration/dd-agent-handler6/serverspec/dd-agent_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe package(@agent_package_name) do
+  it { should be_installed }
+end
+
+describe service(@agent_service_name) do
+  it { should be_running }
+end
+
+describe command('/opt/datadog-agent/bin/agent/agent status | grep -v "Instance ID"'), :if => os[:family] != 'windows' do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should contain '[OK]' }
+  its(:stdout) { should_not contain 'ERROR' }
+end
+
+# The new APT key is imported
+describe command('apt-key list'), :if => ['debian', 'ubuntu'].include?(os[:family]) do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should contain '382E94DE' }
+end
+
+# The new RPM key is imported
+describe command('rpm -q gpg-pubkey-e09422b3'), :if => os[:family] == 'redhat' do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should contain 'gpg-pubkey-e09422b3' }
+end

--- a/test/integration/dd-agent-handler6/serverspec/dd-handler_spec.rb
+++ b/test/integration/dd-agent-handler6/serverspec/dd-handler_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+# the be_installed.by('gem') check is not implemented for Windows as of v2.24 of Serverspec
+describe package('chef-handler-datadog'), :if => os[:family] != 'windows' do
+  it { should be_installed.by('gem') }
+end

--- a/test/integration/dd-agent-handler7/serverspec/dd-agent_spec.rb
+++ b/test/integration/dd-agent-handler7/serverspec/dd-agent_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe package(@agent_package_name) do
+  it { should be_installed }
+end
+
+describe service(@agent_service_name) do
+  it { should be_running }
+end
+
+describe command('/opt/datadog-agent/bin/agent/agent status | grep -v "Instance ID"'), :if => os[:family] != 'windows' do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should contain '[OK]' }
+  its(:stdout) { should_not contain 'ERROR' }
+end
+
+# The new APT key is imported
+describe command('apt-key list'), :if => ['debian', 'ubuntu'].include?(os[:family]) do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should contain '382E94DE' }
+end
+
+# The new RPM key is imported
+describe command('rpm -q gpg-pubkey-e09422b3'), :if => os[:family] == 'redhat' do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should contain 'gpg-pubkey-e09422b3' }
+end

--- a/test/integration/dd-agent-handler7/serverspec/dd-handler_spec.rb
+++ b/test/integration/dd-agent-handler7/serverspec/dd-handler_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+# the be_installed.by('gem') check is not implemented for Windows as of v2.24 of Serverspec
+describe package('chef-handler-datadog'), :if => os[:family] != 'windows' do
+  it { should be_installed.by('gem') }
+end


### PR DESCRIPTION
### What does this PR do?
Added kitchen docker tests using the agent 6 and 7 on every OSes. Agent > 5 does not use supervisord but system specific init runners like system 5 or systemd. For systemd OSes, it use specific homemade images simulated systemd. For system5 OSes, the PR https://github.com/DataDog/datadog-agent/pull/4691 fix the system5 init.d scripts for compability with docker.

### Motivation

We will be able to run chef kitchen docker tests on the CI for agent 5 but also for agent 6 and 7.