### PR TITLE
Issue 748: conflit with gpnupg2 on centos8

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,9 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   Enabled: false
 
+Style/TrailingCommaInLiteral:
+  Enabled: false
+
 # Only enforce a wordlist for 5 or longer lists.
 Style/WordArray:
   MinSize: 5

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,9 +21,6 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   Enabled: false
 
-Style/TrailingCommaInLiteral:
-  Enabled: false
-
 # Only enforce a wordlist for 5 or longer lists.
 Style/WordArray:
   MinSize: 5

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -70,6 +70,7 @@ when 'rhel', 'fedora', 'amazon'
     # gnupg is required to check the downloaded key's fingerprint
     package 'gnupg' do
       action :install
+      only_if { node['packages']['gnupg2'].nil? }
     end
 
     # Download new RPM key

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -41,10 +41,6 @@ describe 'datadog::repository' do
         )
       end
 
-      it 'installs gnupg' do
-        expect(chef_run).to install_package('gnupg')
-      end
-
       it 'downloads the new RPM key' do
         expect(chef_run).to create_remote_file('DATADOG_RPM_KEY_E09422B3.public').with(path: ::File.join(Chef::Config[:file_cache_path], 'DATADOG_RPM_KEY_E09422B3.public'))
       end
@@ -83,10 +79,6 @@ describe 'datadog::repository' do
         )
       end
 
-      it 'installs gnupg' do
-        expect(chef_run).to install_package('gnupg')
-      end
-
       it 'downloads the new RPM key' do
         expect(chef_run).to create_remote_file('DATADOG_RPM_KEY_E09422B3.public').with(path: ::File.join(Chef::Config[:file_cache_path], 'DATADOG_RPM_KEY_E09422B3.public'))
       end
@@ -123,10 +115,6 @@ describe 'datadog::repository' do
         expect(chef_run.node['datadog']['yumrepo_gpgkey_new']).to match(
           /DATADOG_RPM_KEY_E09422B3.public/
         )
-      end
-
-      it 'installs gnupg' do
-        expect(chef_run).to install_package('gnupg')
       end
 
       it 'downloads the new RPM key' do

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -41,6 +41,10 @@ describe 'datadog::repository' do
         )
       end
 
+      it 'installs gnupg' do
+        expect(chef_run).to install_package('gnupg') if chef_run.node['packages']['gnupg2'].nil?
+      end
+
       it 'downloads the new RPM key' do
         expect(chef_run).to create_remote_file('DATADOG_RPM_KEY_E09422B3.public').with(path: ::File.join(Chef::Config[:file_cache_path], 'DATADOG_RPM_KEY_E09422B3.public'))
       end
@@ -79,6 +83,10 @@ describe 'datadog::repository' do
         )
       end
 
+      it 'installs gnupg' do
+        expect(chef_run).to install_package('gnupg') if chef_run.node['packages']['gnupg2'].nil?
+      end
+
       it 'downloads the new RPM key' do
         expect(chef_run).to create_remote_file('DATADOG_RPM_KEY_E09422B3.public').with(path: ::File.join(Chef::Config[:file_cache_path], 'DATADOG_RPM_KEY_E09422B3.public'))
       end
@@ -115,6 +123,10 @@ describe 'datadog::repository' do
         expect(chef_run.node['datadog']['yumrepo_gpgkey_new']).to match(
           /DATADOG_RPM_KEY_E09422B3.public/
         )
+      end
+
+      it 'installs gnupg' do
+        expect(chef_run).to install_package('gnupg') if chef_run.node['packages']['gnupg2'].nil?
       end
 
       it 'downloads the new RPM key' do


### PR DESCRIPTION
Issue #748 

- Add guards on while installing gnupg to avoid conflit with gnupg2 on RHEL/Centos8