### PR TITLE
Force reinstallation of agent when downgrading to old version on Windows

### DIFF
--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -104,6 +104,10 @@ class Chef
         end
 
         def chef_version_can_uninstall?
+          # Chef versions previous to 14 cannot correctly uninstall the agent
+          # because they cannot correctly fetch the registry keys of 64 bits
+          # applications for uninstallation so we are only using the downgrade
+          # feature on chef >= to 14
           Gem::Requirement.new('>= 14').satisfied_by?(Gem::Version.new(Chef::VERSION))
         end
       end

--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -34,12 +34,12 @@ temp_fix_file = ::File.join(Chef::Config[:file_cache_path], 'fix_6_14.ps1')
 if node['datadog']['windows_agent_use_exe']
   dd_agent_installer = "#{dd_agent_installer_basename}.exe"
   temp_file = "#{temp_file_basename}.exe"
-  installer_type = :custom
+  resolved_installer_type = :custom
   install_options = '/q'
 else
   dd_agent_installer = "#{dd_agent_installer_basename}.msi"
   temp_file = "#{temp_file_basename}.msi"
-  installer_type = :msi
+  resolved_installer_type = :msi
   # Agent >= 5.12.0 installs per-machine by default, but specifying ALLUSERS=1 shouldn't affect the install
   install_options = '/norestart ALLUSERS=1'
 
@@ -107,7 +107,7 @@ end
 # Install the package
 windows_package 'Datadog Agent' do # ~FC009
   source temp_file
-  installer_type installer_type
+  installer_type resolved_installer_type
   options install_options
   timeout node['datadog']['windows_msi_timeout']
   action :install

--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -19,6 +19,8 @@
 
 dd_agent_version = Chef::Datadog.agent_version(node)
 
+dd_agent_version = Chef::Datadog.agent_version(node)
+
 if dd_agent_version.nil?
   # Use latest
   agent_major_version = Chef::Datadog.agent_major_version(node)

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -148,6 +148,9 @@ describe 'datadog::dd-agent' do
         allow(File).to receive(:open).with(temp_file).and_return('foo')
         allow(Digest::SHA256).to receive(:file).and_call_original
         allow(Digest::SHA256).to receive(:file).with(temp_file).and_return(mock_digest)
+        allow(Chef::Datadog::WindowsInstallHelpers)
+          .to receive(:must_reinstall?)
+          .and_return(true)
       end
 
       it_behaves_like 'windows Datadog Agent', :msi
@@ -176,6 +179,9 @@ describe 'datadog::dd-agent' do
         allow(File).to receive(:open).with(temp_file).and_return('foo')
         allow(Digest::SHA256).to receive(:file).and_call_original
         allow(Digest::SHA256).to receive(:file).with(temp_file).and_return(mock_digest)
+        allow(Chef::Datadog::WindowsInstallHelpers)
+          .to receive(:must_reinstall?)
+          .and_return(true)
       end
 
       it_behaves_like 'windows Datadog Agent', :exe
@@ -249,6 +255,9 @@ describe 'datadog::dd-agent' do
         allow(File).to receive(:open).with(temp_file).and_return('foo')
         allow(Digest::SHA256).to receive(:file).and_call_original
         allow(Digest::SHA256).to receive(:file).with(temp_file).and_return(mock_digest)
+        allow(Chef::Datadog::WindowsInstallHelpers)
+          .to receive(:must_reinstall?)
+          .and_return(true)
       end
 
       it_behaves_like 'windows Datadog Agent v5', :msi
@@ -345,6 +354,9 @@ describe 'datadog::dd-agent' do
         allow(File).to receive(:open).with(temp_file).and_return('foo')
         allow(Digest::SHA256).to receive(:file).and_call_original
         allow(Digest::SHA256).to receive(:file).with(temp_file).and_return(mock_digest)
+        allow(Chef::Datadog::WindowsInstallHelpers)
+          .to receive(:must_reinstall?)
+          .and_return(true)
       end
 
       it_behaves_like 'windows Datadog Agent', :msi
@@ -388,6 +400,9 @@ describe 'datadog::dd-agent' do
         allow(File).to receive(:open).with(temp_file).and_return('foo')
         allow(Digest::SHA256).to receive(:file).and_call_original
         allow(Digest::SHA256).to receive(:file).with(temp_file).and_return(mock_digest)
+        allow(Chef::Datadog::WindowsInstallHelpers)
+          .to receive(:must_reinstall?)
+          .and_return(true)
       end
 
       it_behaves_like 'windows Datadog Agent', :msi
@@ -495,6 +510,9 @@ describe 'datadog::dd-agent' do
         allow(File).to receive(:open).with(temp_file).and_return('foo')
         allow(Digest::SHA256).to receive(:file).and_call_original
         allow(Digest::SHA256).to receive(:file).with(temp_file).and_return(mock_digest)
+        allow(Chef::Datadog::WindowsInstallHelpers)
+          .to receive(:must_reinstall?)
+          .and_return(true)
       end
 
       it_behaves_like 'windows Datadog Agent v5', :msi


### PR DESCRIPTION
### What does this PR do?

It reinstalls the agent, only if the targeted agent_version is lower than the currently installed version. Also, it skips the reinstallation on chef versions lower than 14 as it does not correctly uninstall the agent.

### Motivation

The agent installer does not support downgrading since the fix for the windows incident on 6.14. By allowing to explicitly uninstall and then reinstall the agent when a lower version of the agent is targeted, we are allowing our users to downgrade.