### PR TITLE
Fix datadog_monitor action :delete not using A6's path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ Gemfile*.lock
 
 # Berkshelf
 Berksfile.lock
-cookbooks/
 /.ruby-version
 
 # Test-Kitchen

--- a/Berksfile
+++ b/Berksfile
@@ -4,5 +4,5 @@ metadata
 
 group :integration do
   cookbook 'sudo'
-  cookbook 'test', path: './test/cookbooks/test' # Integration test
+  cookbook 'test', path: './test/cookbooks/test' # Used to test custom resources (datadog_monitor, integration)
 end

--- a/resources/monitor.rb
+++ b/resources/monitor.rb
@@ -72,10 +72,10 @@ end
 
 action :remove do
   yaml_file = if Chef::Datadog.agent_major_version(node) != 5
-    ::File.join(yaml_dir, "#{new_resource.name}.d", 'conf.yaml')
-  else
-    ::File.join(yaml_dir, "#{new_resource.name}.yaml")
-  end
+                ::File.join(yaml_dir, "#{new_resource.name}.d", 'conf.yaml')
+              else
+                ::File.join(yaml_dir, "#{new_resource.name}.yaml")
+              end
 
   Chef::Log.debug("Removing #{yaml_file}")
 

--- a/resources/monitor.rb
+++ b/resources/monitor.rb
@@ -71,9 +71,15 @@ action :add do
 end
 
 action :remove do
-  Chef::Log.debug("Removing #{new_resource.name} from #{yaml_dir}")
+  yaml_file = if Chef::Datadog.agent_major_version(node) != 5
+    ::File.join(yaml_dir, "#{new_resource.name}.d", 'conf.yaml')
+  else
+    ::File.join(yaml_dir, "#{new_resource.name}.yaml")
+  end
 
-  file ::File.join(yaml_dir, "#{new_resource.name}.yaml") do
+  Chef::Log.debug("Removing #{yaml_file}")
+
+  file yaml_file do
     action :delete
     sensitive true
   end

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -1306,3 +1306,73 @@ describe 'datadog::dd-agent' do
     end
   end
 end
+
+describe 'test::monitor_add' do
+  context 'add custom monitor A5' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(
+        platform: 'fedora', version: '27',
+        step_into: ['datadog_monitor']
+      ) do |node|
+        node.normal['datadog'] = {
+          'api_key' => 'somethingnotnil',
+          'agent_major_version' => 5
+        }
+      end.converge described_recipe
+    end
+    it 'creates the config file at A5\'s path' do
+      expect(chef_run).to render_file('/etc/dd-agent/conf.d/potato.yaml')
+    end
+  end
+  context 'add custom monitor A7' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(
+        platform: 'fedora', version: '27',
+        step_into: ['datadog_monitor']
+      ) do |node|
+        node.normal['datadog'] = {
+          'api_key' => 'somethingnotnil',
+          'agent_major_version' => 7
+        }
+      end.converge described_recipe
+    end
+    it 'creates the config file at A7\'s path' do
+      expect(chef_run).to render_file('/etc/datadog-agent/conf.d/potato.d/conf.yaml')
+    end
+  end
+end
+
+describe 'test::monitor_remove' do
+  context 'remove custom monitor A5' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(
+        platform: 'fedora', version: '27',
+        step_into: ['datadog_monitor']
+      ) do |node|
+        node.normal['datadog'] = {
+          'api_key' => 'somethingnotnil',
+          'agent_major_version' => 5
+        }
+      end.converge described_recipe
+    end
+    it 'creates the config file at A5\'s path' do
+      expect(chef_run).to delete_file('/etc/dd-agent/conf.d/potato.yaml')
+    end
+  end
+  context 'remove custom monitor A7' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(
+        platform: 'fedora', version: '27',
+        step_into: ['datadog_monitor']
+      ) do |node|
+        node.normal['datadog'] = {
+          'api_key' => 'somethingnotnil',
+          'agent_major_version' => 7
+        }
+      end.converge described_recipe
+    end
+    it 'creates the config file at A7\'s path' do
+      expect(chef_run).to delete_file('/etc/datadog-agent/conf.d/potato.d/conf.yaml')
+    end
+  end
+end

--- a/test/cookbooks/test/recipes/monitor_add.rb
+++ b/test/cookbooks/test/recipes/monitor_add.rb
@@ -1,0 +1,3 @@
+datadog_monitor 'potato' do
+  action :add
+end

--- a/test/cookbooks/test/recipes/monitor_remove.rb
+++ b/test/cookbooks/test/recipes/monitor_remove.rb
@@ -1,0 +1,3 @@
+datadog_monitor 'potato' do
+  action :remove
+end


### PR DESCRIPTION
- Use the right path for `:delete` depending on the Agent version
- Add basic tests both for `:add` and `:delete` actions.

Unfortunately to test custom resources like `datadog_monitor` you need to create a test cookbook. Fortunately we already had one, although for some reason it was gitignored (but commited). This also unignores it.