### PR TITLE
Add support of IOT agent flavor

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ depends 'yum', '< 5.0'
     # Berksfile
     cookbook 'datadog', '~> 4.0.0'
     ```
-    
+
     ```shell
     # Knife
     knife cookbook site install datadog
     ```
-    
+
 2. Set the [Datadog-specific attributes](#datadog-attributes) in a role, environment, or another recipe:
     ```text
     node.default['datadog']['api_key'] = "<YOUR_DD_API_KEY>"
@@ -149,7 +149,7 @@ Follow the steps below to deploy the Datadog Agent with Chef on AWS OpsWorks:
 
 ### Integrations
 
-Enable Agent integrations by including the [recipe](#recipes) and configuration details in your role’s run-list and attributes. 
+Enable Agent integrations by including the [recipe](#recipes) and configuration details in your role’s run-list and attributes.
 **Note**: You can create additional integration recipes by using the [datadog_monitor](#datadog-monitor) resource.
 
 Associate your recipes with the desired `roles`, for example `role:chef-client` should contain `datadog::dd-handler` and `role:base` should start the Agent with `datadog::dd-agent`. Below is an example role with the `dd-handler`, `dd-agent`, and `mongo` recipes:
@@ -189,6 +189,7 @@ By default, the current major version of this cookbook installs Agent v7. The fo
 | `agent_major_version`  | Pin the major version of the Agent to 5, 6, or 7 (default).                                                                                                                         |
 | `agent_version`        | Pin a specific Agent version (recommended).                                                                                                                                         |
 | `agent_package_action` | (Linux only) Defaults to `'install'` (recommended), `'upgrade'` to get automatic Agent updates (not recommended, use the default and change the pinned `agent_version` to upgrade). |
+| `agent_flavor` | (Linux only) Defaults to `'datadog-agent'` to install the datadog-agent, can be set to `'datadog-iot-agent'` to install the IOT agent. |
 
 See the sample [attributes/default.rb][1] for your cookbook version for all available attributes.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,8 +40,8 @@ default['datadog']['agent_major_version'] = nil # nil to autodetect based on 'ag
 # Example:
 # default['datadog']['agent_version'] = '7.16.0'
 default['datadog']['agent_version'] = nil # nil to install latest
-# Agent flavor, acceptable values are "agent", iot-agent"
-default['datadog']['agent_flavor'] = 'agent' # "agent" to install default agent
+# Agent flavor to install, acceptable values are "agent", "iot-agent"
+default['datadog']['agent_flavor'] = 'agent' # "agent" to install the datadog-agent package
 
 # Allow override with `upgrade` to get latest (Linux only)
 default['datadog']['agent_package_action'] = 'install'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,8 +40,8 @@ default['datadog']['agent_major_version'] = nil # nil to autodetect based on 'ag
 # Example:
 # default['datadog']['agent_version'] = '7.16.0'
 default['datadog']['agent_version'] = nil # nil to install latest
-# Agent flavor to install, acceptable values are "agent", "iot-agent"
-default['datadog']['agent_flavor'] = 'agent' # "agent" to install the datadog-agent package
+# Agent flavor to install, acceptable values are "datadog-agent", "datadog-iot-agent"
+default['datadog']['agent_flavor'] = 'datadog-agent' # "datadog-agent" to install the datadog-agent package
 
 # Allow override with `upgrade` to get latest (Linux only)
 default['datadog']['agent_package_action'] = 'install'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -41,7 +41,7 @@ default['datadog']['agent_major_version'] = nil # nil to autodetect based on 'ag
 # default['datadog']['agent_version'] = '7.16.0'
 default['datadog']['agent_version'] = nil # nil to install latest
 # Agent flavor, acceptable values are "agent", iot-agent"
-default['datadog']['agent_flavor'] = "agent" # "agent" to install default agent
+default['datadog']['agent_flavor'] = 'agent' # "agent" to install default agent
 
 # Allow override with `upgrade` to get latest (Linux only)
 default['datadog']['agent_package_action'] = 'install'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,6 +40,8 @@ default['datadog']['agent_major_version'] = nil # nil to autodetect based on 'ag
 # Example:
 # default['datadog']['agent_version'] = '7.16.0'
 default['datadog']['agent_version'] = nil # nil to install latest
+# Agent flavor, acceptable values are "agent", iot-agent"
+default['datadog']['agent_flavor'] = "agent" # "agent" to install default agent
 
 # Allow override with `upgrade` to get latest (Linux only)
 default['datadog']['agent_package_action'] = 'install'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -79,7 +79,7 @@ suites:
       api_key: somenonnullapikeythats32charlong
       application_key: alsonotnil
       install_info_enabled: true
-      agent_flavor: iot-agent
+      agent_flavor: datadog-iot-agent
       aptrepo: 'https://apt.datad0g.com'
       aptrepo_dist: 'beta'
       agent_version: '7.20.0~rc.3'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -71,6 +71,19 @@ suites:
       api_key: somenonnullapikeythats32charlong
       application_key: alsonotnil
 
+- name: dd-agent-iot
+  run_list:
+    - recipe[datadog::dd-agent]
+  attributes:
+    datadog: &DATADOG
+      api_key: somenonnullapikeythats32charlong
+      application_key: alsonotnil
+      install_info_enabled: true
+      agent_flavor: iot-agent
+      aptrepo: 'https://apt.datad0g.com'
+      aptrepo_dist: 'beta'
+      agent_version: '7.20.0~rc.3'
+
 - name: system-probe
   run_list:
     - recipe[datadog::dd-agent]

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -2,6 +2,11 @@ class Chef
   # Helper class for Datadog Chef recipes
   class Datadog
     class << self
+      ACCEPTABLE_AGENT_FLAVORS = %w[
+        agent
+        iot-agent
+      ].freeze
+
       def agent_version(node)
         dd_agent_version = node['datadog']['agent_version']
         if dd_agent_version.respond_to?(:each_pair)
@@ -45,6 +50,18 @@ class Chef
         # default to Agent 7
         node.default['datadog']['agent_major_version'] = 7
         7
+      end
+
+      def agent_flavor(node)
+        # user-specified values
+        agent_flavor = node['datadog']['agent_flavor']
+        agent_flavor ||= node.default['datadog']['agent_flavor']
+
+        unless ACCEPTABLE_AGENT_FLAVORS.include?(agent_flavor)
+          raise "Unknown agent flavor '#{agent_flavor}' (acceptable values: #{ACCEPTABLE_AGENT_FLAVORS.inspect})"
+        end
+
+        agent_flavor
       end
 
       def api_key(node)

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -3,8 +3,8 @@ class Chef
   class Datadog
     class << self
       ACCEPTABLE_AGENT_FLAVORS = %w[
-        agent
-        iot-agent
+        datadog-agent
+        datadog-iot-agent
       ].freeze
 
       def agent_version(node)

--- a/recipes/_install-linux.rb
+++ b/recipes/_install-linux.rb
@@ -21,15 +21,19 @@
 include_recipe 'datadog::repository' if node['datadog']['installrepo']
 
 dd_agent_version = Chef::Datadog.agent_version(node)
+dd_agent_flavor = Chef::Datadog.agent_flavor(node)
+
+package_name = "datadog-#{dd_agent_flavor}"
 
 package_action = node['datadog']['agent_package_action']
 
 package_retries = node['datadog']['agent_package_retries']
 package_retry_delay = node['datadog']['agent_package_retry_delay']
+
 # Install the regular package
 case node['platform_family']
 when 'debian'
-  apt_package 'datadog-agent' do
+  apt_package package_name do
     version dd_agent_version
     retries package_retries unless package_retries.nil?
     retry_delay package_retry_delay unless package_retry_delay.nil?
@@ -41,14 +45,14 @@ when 'rhel', 'fedora', 'amazon'
      node['platform_family'] == 'fedora' && node['platform_version'].to_i >= 28
     # yum_package doesn't work on RHEL 8 and Fedora >= 28
     # dnf_package only works on RHEL 8 / Fedora >= 28 if Chef 15+ is used
-    dnf_package 'datadog-agent' do
+    dnf_package package_name do
       version dd_agent_version
       retries package_retries unless package_retries.nil?
       retry_delay package_retry_delay unless package_retry_delay.nil?
       action package_action # default is :install
     end
   else
-    yum_package 'datadog-agent' do
+    yum_package package_name do
       version dd_agent_version
       retries package_retries unless package_retries.nil?
       retry_delay package_retry_delay unless package_retry_delay.nil?
@@ -57,7 +61,7 @@ when 'rhel', 'fedora', 'amazon'
     end
   end
 when 'suse'
-  zypper_package 'datadog-agent' do # ~FC009
+  zypper_package package_name do # ~FC009
     version dd_agent_version
     retries package_retries unless package_retries.nil?
     retry_delay package_retry_delay unless package_retry_delay.nil?

--- a/recipes/_install-linux.rb
+++ b/recipes/_install-linux.rb
@@ -23,8 +23,6 @@ include_recipe 'datadog::repository' if node['datadog']['installrepo']
 dd_agent_version = Chef::Datadog.agent_version(node)
 dd_agent_flavor = Chef::Datadog.agent_flavor(node)
 
-package_name = "datadog-#{dd_agent_flavor}"
-
 package_action = node['datadog']['agent_package_action']
 
 package_retries = node['datadog']['agent_package_retries']
@@ -33,7 +31,7 @@ package_retry_delay = node['datadog']['agent_package_retry_delay']
 # Install the regular package
 case node['platform_family']
 when 'debian'
-  apt_package package_name do
+  apt_package dd_agent_flavor do
     version dd_agent_version
     retries package_retries unless package_retries.nil?
     retry_delay package_retry_delay unless package_retry_delay.nil?
@@ -45,14 +43,14 @@ when 'rhel', 'fedora', 'amazon'
      node['platform_family'] == 'fedora' && node['platform_version'].to_i >= 28
     # yum_package doesn't work on RHEL 8 and Fedora >= 28
     # dnf_package only works on RHEL 8 / Fedora >= 28 if Chef 15+ is used
-    dnf_package package_name do
+    dnf_package dd_agent_flavor do
       version dd_agent_version
       retries package_retries unless package_retries.nil?
       retry_delay package_retry_delay unless package_retry_delay.nil?
       action package_action # default is :install
     end
   else
-    yum_package package_name do
+    yum_package dd_agent_flavor do
       version dd_agent_version
       retries package_retries unless package_retries.nil?
       retry_delay package_retry_delay unless package_retry_delay.nil?
@@ -61,7 +59,7 @@ when 'rhel', 'fedora', 'amazon'
     end
   end
 when 'suse'
-  zypper_package package_name do # ~FC009
+  zypper_package dd_agent_flavor do # ~FC009
     version dd_agent_version
     retries package_retries unless package_retries.nil?
     retry_delay package_retry_delay unless package_retry_delay.nil?

--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -20,8 +20,8 @@
 dd_agent_version = Chef::Datadog.agent_version(node)
 dd_agent_flavor = Chef::Datadog.agent_flavor(node)
 
-if dd_agent_flavor != 'agent'
-  raise "Unsupported agent flavor '#{dd_agent_flavor}' on Windows (only supports 'agent')"
+if dd_agent_flavor != 'datadog-agent'
+  raise "Unsupported agent flavor '#{dd_agent_flavor}' on Windows (only supports 'datadog-agent')"
 end
 
 if dd_agent_version.nil?

--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -18,6 +18,11 @@
 #
 
 dd_agent_version = Chef::Datadog.agent_version(node)
+dd_agent_flavor = Chef::Datadog.agent_flavor(node)
+
+if dd_agent_flavor != 'agent'
+  raise "Unsupported agent flavor '#{dd_agent_flavor}' on Windows (only supports 'agent')"
+end
 
 if dd_agent_version.nil?
   # Use latest

--- a/test/integration/dd-agent-iot/serverspec/dd-agent_spec.rb
+++ b/test/integration/dd-agent-iot/serverspec/dd-agent_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+@agent_package_name = 'datadog-iot-agent'
+
+describe package(@agent_package_name) do
+  it { should be_installed }
+end
+
+describe service(@agent_service_name) do
+  it { should be_running }
+end
+
+describe command('/opt/datadog-agent/bin/agent/agent status | grep -v "Instance ID"'), :if => os[:family] != 'windows' do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should contain '[OK]' }
+  its(:stdout) { should_not contain 'ERROR' }
+end
+
+
+# The new APT key is imported
+describe command('apt-key list'), :if => ['debian', 'ubuntu'].include?(os[:family]) do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should contain '382E94DE' }
+end
+
+# The new RPM key is imported
+describe command('rpm -q gpg-pubkey-e09422b3'), :if => os[:family] == 'redhat' do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should contain 'gpg-pubkey-e09422b3' }
+end

