### PR TITLE
Install dd agent with yum on Amazon Linux 1

### DIFF
--- a/recipes/_install-linux.rb
+++ b/recipes/_install-linux.rb
@@ -39,7 +39,7 @@ when 'debian'
     options '--force-yes' if node['datadog']['agent_allow_downgrade']
   end
 when 'rhel', 'fedora', 'amazon'
-  if node['platform_family'] == 'rhel' && node['platform_version'].to_i >= 8 ||
+  if node['platform_family'] == 'rhel' && node['platform_version'].to_i >= 8 && node['platform'] != 'amazon' ||
      node['platform_family'] == 'fedora' && node['platform_version'].to_i >= 28
     # yum_package doesn't work on RHEL 8 and Fedora >= 28
     # dnf_package only works on RHEL 8 / Fedora >= 28 if Chef 15+ is used


### PR DESCRIPTION
It turns out that Amazon Linux 1 identifies with the following node platform attributes, which cause the linux dd agent install recipe to treat it like RHEL >=8:

```
platform: amazon
platform_version: 2018.03
platform_family: rhel
```

I believe we would rather have the dd agent package get installed with the `yum_package` resource on Amazon Linux 1 instead of the `dnf_package` resource.

Relates to https://github.com/DataDog/chef-datadog/pull/641
