### PR TITLE
Fix Proxy configuration with authentication

### DIFF
--- a/templates/default/datadog.yaml.erb
+++ b/templates/default/datadog.yaml.erb
@@ -52,7 +52,7 @@ if node['datadog']['web_proxy']['host']
   end
   if user
     if password
-      http_proxy = "#{user}:#{port}@#{http_proxy}"
+      http_proxy = "#{user}:#{password}@#{http_proxy}"
     else
       http_proxy = "#{user}@#{http_proxy}"
     end


### PR DESCRIPTION
Instead of the password, the port is stored in the datadog.yaml file.