### PR TITLE
Do not crash if the agent is not running

### DIFF
--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -118,7 +118,7 @@ class Chef
           match_data = agent_status.match(/^Agent \(v(.*)\)/)
 
           # Nightlies like 6.20.0-devel+git.38.cd7f989 fail to parse as Gem::Version because of the '+' sign
-          version = match_data[1].tr('+', '-')
+          version = match_data[1].tr('+', '-') if match_data
 
           Gem::Version.new(version) if version
         end

--- a/spec/recipe_helpers_spec.rb
+++ b/spec/recipe_helpers_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+
+require_relative '../libraries/recipe_helpers'
+
+describe Chef::Datadog::WindowsInstallHelpers do
+  describe '#must_reinstall?' do
+    before do
+      stub_const('Chef::VERSION', chef_version)
+      allow(Chef::Datadog).to receive(:agent_version).with(node).and_return(requested_agent_version)
+    end
+
+    let(:node) do
+      {}
+    end
+
+    let(:requested_agent_version) do
+      '6.20.0'
+    end
+
+    let(:chef_version) do
+      '14.0.0'
+    end
+
+    context 'when the agent is not installed' do
+      before do
+        allow(File)
+          .to receive(:exist?)
+          .with('C:/Program Files/Datadog/Datadog Agent/bin/agent')
+          .and_return(false)
+      end
+
+      it 'returns false' do
+        expect(described_class.must_reinstall?(node)).to be false
+      end
+    end
+
+    context 'when the agent is installed' do
+      before do
+        allow(File).to receive(:exist?).and_return(false)
+        allow(File)
+          .to receive(:exist?)
+          .with('C:/Program Files/Datadog/Datadog Agent/bin/agent')
+          .and_return(true)
+
+        # stub agent status call
+        allow_any_instance_of(Module)
+          .to receive(:`)
+          .with('"C:/Program Files/Datadog/Datadog Agent/bin/agent" status')
+          .and_return(agent_status)
+      end
+
+      let(:agent_status) do
+        %(
+.....
+Agent (v6.20.0)
+....
+        )
+      end
+
+      context 'when the agent version requested is greater than the installed version' do
+        let(:requested_agent_version) do
+          '6.21.0'
+        end
+
+        it 'returns false' do
+          expect(described_class.must_reinstall?(node)).to be false
+        end
+      end
+
+      context 'when the agent version requested is lesser than the installed version' do
+        let(:requested_agent_version) do
+          '6.17.0'
+        end
+
+        it 'returns true' do
+          expect(described_class.must_reinstall?(node)).to be true
+        end
+      end
+
+      context 'when the current agent version is a nightly' do
+        let(:agent_status) do
+          %(
+.....
+Agent (v6.20.0-devel+git.38.cd7f989)
+....
+          )
+        end
+
+        it 'returns false' do
+          expect(described_class.must_reinstall?(node)).to be false
+        end
+      end
+
+      context 'when the chef version cannot reinstall the agent (registry key problem)' do
+        let(:chef_version) do
+          '13.0.0'
+        end
+
+        it 'returns false' do
+          expect(described_class.must_reinstall?(node)).to be false
+        end
+      end
+    end
+  end
+end
+
+

--- a/spec/recipe_helpers_spec.rb
+++ b/spec/recipe_helpers_spec.rb
@@ -103,5 +103,3 @@ Agent (v6.20.0-devel+git.38.cd7f989)
     end
   end
 end
-
-


### PR DESCRIPTION
Fixes `NoMethodError: undefined method '[]' for nil:NilClass` if `agent status` doesn't return anything useful (eg: if the agent is not running).