### PR TITLE
Warn when the Agent will start despite being disabled

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -226,7 +226,8 @@ default['datadog']['hostname'] = node.name
 # rather than the hostname for chef-handler.
 default['datadog']['use_ec2_instance_id'] = false
 
-# Enable the agent to start at boot
+# Enable the agent to start at boot. Note that this can't be false if 'enable_process_agent'
+# or 'enable_trace_agent' are true, since they depend on the main agent.
 default['datadog']['agent_enable'] = true
 
 # Start agent or not

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -44,6 +44,14 @@ else
   include_recipe 'datadog::_install-linux'
 end
 
+if !node['datadog']['agent_enable'] && node['datadog']['enable_process_agent']
+  Chef::Log.warn("'agent_enable' is set to 'false', but 'enable_process_agent' is set to 'true'. This will cause the datadog-agent to start, since the process-agent depends on it.")
+end
+
+if !node['datadog']['agent_enable'] && node['datadog']['enable_trace_agent']
+  Chef::Log.warn("'agent_enable' is set to 'false', but 'enable_trace_agent' is set to 'true'. This will cause the datadog-agent to start, since the trace-agent depends on it.")
+end
+
 # Set the Agent service enable or disable
 agent_enable = node['datadog']['agent_enable'] ? :enable : :disable
 # Set the correct Agent startup action


### PR DESCRIPTION
Since the trace and process agents depend on the main agent, disabling the later without disabling the former won't have the expected behavior.

Fixes #447