### PR TITLE
Add installation info metadata support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -230,6 +230,9 @@ default['datadog']['agent_enable'] = true
 # Start agent or not
 default['datadog']['agent_start'] = true
 
+# installation info
+default['datadog']['install_info_enabled'] = true
+
 # Logging configuration
 default['datadog']['syslog']['active'] = false
 default['datadog']['syslog']['udp'] = false

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -59,6 +59,10 @@ class Chef
         run_state_or_attribute(node, 'windows_ddagentuser_password')
       end
 
+      def cookbook_version(run_context)
+        run_context.cookbook_collection['datadog'].version
+      end
+
       private
 
       def run_state_or_attribute(node, attribute)

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -173,5 +173,8 @@ if system_probe_managed
   end
 end
 
+# Installation metadata to let know the agent about installation method and its version
+include_recipe 'datadog::install_info'
+
 # Install integration packages
 include_recipe 'datadog::integrations' unless is_windows

--- a/recipes/install_info.rb
+++ b/recipes/install_info.rb
@@ -51,7 +51,7 @@ template flare_path do
 
   variables(
     install_method: "chef-#{Chef::VERSION}",
-    install_method_version: "datadog-cookbook-#{Chef::Datadog.cookbook_version(run_context)}"
+    install_method_version: "datadog_cookbook-#{Chef::Datadog.cookbook_version(run_context)}"
   )
   sensitive true
 end

--- a/recipes/install_info.rb
+++ b/recipes/install_info.rb
@@ -50,8 +50,8 @@ template flare_path do
   source 'install_info.yaml.erb'
 
   variables(
-    install_method: "chef-#{Chef::VERSION}",
-    install_method_version: "datadog_cookbook-#{Chef::Datadog.cookbook_version(run_context)}"
+    chef_version: Chef::VERSION,
+    cookbook_version: Chef::Datadog.cookbook_version(run_context)
   )
   sensitive true
 end

--- a/recipes/install_info.rb
+++ b/recipes/install_info.rb
@@ -51,7 +51,7 @@ template flare_path do
 
   variables(
     install_method: "chef-#{Chef::VERSION}",
-    install_method_version: "datadog-cookbook-#{Chef::Datadog.cookbook_version(run_context)}",
+    install_method_version: "datadog-cookbook-#{Chef::Datadog.cookbook_version(run_context)}"
   )
   sensitive true
 end

--- a/recipes/install_info.rb
+++ b/recipes/install_info.rb
@@ -1,0 +1,57 @@
+#
+# Cookbook Name:: datadog
+# Recipe:: install_info
+#
+# Copyright 2011-2020, Datadog
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Create install info metadata to send installation metadata to Datadog
+# example:
+# default['datadog']['install_info_enabled'] = true
+
+return if Chef::Datadog.agent_major_version(node) == 5
+
+def flare_path
+  case node['platform_family']
+  when 'windows'
+    "#{ENV['ProgramData']}/Datadog/install_info"
+  else
+    '/etc/datadog-agent/install_info'
+  end
+end
+
+template flare_path do
+  if node['datadog']['install_info_enabled']
+    action :create
+  else
+    action :delete
+  end
+
+  case node['platform_family']
+  when 'windows'
+    inherits true # Agent 6/7 rely on inheritance being enabled. Reset it in case it was disabled when installing Agent 5.
+  else
+    owner 'dd-agent'
+    mode '600'
+  end
+
+  source 'install_info.yaml.erb'
+
+  variables(
+    install_method: "chef-#{Chef::VERSION}",
+    install_method_version: "datadog-cookbook-#{Chef::Datadog.cookbook_version(run_context)}",
+  )
+  sensitive true
+end

--- a/templates/default/install_info.yaml.erb
+++ b/templates/default/install_info.yaml.erb
@@ -1,6 +1,7 @@
-<%= JSON.parse(({
+<%=
+{
   'install_method' => {
     'name' => @install_method,
     'version' => @install_method_version,
-  }
-}).to_json).to_yaml %>
+  },
+}.to_yaml %>

--- a/templates/default/install_info.yaml.erb
+++ b/templates/default/install_info.yaml.erb
@@ -1,7 +1,8 @@
 <%=
 {
   'install_method' => {
-    'name' => @install_method,
-    'version' => @install_method_version,
+    'tool' => 'chef',
+    'tool_version' => "chef-#{@chef_version}",
+    'installer_version' => "datadog_cookbook-#{@cookbook_version}",
   },
 }.to_yaml %>

--- a/templates/default/install_info.yaml.erb
+++ b/templates/default/install_info.yaml.erb
@@ -1,0 +1,6 @@
+<%= JSON.parse(({
+  'install_method' => {
+    'name' => @install_method,
+    'version' => @install_method_version,
+  }
+}).to_json).to_yaml %>

--- a/test/integration/dd-agent/serverspec/install_info_spec.rb
+++ b/test/integration/dd-agent/serverspec/install_info_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'Install infos' do
+  let(:install_info_path) do
+    if os == :windows
+      conf_path = "#{ENV['ProgramData']}\\Datadog\\install_info"
+    else
+      '/etc/datadog-agent/install_info'
+    end
+  end
+
+  let(:install_info) do
+    YAML.load_file(install_info_path)
+  end
+
+  it 'adds an install_info' do
+    expect(install_info['install_method']).to match(
+      'name' => /chef-\d+\.\d+\.\d+/,
+      'version' => /^datadog-cookbook-\d+\.\d+\.\d+$/
+    )
+  end
+end

--- a/test/integration/dd-agent/serverspec/install_info_spec.rb
+++ b/test/integration/dd-agent/serverspec/install_info_spec.rb
@@ -15,8 +15,9 @@ describe 'Install infos' do
 
   it 'adds an install_info' do
     expect(install_info['install_method']).to match(
-      'name' => /chef-\d+\.\d+\.\d+/,
-      'version' => /^datadog_cookbook-\d+\.\d+\.\d+$/
+      'tool_version' => /chef-\d+\.\d+\.\d+/,
+      'tool' => 'chef',
+      'installer_version' => /^datadog_cookbook-\d+\.\d+\.\d+$/
     )
   end
 end

--- a/test/integration/dd-agent/serverspec/install_info_spec.rb
+++ b/test/integration/dd-agent/serverspec/install_info_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Install infos' do
   let(:install_info_path) do
     if os == :windows
-      conf_path = "#{ENV['ProgramData']}\\Datadog\\install_info"
+      "#{ENV['ProgramData']}\\Datadog\\install_info"
     else
       '/etc/datadog-agent/install_info'
     end

--- a/test/integration/dd-agent/serverspec/install_info_spec.rb
+++ b/test/integration/dd-agent/serverspec/install_info_spec.rb
@@ -16,7 +16,7 @@ describe 'Install infos' do
   it 'adds an install_info' do
     expect(install_info['install_method']).to match(
       'name' => /chef-\d+\.\d+\.\d+/,
-      'version' => /^datadog-cookbook-\d+\.\d+\.\d+$/
+      'version' => /^datadog_cookbook-\d+\.\d+\.\d+$/
     )
   end
 end


### PR DESCRIPTION
### What does this PR do?

It adds the installation info metadata to the chef cookbook so the agent returns that it was installed by the triple chef/chef version/cookbook version

### Motivation.

Allow customers to track their chef installation. Allows us to make stats on installation methods.