### PR TITLE
Use new S3 URL format

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -158,7 +158,7 @@ default['datadog']['yumrepo_gpgkey'] = "#{yum_protocol}://yum.datadoghq.com/DATA
 default['datadog']['yumrepo_proxy'] = nil
 default['datadog']['yumrepo_proxy_username'] = nil
 default['datadog']['yumrepo_proxy_password'] = nil
-default['datadog']['windows_agent_url'] = 'https://s3.amazonaws.com/ddagent-windows-stable/'
+default['datadog']['windows_agent_url'] = 'https://ddagent-windows-stable.s3.amazonaws.com/'
 
 # This attribute is unsupported and liable to change in patch or minor releases
 # The vast majority of use cases will never require you to set this attribute


### PR DESCRIPTION
### What does this PR do?

Switch S3 URLs to virtual-hosted style.

### Motivation

Comply with the new standard. Even if old buckets should not be affected, let's be consistent in the path style we use.
