### PR TITLE
Revert windows login leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 Changes
 =======
 
-# 4.2.0 / 2020-02-27
+# 4.2.0 / 2020-02-27 - KNOWN BUG
 
 * [FEATURE] Automatically uninstall and then install the Agent only when trying to downgrade agent version on Windows. See [#690][] [@kbogtob][]
-* [BUGFIX] Set Windows installer as sensitive resource and use env var to specify Windows user credentials to avoid leaks of credentials in logs. See [#691][] and [#694][] [@julien-lebot][]
+* [BUGFIX] Set Windows installer as sensitive resource and use env var to specify Windows user credentials to avoid leaks of credentials in logs. See [#691][] and [#694][] [@julien-lebot][] - Known bug: This bugfix introduces a new bug blocking users not using credentials to install on Windows
 * [FEATURE] Support tags feature on directory integration. See [#687][] [@dimier]
 * [FEATURE] Support options feature on memcache integration. See [#689][] [@mikelaning]
 

--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -46,8 +46,8 @@ else
   # Since 6.11.0, the core and APM/trace components of the Windows Agent run under
   # a specific user instead of LOCAL_SYSTEM, check whether the user has provided
   # custom credentials and use them if that's the case.
-  install_options.concat(' DDAGENTUSER_NAME=%DDAGENTUSER_NAME%')
-  install_options.concat(' DDAGENTUSER_PASSWORD=%DDAGENTUSER_PASSWORD%')
+  install_options.concat(' DDAGENTUSER_NAME=').concat(Chef::Datadog.ddagentuser_name(node)) if Chef::Datadog.ddagentuser_name(node)
+  install_options.concat(' DDAGENTUSER_PASSWORD=').concat(Chef::Datadog.ddagentuser_password(node)) if Chef::Datadog.ddagentuser_password(node)
 end
 
 package 'Datadog Agent removal' do
@@ -108,16 +108,6 @@ powershell_script 'datadog_6.14.x_fix' do
   notifies :remove, 'package[Datadog Agent removal]', :immediately
 end
 
-windows_env 'DDAGENTUSER_NAME' do
-  value Chef::Datadog.ddagentuser_name(node) if Chef::Datadog.ddagentuser_name(node)
-  sensitive true
-end
-
-windows_env 'DDAGENTUSER_PASSWORD' do
-  value Chef::Datadog.ddagentuser_password(node) if Chef::Datadog.ddagentuser_password(node)
-  sensitive true
-end
-
 # Install the package
 windows_package 'Datadog Agent' do # ~FC009
   source temp_file
@@ -140,12 +130,4 @@ windows_package 'Datadog Agent' do # ~FC009
 
     unsafe
   end
-end
-
-windows_env 'DDAGENTUSER_NAME' do
-  action :delete
-end
-
-windows_env 'DDAGENTUSER_PASSWORD' do
-  action :delete
 end

--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -17,29 +17,6 @@
 # limitations under the License.
 #
 
-include_recipe 'chef_handler'
-
-module Windows
-  class Helper
-    def do_cleanup(context)
-      Chef::Log.info 'Windows environment vars cleanup started.'
-      resource = context.resource_collection.lookup('windows_env[DDAGENTUSER_NAME]')
-      resource.run_action(:delete) if resource
-      resource = context.resource_collection.lookup('windows_env[DDAGENTUSER_PASSWORD]')
-      resource.run_action(:delete) if resource
-      Chef::Log.info 'Windows environment vars cleanup finished.'
-    end
-  end
-end
-
-Chef.event_handler do
-  on :run_failed do
-    Windows::Helper.new.do_cleanup(
-      Chef.run_context
-    )
-  end
-end
-
 dd_agent_version = Chef::Datadog.agent_version(node)
 
 if dd_agent_version.nil?
@@ -167,10 +144,8 @@ end
 
 windows_env 'DDAGENTUSER_NAME' do
   action :delete
-  sensitive true
 end
 
 windows_env 'DDAGENTUSER_PASSWORD' do
   action :delete
-  sensitive true
 end


### PR DESCRIPTION
### What does this PR do?

Reverting #694 and #691 

### Motivation

Users could not use the cookbook to install the agent on Windows without credentials

Fixes: #698