### PR TITLE
[debian/ubuntu] Add new signing key

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -28,7 +28,7 @@ agent_major_version = Chef::Datadog.agent_major_version(node)
 
 # A2923DFF56EDA6E76E55E492D3A80E30382E94DE expires in 2022
 # D75CEA17048B9ACBF186794B32637D44F14F620E expires in 2032
-apt_gpg_key = 'A2923DFF56EDA6E76E55E492D3A80E30382E94DE'
+apt_gpg_keys = ['A2923DFF56EDA6E76E55E492D3A80E30382E94DE', 'D75CEA17048B9ACBF186794B32637D44F14F620E']
 
 # DATADOG_RPM_KEY_E09422B3.public expires in 2022
 # DATADOG_RPM_KEY_20200908.public expires in 2024
@@ -67,7 +67,7 @@ when 'debian'
   # Add APT repositories
   apt_repository 'datadog' do
     keyserver keyserver
-    key apt_gpg_key
+    key apt_gpg_keys
     uri node['datadog']['aptrepo']
     distribution node['datadog']['aptrepo_dist']
     components components
@@ -75,10 +75,19 @@ when 'debian'
     retries retries
   end
 
-  # Previous versions of the cookbook could create this repo file, make sure we remove it now
+  # Previous versions of the cookbook could create these repo files, make sure we remove it now
   apt_repository 'datadog-beta' do
     action :remove
   end
+
+  apt_repository 'datadog_apt_A2923DFF56EDA6E76E55E492D3A80E30382E94DE' do
+    action :remove
+  end
+
+  apt_repository 'datadog_apt_D75CEA17048B9ACBF186794B32637D44F14F620E' do
+    action :remove
+  end
+
 when 'rhel', 'fedora', 'amazon'
   # Import new RPM key
   rpm_gpg_keys.each do |rpm_gpg_key|

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -14,14 +14,22 @@ describe 'datadog::repository' do
       expect(chef_run).to install_package('install-apt-transport-https')
     end
 
-    it 'sets up an apt repo with fingerprint A2923DFF56EDA6E76E55E492D3A80E30382E94DE' do
+    it 'sets up an apt repo with fingerprint A2923DFF56EDA6E76E55E492D3A80E30382E94DE and D75CEA17048B9ACBF186794B32637D44F14F620E' do
       expect(chef_run).to add_apt_repository('datadog').with(
-        key: ['A2923DFF56EDA6E76E55E492D3A80E30382E94DE']
+        key: ['A2923DFF56EDA6E76E55E492D3A80E30382E94DE', 'D75CEA17048B9ACBF186794B32637D44F14F620E']
       )
     end
 
     it 'removes the datadog-beta repo' do
       expect(chef_run).to remove_apt_repository('datadog-beta')
+    end
+
+    it 'removes the datadog_apt_A2923DFF56EDA6E76E55E492D3A80E30382E94DE repo' do
+      expect(chef_run).to remove_apt_repository('datadog_apt_A2923DFF56EDA6E76E55E492D3A80E30382E94DE')
+    end
+
+    it 'removes the datadog_apt_D75CEA17048B9ACBF186794B32637D44F14F620E repo' do
+      expect(chef_run).to remove_apt_repository('datadog_apt_D75CEA17048B9ACBF186794B32637D44F14F620E')
     end
   end
 

--- a/test/integration/dd-agent-handler5/serverspec/dd-agent_spec.rb
+++ b/test/integration/dd-agent-handler5/serverspec/dd-agent_spec.rb
@@ -14,10 +14,11 @@ describe command('/etc/init.d/datadog-agent info | grep -v "API Key is invalid"'
   its(:stdout) { should_not contain 'ERROR' }
 end
 
-# The new APT key is imported
+# The new APT keys are imported
 describe command('apt-key list'), :if => ['debian', 'ubuntu'].include?(os[:family]) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should contain '382E94DE' }
+  its(:stdout) { should contain 'F14F620E' }
 end
 
 # The new RPM keys are imported

--- a/test/integration/dd-agent-handler6/serverspec/dd-agent_spec.rb
+++ b/test/integration/dd-agent-handler6/serverspec/dd-agent_spec.rb
@@ -14,10 +14,11 @@ describe command('/opt/datadog-agent/bin/agent/agent status | grep -v "Instance 
   its(:stdout) { should_not contain 'ERROR' }
 end
 
-# The new APT key is imported
+# The new APT keys are imported
 describe command('apt-key list'), :if => ['debian', 'ubuntu'].include?(os[:family]) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should contain '382E94DE' }
+  its(:stdout) { should contain 'F14F620E' }
 end
 
 # The new RPM keys are imported

--- a/test/integration/dd-agent-handler7/serverspec/dd-agent_spec.rb
+++ b/test/integration/dd-agent-handler7/serverspec/dd-agent_spec.rb
@@ -14,10 +14,11 @@ describe command('/opt/datadog-agent/bin/agent/agent status | grep -v "Instance 
   its(:stdout) { should_not contain 'ERROR' }
 end
 
-# The new APT key is imported
+# The new APT keys are imported
 describe command('apt-key list'), :if => ['debian', 'ubuntu'].include?(os[:family]) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should contain '382E94DE' }
+  its(:stdout) { should contain 'F14F620E' }
 end
 
 # The new RPM keys are imported

--- a/test/integration/dd-agent-iot/serverspec/dd-agent_spec.rb
+++ b/test/integration/dd-agent-iot/serverspec/dd-agent_spec.rb
@@ -16,10 +16,11 @@ describe command('/opt/datadog-agent/bin/agent/agent status | grep -v "Instance 
   its(:stdout) { should_not contain 'ERROR' }
 end
 
-# The new APT key is imported
+# The new APT keys are imported
 describe command('apt-key list'), :if => ['debian', 'ubuntu'].include?(os[:family]) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should contain '382E94DE' }
+  its(:stdout) { should contain 'F14F620E' }
 end
 
 # The new RPM keys are imported

--- a/test/integration/dd-agent/serverspec/dd-agent_spec.rb
+++ b/test/integration/dd-agent/serverspec/dd-agent_spec.rb
@@ -14,10 +14,11 @@ describe command('/opt/datadog-agent/bin/agent/agent status | grep -v "Instance 
   its(:stdout) { should_not contain 'ERROR' }
 end
 
-# The new APT key is imported
+# The new APT keys are imported
 describe command('apt-key list'), :if => ['debian', 'ubuntu'].include?(os[:family]) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should contain '382E94DE' }
+  its(:stdout) { should contain 'F14F620E' }
 end
 
 # The new RPM keys are imported


### PR DESCRIPTION
### What does this PR do?

Re-introduces the install of the new apt signing key `D75CEA17048B9ACBF186794B32637D44F14F620E`, removed in #761 because of a bug.
Cleans up superfluous repository files that may have been added by versions 4.7.0 and 4.7.2 of the cookbook.

### Motivation

Prepare future key rotation.
Clean up bad repository files created in 4.7.0 and 4.7.2.

### Additional notes

I still need to test upgrades (of an Agent & of the cookbook), but this should work.
Update: done.