### PR TITLE
Add Amazon Linux 2 to kitchen tests

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -8,6 +8,7 @@ platforms:
 # Loop through two lists and output a total matrix of all possible platform + chef versions
 # fedora-20 needs kitchen-docker 1.7.0, but other bugs prevent that version from being used.
 <% test_platforms = %w(
+      amazonlinux-2
       ubuntu-12.04
       ubuntu-14.04
       ubuntu-16.04


### PR DESCRIPTION
Makes it easier to test changes that affect Amazon Linux, since there is some special cases for this OS.