### PR TITLE
Make dd-agent recipe idempotent

### DIFF
--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -52,6 +52,20 @@ class Chef
         7
       end
 
+      def agent_minor_version(node)
+        agent_version = agent_version(node)
+        unless agent_version.nil?
+          match = agent_version.match(/([0-9]+:)?([0-9]+)\.([0-9]+)\.([0-9]+)([^-\s]+)?(?:-([0-9]+))?/)
+          if match.nil?
+            Chef::Log.warn "Couldn't infer agent_minor_version from agent_version '#{agent_version}'"
+          else
+            _epoch, _major, minor, _patch, _suffix, _release = match.captures
+            return minor.to_i
+          end
+        end
+        nil
+      end
+
       def agent_flavor(node)
         # user-specified values
         agent_flavor = node['datadog']['agent_flavor']

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -35,6 +35,8 @@ ruby_block 'datadog-api-key-unset' do
   only_if { Chef::Datadog.api_key(node).nil? }
 end
 
+agent_major_version = Chef::Datadog.agent_major_version(node)
+agent_minor_version = Chef::Datadog.agent_minor_version(node)
 is_windows = node['platform_family'] == 'windows'
 
 # Install the agent
@@ -62,7 +64,7 @@ agent_start = node['datadog']['agent_start'] ? :start : :stop
 # To add integration-specific configurations, add 'datadog::config_name' to
 # the node's run_list and set the relevant attributes
 #
-if Chef::Datadog.agent_major_version(node) > 5
+if agent_major_version > 5
   include_recipe 'datadog::_agent6_config'
   agent_config_dir = is_windows ? "#{ENV['ProgramData']}/Datadog" : '/etc/datadog-agent'
   directory agent_config_dir do
@@ -131,7 +133,7 @@ end
 
 # Common configuration
 service_provider = nil
-if Chef::Datadog.agent_major_version(node) > 5 &&
+if agent_major_version > 5 &&
    (((node['platform'] == 'amazon' || node['platform_family'] == 'amazon') && node['platform_version'].to_i != 2) ||
     (node['platform'] == 'ubuntu' && node['platform_version'].to_f < 15.04) || # chef <11.14 doesn't use the correct service provider
    (node['platform'] != 'amazon' && node['platform_family'] == 'rhel' && node['platform_version'].to_i < 7))
@@ -168,7 +170,10 @@ service 'datadog-agent' do
 end
 
 system_probe_managed = node['datadog']['system_probe']['manage_config']
-system_probe_supported = !is_windows && Chef::Datadog.agent_major_version(node) > 5
+agent_version_greater_than_6_11 = agent_major_version > 5 && (agent_minor_version.nil? || agent_minor_version > 11) || agent_major_version > 6
+
+# System probe requires at least agent 6.12, before that it was called the network-tracer
+system_probe_supported = agent_version_greater_than_6_11 && !is_windows
 
 # system-probe is a dependency of the agent on Linux
 include_recipe 'datadog::system-probe' if system_probe_managed && system_probe_supported

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -168,18 +168,10 @@ service 'datadog-agent' do
 end
 
 system_probe_managed = node['datadog']['system_probe']['manage_config']
-if system_probe_managed
-  ruby_block 'include system-probe' do
-    block do
-      # only load system-probe recipe if an agent 6/7 installation comes with it
-      system_probe_supported = !is_windows && Chef::Datadog.agent_major_version(node) > 5
-      system_probe_installed = ::File.exist?('/opt/datadog-agent/embedded/bin/system-probe')
-      if system_probe_supported && system_probe_installed
-        run_context.include_recipe 'datadog::system-probe'
-      end
-    end
-  end
-end
+system_probe_supported = !is_windows && Chef::Datadog.agent_major_version(node) > 5
+
+# system-probe is a dependency of the agent on Linux
+include_recipe 'datadog::system-probe' if system_probe_managed && system_probe_supported
 
 # Installation metadata to let know the agent about installation method and its version
 include_recipe 'datadog::install_info'

--- a/spec/system-probe_spec.rb
+++ b/spec/system-probe_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog::system-probe' do
-  context 'with configuration' do
-    cached(:chef_run) do
+  context 'with system-probe not enabled' do
+    cached(:solo) do
       ChefSpec::SoloRunner.new(
         platform: 'ubuntu',
         version: '16.04'
@@ -17,7 +17,46 @@ describe 'datadog::system-probe' do
             'sysprobe_socket' => '/test/ing.sock'
           }
         }
