### PR TITLE
Add -1 version suffix if not set on OSes with yum

### DIFF
--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -12,9 +12,11 @@ class Chef
           end
           dd_agent_version = dd_agent_version[platform_family]
         end
-        if node['platform_family'] == 'suse' || node['platform_family'] == 'debian'
-          if !dd_agent_version.nil? && dd_agent_version.match(/^[0-9]+\.[0-9]+\.[0-9]+((?:~|-)[^0-9\s-]+[^-\s]*)?$/)
+        if !dd_agent_version.nil? && dd_agent_version.match(/^[0-9]+\.[0-9]+\.[0-9]+((?:~|-)[^0-9\s-]+[^-\s]*)?$/)
+          if node['platform_family'] == 'suse' || node['platform_family'] == 'debian'
             dd_agent_version = '1:' + dd_agent_version + '-1'
+          elsif node['platform_family'] == 'rhel' || node['platform_family'] == 'fedora' || node['platform_family'] == 'amazon'
+            dd_agent_version += '-1'
           end
         end
         dd_agent_version

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -1288,4 +1288,21 @@ describe 'datadog::dd-agent' do
       expect(chef_run).to install_apt_package('datadog-agent').with_version('1:6.16.0-1')
     end
   end
+
+  context 'add suffix to version number in fedora' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(
+        platform: 'fedora',
+        version: '27'
+      ) do |node|
+        node.normal['datadog'] = {
+          'api_key' => 'somethingnotnil',
+          'agent_version' => '6.16.0'
+        }
+      end.converge described_recipe
+    end
+    it 'installs the full version' do
+      expect(chef_run).to install_yum_package('datadog-agent').with_version('6.16.0-1')
+    end
+  end
 end


### PR DESCRIPTION
Adds a `-1` suffix to agent versions before passing them to `yum_package`. Otherwise, it fails to find them.

Tested on RHEL and CentOS. Assuming it works the same way on Fedora and Amazon Linux since they also use `yum`. 

RHEL >= 8 and Fedora >= 28 use `dnf` instead of `yum, which takes both formats so it should still be fine to add the suffix.