### PR TITLE
[cassandra] add support for failures/timeouts/unavailable collection

### DIFF
--- a/spec/integrations/cassandra_spec.rb
+++ b/spec/integrations/cassandra_spec.rb
@@ -387,8 +387,13 @@ describe 'datadog::cassandra' do
             domain: org.apache.cassandra.metrics
             type: ClientRequest
             name:
+              - Failures
+              - Latency
+              - Timeouts
+              - Unavailables
               - Latency
             attribute:
+              - Count
               - 75thPercentile
               - 95thPercentile
               - OneMinuteRate

--- a/templates/default/cassandra.yaml.erb
+++ b/templates/default/cassandra.yaml.erb
@@ -19,8 +19,12 @@ init_config:
         domain: org.apache.cassandra.metrics
         type: ClientRequest
         name:
+          - Failures
           - Latency
+          - Timeouts
+          - Unavailables
         attribute:
+          - Count
           - 75thPercentile
           - 95thPercentile
           - OneMinuteRate


### PR DESCRIPTION
These metrics are exported by cassandra and show the number of requests failures 