-      end.converge described_recipe
+      end
+    end
+
+    cached(:chef_run) do
+      solo.converge(described_recipe) do
+        solo.resource_collection.insert(
+          Chef::Resource::Service.new('datadog-agent', solo.run_context))
+      end
+    end
+
+    it 'is NOT created' do
+      expect(chef_run).not_to create_template('/etc/datadog-agent/system-probe.yaml')
+    end
+  end
+
+  context 'with system-probe enabled' do
+    cached(:solo) do
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '16.04'
+      ) do |node|
+        node.name 'chef-nodename' # expected to be used as the hostname in `datadog.yaml`
+        node.normal['datadog'] = {
+          'api_key' => 'somethingnotnil',
+          'agent_major_version' => 6,
+          'system_probe' => {
+            'enabled' => true,
+            'debug_port' => 123,
+            'bpf_debug' => true,
+            'sysprobe_socket' => '/test/ing.sock'
+          }
+        }
+      end
+    end
+
+    cached(:chef_run) do
+      solo.converge(described_recipe) do
+        solo.resource_collection.insert(
+          Chef::Resource::Service.new('datadog-agent', solo.run_context))
+      end
     end
 
     it 'is created' do
@@ -30,7 +69,7 @@ describe 'datadog::system-probe' do
         bpf_debug: true
         debug_port: 123
         enable_conntrack: false
-        enabled: false
+        enabled: true
         sysprobe_socket: "/test/ing.sock"
       EOF
 
@@ -41,7 +80,7 @@ describe 'datadog::system-probe' do
   end
 
   context 'with extra_config params set' do
-    cached(:chef_run) do
+    cached(:solo) do
       ChefSpec::SoloRunner.new(
         platform: 'ubuntu',
         version: '16.04'
@@ -50,13 +89,23 @@ describe 'datadog::system-probe' do
         node.normal['datadog'] = {
           'api_key' => 'somethingnotnil',
           'agent_major_version' => 6,
+          'system_probe' => {
+            'enabled' => true,
+          },
           'extra_config' => {
             'system_probe' => {
               'max_tracked_connections' => 1000
             }
           }
         }
-      end.converge described_recipe
+      end
+    end
+
+    cached(:chef_run) do
+      solo.converge(described_recipe) do
+        solo.resource_collection.insert(
+          Chef::Resource::Service.new('datadog-agent', solo.run_context))
+      end
     end
 
     it 'is created' do
@@ -69,7 +118,7 @@ describe 'datadog::system-probe' do
         bpf_debug: false
         debug_port: 0
         enable_conntrack: false
-        enabled: false
+        enabled: true
         sysprobe_socket: "/opt/datadog-agent/run/sysprobe.sock"
         max_tracked_connections: 1000
       EOF


### PR DESCRIPTION
### Summary
This PR aims to address issue #683, the `dd-agent` recipe was always running the `ruby_block` which was causing a resource update at each run (With message for example 'Chef Infra Client finished, 1/26 resources updated in 02 seconds').

Given that the `system-probe` is a dependency of the main agent, it's safe to always include the `system-probe` recipe from the `dd-agent` recipe, unless it's explicitly not supported or not enabled.

An other issue mentioned in #683 concerns the creation of the `system-probe.yaml` template on the host regardless if `system-probe` is enabled or not. However the attribute `['datadog']['system_probe']['manage_config']` is meant to govern this. Nevertheless, I added a clause to not create the template if system_probe is not enabled and the file doesn't already exists.

Finally, the rspec test fail since we are testing the `system-probe` recipe independently the `dd-agent` recipe, and the `system-probe` template notifies the `datadog-agent` which doesn't exist in this context.
So I refactored the test a bit and introduced a mock `datadog-agent` service into the run context.

### Test plan
1. Run kitchen test for `dd-agent`
The first time the recipe is converged, it should not create the system probe template.
The second time the recipe is converged, it should not update any resource.

2. Run kitchen test for `system-probe`
The first time the recipe is converged, it should create the system probe template and start the service.
The second time the recipe is converged, it should not update any resource.
Disabling `system-probe` in `kitchen.yml` and re-converging, the `system-probe` recipe should update the template file to set `enabled: false` and stop the service.
Re-converging once more after that, no resource should be updated.

3. Set the agent version to 6.11 or less in `kitchen.yml`.
Upon convergence the `system-probe` recipe should not be included.

4. Set the agent version to 6.12+, 7.16, (or any 7.x version) in `kitchen.yml`.
Upon convergence the `system-probe` recipe should be included.