### PR TITLE
Default skip_ssl_validation into false

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -247,7 +247,7 @@ default['datadog']['web_proxy']['host'] = nil
 default['datadog']['web_proxy']['port'] = nil
 default['datadog']['web_proxy']['user'] = nil
 default['datadog']['web_proxy']['password'] = nil
-default['datadog']['web_proxy']['skip_ssl_validation'] = nil # accepted values 'yes' or 'no'
+default['datadog']['web_proxy']['skip_ssl_validation'] = nil # accepted values true or false
 default['datadog']['web_proxy']['no_proxy'] = nil # only used for agent v6.0+
 
 # dogstatsd


### PR DESCRIPTION
Related issue: https://github.com/DataDog/chef-datadog/issues/692

Modified comments on skip_ssl_validation that suggests true/false is supported value to be populated into datadog config, which is compatible across agent v5, v6, and v7