### PR TITLE
Adding Memcache integration "options"

### DIFF
--- a/recipes/memcache.rb
+++ b/recipes/memcache.rb
@@ -10,7 +10,11 @@ include_recipe 'datadog::dd-agent'
 #                                    {
 #                                      "url" => "localhost",
 #                                      "port" => "11211",
-#                                      "tags" => ["prod", "aws"]
+#                                      "tags" => ["prod", "aws"],
+#                                      "options" => [
+#                                        "items: false",
+#                                        "slabs: false"
+#                                      ]
 #                                    }
 #                                   ]
 

--- a/templates/default/mcache.yaml.erb
+++ b/templates/default/mcache.yaml.erb
@@ -12,6 +12,12 @@ instances:
       - <%= t %>
       <% end -%>
     <% end -%>
+    <% if i.key?('options') -%>
+    options:
+      <% i['options'].each do |o| -%>
+        <%= o %>
+      <% end -%>
+    <% end -%>
   <% end -%>
 
 init_config:


### PR DESCRIPTION
there is a field in the memcache integration for "options" which allows for additional metrics to be gathered. This pull requests allows this parameter to be flipped on when deploying the integration.
https://github.com/DataDog/integrations-core/blob/master/mcache/datadog_checks/mcache/data/conf.yaml.example#L44-L46

This is similar to the mysql template, which does include this option https://github.com/DataDog/chef-datadog/blob/master/templates/default/mysql.yaml.erb#L24-L27