### PR TITLE
Remove duplicate attribute

### DIFF
--- a/spec/integrations/cassandra_spec.rb
+++ b/spec/integrations/cassandra_spec.rb
@@ -391,7 +391,6 @@ describe 'datadog::cassandra' do
               - Latency
               - Timeouts
               - Unavailables
-              - Latency
             attribute:
               - Count
               - 75thPercentile


### PR DESCRIPTION
#725 introduced a duplicate attribute `latency` which caused the CI to fail.