### PR TITLE
Release version 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changes
 =======
 
+# 4.2.0 / 2020-02-27
+
+* [FEATURE] Automatically uninstall and then install the Agent only when trying to downgrade agent version on Windows. See [#690][] [@kbogtob][]
+* [BUGFIX] Set Windows installer as sensitive resource and use env var to specify Windows user credentials to avoid leaks of credentials in logs. See [#691][] and [#694][] [@julien-lebot][]
+* [FEATURE] Support tags feature on directory integration. See [#687][] [@dimier]
+
 # 4.1.1 / 2020-01-28
 
 * [BUGFIX] Fix version formating for Linuxes that use yum. See [#685][] [@albertvaka][]
@@ -838,6 +844,10 @@ A fix has gone in to `apt` 2.1.0 that relaxes this condition, and plays well wit
 [#675]: https://github.com/DataDog/chef-datadog/issues/675
 [#678]: https://github.com/DataDog/chef-datadog/issues/678
 [#685]: https://github.com/DataDog/chef-datadog/issues/685
+[#687]: https://github.com/DataDog/chef-datadog/issues/687
+[#690]: https://github.com/DataDog/chef-datadog/issues/690
+[#691]: https://github.com/DataDog/chef-datadog/issues/691
+[#694]: https://github.com/DataDog/chef-datadog/issues/694
 [@ABrehm264]: https://github.com/ABrehm264
 [@AlexBevan]: https://github.com/AlexBevan
 [@BrentOnRails]: https://github.com/BrentOnRails
@@ -882,6 +892,7 @@ A fix has gone in to `apt` 2.1.0 that relaxes this condition, and plays well wit
 [@darron]: https://github.com/darron
 [@datwiz]: https://github.com/datwiz
 [@degemer]: https://github.com/degemer
+[@dimier]: https://github.com/dimier
 [@dlackty]: https://github.com/dlackty
 [@dominicchan]: https://github.com/dominicchan
 [@donaldguy]: https://github.com/donaldguy
@@ -921,6 +932,7 @@ A fix has gone in to `apt` 2.1.0 that relaxes this condition, and plays well wit
 [@jschirle73]: https://github.com/jschirle73
 [@jtimberman]: https://github.com/jtimberman
 [@juliandunn]: https://github.com/juliandunn
+[@julien-lebot]: https://github.com/julien-lebot
 [@jvrplmlmn]: https://github.com/jvrplmlmn
 [@kbogtob]: https://github.com/kbogtob
 [@kevinconaway]: https://github.com/kevinconaway

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,7 +194,7 @@ GEM
       net-ssh-gateway (>= 1.2.0)
     net-telnet (0.1.1)
     nio4r (2.5.2)
-    nokogiri (1.10.7)
+    nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     nori (2.6.0)
     octokit (4.14.0)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'package@datadoghq.com'
 license          'Apache-2.0'
 description      'Installs/Configures datadog components'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '4.1.1'
+version          '4.2.0'
 chef_version     '>= 12.7'
 source_url       'https://github.com/DataDog/chef-datadog'
 issues_url       'https://github.com/DataDog/chef-datadog/issues'


### PR DESCRIPTION
### What does this PR do?

Update CHANGELOG.md and metadata.rb to prepare the release of version 4.2.0.

It also updates the Gemfile.lock to update the Nokogiri dependency.