### PR TITLE
Implement Mongo Authentication

### DIFF
--- a/recipes/mongo.rb
+++ b/recipes/mongo.rb
@@ -4,11 +4,10 @@ include_recipe 'datadog::dd-agent'
 #
 # node.set['datadog']['mongo']['instances'] = [
 #   {
-#     'hosts' => 'localhost',
+#     'host' => 'localhost',
 #     'port' => '27017',
 #     'username' => 'someuser',
-#     'password' => 'somepassword',
-#     'timeout' => 30
+#     'password' => 'somepassword'
 #   }
 # ]
 

--- a/recipes/mongo.rb
+++ b/recipes/mongo.rb
@@ -5,7 +5,10 @@ include_recipe 'datadog::dd-agent'
 # node.set['datadog']['mongo']['instances'] = [
 #   {
 #     'host' => 'localhost',
-#     'port' => '27017'
+#     'port' => '27017',
+#     'username' => 'someuser',
+#     'password' => 'somepassword',
+#     'timeout' => 30
 #   }
 # ]
 

--- a/recipes/mongo.rb
+++ b/recipes/mongo.rb
@@ -4,7 +4,7 @@ include_recipe 'datadog::dd-agent'
 #
 # node.set['datadog']['mongo']['instances'] = [
 #   {
-#     'host' => 'localhost',
+#     'hosts' => 'localhost',
 #     'port' => '27017',
 #     'username' => 'someuser',
 #     'password' => 'somepassword',

--- a/spec/integrations/mongo_spec.rb
+++ b/spec/integrations/mongo_spec.rb
@@ -4,10 +4,12 @@ describe 'datadog::mongo' do
     init_config:
 
     instances:
-      - hosts:
-          - localhost:27017
+      - hosts: localhost:27017
+        username: someuser
+        password: somepassword
+        timeout: 60
         tags:
-          - 'env:test'
+        - 'env:test'
 
   EOF
 
@@ -23,8 +25,11 @@ describe 'datadog::mongo' do
         mongo: {
           instances: [
             {
-              hosts: 'localhost',
+              host: 'localhost',
               port: '27017',
+              username: 'someuser',
+              password: 'somepassword',
+              timeout: '60',
               tags: ['env:test']
             }
           ]

--- a/spec/integrations/mongo_spec.rb
+++ b/spec/integrations/mongo_spec.rb
@@ -4,12 +4,13 @@ describe 'datadog::mongo' do
     init_config:
 
     instances:
-      - host: localhost:27017
+      - hosts:
+          - localhost:27017
         username: someuser
         password: somepassword
-      timeout: 60
-      tags:
-      - 'env:test'
+        timeout: 60
+        tags:
+        - 'env:test'
 
   EOF
 

--- a/spec/integrations/mongo_spec.rb
+++ b/spec/integrations/mongo_spec.rb
@@ -7,7 +7,7 @@ describe 'datadog::mongo' do
       - hosts:
           - localhost:27017
         tags:
-        - 'env:test'
+          - 'env:test'
 
   EOF
 

--- a/spec/integrations/mongo_spec.rb
+++ b/spec/integrations/mongo_spec.rb
@@ -4,7 +4,9 @@ describe 'datadog::mongo' do
     init_config:
 
     instances:
-    - server: mongodb://localhost:27017
+      - host: localhost:27017
+        username: someuser
+        password: somepassword
       timeout: 60
       tags:
       - 'env:test'

--- a/spec/integrations/mongo_spec.rb
+++ b/spec/integrations/mongo_spec.rb
@@ -4,7 +4,8 @@ describe 'datadog::mongo' do
     init_config:
 
     instances:
-      - hosts: localhost:27017
+      - hosts:
+          - localhost:27017
         username: someuser
         password: somepassword
         timeout: 60

--- a/spec/integrations/mongo_spec.rb
+++ b/spec/integrations/mongo_spec.rb
@@ -6,9 +6,6 @@ describe 'datadog::mongo' do
     instances:
       - hosts:
           - localhost:27017
-        username: someuser
-        password: somepassword
-        timeout: 60
         tags:
         - 'env:test'
 
@@ -26,9 +23,8 @@ describe 'datadog::mongo' do
         mongo: {
           instances: [
             {
-              host: 'localhost',
+              hosts: 'localhost',
               port: '27017',
-              timeout: '60',
               tags: ['env:test']
             }
           ]

--- a/templates/default/mongo.yaml.erb
+++ b/templates/default/mongo.yaml.erb
@@ -2,7 +2,14 @@
 
 instances:
   <% @instances.each do |i| -%>
-  - server: mongodb://<%= i['host']%>:<%= i['port'] %>
+  - hosts:
+      - <%= i['host']%>:<%= i['port'] %>
+    <% if i.key?('username') -%>
+    username: <%= i['username'] %>
+    <% end -%>
+    <% if i.key?('password') -%>
+    password: <%= i['password'] %>
+    <% end -%>
     <% if i.key?('timeout') -%>
     timeout: <%= i['timeout'] %>
     <% end -%>
@@ -35,4 +42,3 @@ instances:
 
 init_config:
 # No init_config details needed
-

--- a/test/integration/datadog_mongo/serverspec/mongo_spec.rb
+++ b/test/integration/datadog_mongo/serverspec/mongo_spec.rb
@@ -17,7 +17,10 @@ describe file(AGENT_CONFIG) do
     expected = {
       'instances' => [
         {
-          'hosts' => 'localhost:27017'
+          'hosts' => 'localhost:27017',
+          'username' => 'someuser',
+          'password' => 'somepassword',
+          'timeout' => 30
         }
       ],
       'logs' => nil,

--- a/test/integration/datadog_mongo/serverspec/mongo_spec.rb
+++ b/test/integration/datadog_mongo/serverspec/mongo_spec.rb
@@ -17,7 +17,7 @@ describe file(AGENT_CONFIG) do
     expected = {
       'instances' => [
         {
-          'server' => 'mongodb://localhost:27017'
+          'hosts' => 'localhost:27017'
         }
       ],
       'logs' => nil,


### PR DESCRIPTION
The server attribute is deprecated according to Agent 7.22.1 documentation. Authentication with username and password to Mongo is possible now.