--- a/test/integration/dd-agent-iot/serverspec/dd-agent_spec.rb
+++ b/test/integration/dd-agent-iot/serverspec/dd-agent_spec.rb
@@ -16,7 +16,6 @@ describe command('/opt/datadog-agent/bin/agent/agent status | grep -v "Instance 
   its(:stdout) { should_not contain 'ERROR' }
 end
 
-
 # The new APT key is imported
 describe command('apt-key list'), :if => ['debian', 'ubuntu'].include?(os[:family]) do
   its(:exit_status) { should eq 0 }

--- a/test/integration/dd-agent-iot/serverspec/install_info_spec.rb
+++ b/test/integration/dd-agent-iot/serverspec/install_info_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+@agent_package_name = 'datadog-iot-agent'
+
+describe 'Install infos' do
+  let(:install_info_path) do
+    if os == :windows
+      "#{ENV['ProgramData']}\\Datadog\\install_info"
+    else
+      '/etc/datadog-agent/install_info'
+    end
+  end
+
+  let(:install_info) do
+    YAML.load_file(install_info_path)
+  end
+
+  it 'adds an install_info' do
+    expect(install_info['install_method']).to match(
+      'tool_version' => /chef-\d+\.\d+\.\d+/,
+      'tool' => 'chef',
+      'installer_version' => /^datadog_cookbook-\d+\.\d+\.\d+$/
+    )
+  end
+end

--- a/test/integration/dd-agent/serverspec/dd-agent_spec.rb
+++ b/test/integration/dd-agent/serverspec/dd-agent_spec.rb
@@ -8,9 +8,9 @@ describe service(@agent_service_name) do
   it { should be_running }
 end
 
-describe command('/etc/init.d/datadog-agent info | grep -v "API Key is invalid"'), :if => os[:family] != 'windows' do
+describe command('/opt/datadog-agent/bin/agent/agent status | grep -v "Instance ID"'), :if => os[:family] != 'windows' do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should contain 'OK' }
+  its(:stdout) { should contain '[OK]' }
   its(:stdout) { should_not contain 'ERROR' }
 end
 


### PR DESCRIPTION
### What does this PR do?

It adds the base logic to support agent flavors. And it adds the support of the IOT agent.

### Motivation

Allowing users to install specific flavors of the agent.