### PR TITLE
Fix "Malformed version number string" for nightlies

### DIFF
--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -101,7 +101,7 @@ class Chef
           match_data = agent_status.match(/^Agent \(v(.*)\)/)
 
           # Nightlies like 6.20.0-devel+git.38.cd7f989 fail to parse as Gem::Version because of the '+' sign
-          version = match_data[1].gsub("+","-")
+          version = match_data[1].tr('+', '-')
 
           Gem::Version.new(version) if version
         end

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -100,7 +100,10 @@ class Chef
           agent_status = `"#{WIN_BIN_PATH}" status`
           match_data = agent_status.match(/^Agent \(v(.*)\)/)
 
-          Gem::Version.new(match_data[1]) if match_data
+          # Nightlies like 6.20.0-devel+git.38.cd7f989 fail to parse as Gem::Version because of the '+' sign
+          version = match_data[1].gsub("+","-")
+
+          Gem::Version.new(version) if version
         end
 
         def requested_agent_version(node)


### PR DESCRIPTION
The "+" in our version strings won't parse as Gem::Version, remove it.

This is an addendum to https://github.com/DataDog/chef-datadog/pull/711