### PR TITLE
Fix syntax issues in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ This example enables the ElasticSearch integration by using the `datadog_monitor
 ```ruby
 include_recipe 'datadog::dd-agent'
 
-datadog_monitor 'elastic'
+datadog_monitor 'elastic' do
   instances  [{'url' => 'http://localhost:9200'}]
   use_integration_template true
   notifies :restart, 'service[datadog-agent]' if node['datadog']['agent_start']
@@ -386,7 +386,7 @@ This example installs version `1.11.0` of the ElasticSearch integration by using
 ```ruby
 include_recipe 'datadog::dd-agent'
 
-datadog_integration 'datadog-elastic'
+datadog_integration 'datadog-elastic' do
   version '1.11.0'
 end
 ```


### PR DESCRIPTION
## Changes:
* When using this doc as an example of writing my own code I ran across syntax errors when copying examples direct from this repo. This Pull request fixes the examples to use valid syntax. 


