### PR TITLE
Network plugin yaml nesting

### DIFF
--- a/templates/default/network.yaml.erb
+++ b/templates/default/network.yaml.erb
@@ -9,7 +9,7 @@ instances:
    excluded_interfaces:
  <% i["excluded_interfaces"].each do |interface| -%>
      - <%= interface %>
+ <% end -%>
    combine_connection_states: <%= i['combine_connection_states'] || 'true' %>
    collect_count_metrics: <%= i['collect_count_metrics'] || 'false' %>
- <% end -%>
 <% end -%>


### PR DESCRIPTION
The template has `combine_connection_states` and `collect_count_metrics` inside the `excluded_interfaces` loop, which gives you weird stuff like:

```
instances:
 - collect_connection_state: true
   excluded_interfaces:
     - lo
   combine_connection_states: true
   collect_count_metrics: true
     - lo0
   combine_connection_states: true
   collect_count_metrics: true
```

The [sample yaml](https://github.com/DataDog/integrations-core/blob/master/network/datadog_checks/network/data/conf.yaml.default) shows all the interface names in an array under `excluded_interfaces`.