### PR TITLE
Get Mongo authentication to work

### DIFF
--- a/templates/default/mongo.yaml.erb
+++ b/templates/default/mongo.yaml.erb
@@ -2,7 +2,14 @@
 
 instances:
   <% @instances.each do |i| -%>
-  - server: mongodb://<%= i['host']%>:<%= i['port'] %>
+  - hosts:
+      - <%= i['host']%>:<%= i['port'] %>
+    <% if i.key?('username') -%>
+    username: <%= i['username'] %>
+    <% end -%>
+    <% if i.key?('password') -%>
+    password: <%= i['password'] %>
+    <% end -%>
     <% if i.key?('timeout') -%>
     timeout: <%= i['timeout'] %>
     <% end -%>


### PR DESCRIPTION
The server attribute is deprecated according to Agent 7.22.1 documentation. 
Authentication with username and password to Mongo is possible now.