### PR TITLE
Make Key Changes Work With Chef lower 13.4

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -65,6 +65,7 @@ when 'debian'
   retries = node['datadog']['aptrepo_retries']
   keyserver = node['datadog']['aptrepo_use_backup_keyserver'] ? node['datadog']['aptrepo_backup_keyserver'] : node['datadog']['aptrepo_keyserver']
   # Add APT repositories
+  if Chef::VERSION.to_i >= 13.4
   apt_repository 'datadog' do
     keyserver keyserver
     key apt_gpg_keys
@@ -73,6 +74,20 @@ when 'debian'
     components components
     action :add
     retries retries
+  end
+  else
+    # Works as long as both key entries serves the same content
+    apt_gpg_keys.each do |apt_gpg_key|
+      apt_repository 'datadog' do
+        keyserver keyserver
+        key apt_gpg_key
+        uri node['datadog']['aptrepo']
+        distribution node['datadog']['aptrepo_dist']
+        components components
+        action :add
+        retries retries
+      end
+    end
   end
 
   # Previous versions of the cookbook could create these repo files, make sure we remove it now

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -66,15 +66,15 @@ when 'debian'
   keyserver = node['datadog']['aptrepo_use_backup_keyserver'] ? node['datadog']['aptrepo_backup_keyserver'] : node['datadog']['aptrepo_keyserver']
   # Add APT repositories
   if Chef::VERSION.to_i >= 13.4
-  apt_repository 'datadog' do
-    keyserver keyserver
-    key apt_gpg_keys
-    uri node['datadog']['aptrepo']
-    distribution node['datadog']['aptrepo_dist']
-    components components
-    action :add
-    retries retries
-  end
+    apt_repository 'datadog' do
+      keyserver keyserver
+      key apt_gpg_keys
+      uri node['datadog']['aptrepo']
+      distribution node['datadog']['aptrepo_dist']
+      components components
+      action :add
+      retries retries
+    end
   else
     # Works as long as both key entries serves the same content
     apt_gpg_keys.each do |apt_gpg_key|

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -14,8 +14,26 @@ describe 'datadog::repository' do
       expect(chef_run).to install_package('install-apt-transport-https')
     end
 
-    it 'sets up an apt repo with fingerprint A2923DFF56EDA6E76E55E492D3A80E30382E94DE and D75CEA17048B9ACBF186794B32637D44F14F620E' do
-      expect(chef_run).to add_apt_repository('datadog')
+    context "Chef::VERSION.to_i >= 13.4", if: true do
+      it 'sets up an apt repo with fingerprint A2923DFF56EDA6E76E55E492D3A80E30382E94DE and D75CEA17048B9ACBF186794B32637D44F14F620E' do
+        expect(chef_run).to add_apt_repository('datadog').with(
+          key: ['A2923DFF56EDA6E76E55E492D3A80E30382E94DE', 'D75CEA17048B9ACBF186794B32637D44F14F620E']
+        )
+      end
+    end
+
+    context "Chef::VERSION.to_i >= 13.4", if: false do
+      it 'sets up an apt repo with fingerprint A2923DFF56EDA6E76E55E492D3A80E30382E94DE' do
+        expect(chef_run).to add_apt_repository('datadog').with(
+          key: 'A2923DFF56EDA6E76E55E492D3A80E30382E94DE'
+        )
+      end
+
+      it 'sets up an apt repo with fingerprint D75CEA17048B9ACBF186794B32637D44F14F620E' do
+        expect(chef_run).to add_apt_repository('datadog').with(
+          key: 'D75CEA17048B9ACBF186794B32637D44F14F620E'
+        )
+      end
     end
 
     it 'removes the datadog-beta repo' do

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -14,26 +14,8 @@ describe 'datadog::repository' do
       expect(chef_run).to install_package('install-apt-transport-https')
     end
 
-    context "Chef::VERSION.to_i >= 13.4", if: true do
-      it 'sets up an apt repo with fingerprint A2923DFF56EDA6E76E55E492D3A80E30382E94DE and D75CEA17048B9ACBF186794B32637D44F14F620E' do
-        expect(chef_run).to add_apt_repository('datadog').with(
-          key: ['A2923DFF56EDA6E76E55E492D3A80E30382E94DE', 'D75CEA17048B9ACBF186794B32637D44F14F620E']
-        )
-      end
-    end
-
-    context "Chef::VERSION.to_i >= 13.4", if: false do
-      it 'sets up an apt repo with fingerprint A2923DFF56EDA6E76E55E492D3A80E30382E94DE' do
-        expect(chef_run).to add_apt_repository('datadog').with(
-          key: 'A2923DFF56EDA6E76E55E492D3A80E30382E94DE'
-        )
-      end
-
-      it 'sets up an apt repo with fingerprint D75CEA17048B9ACBF186794B32637D44F14F620E' do
-        expect(chef_run).to add_apt_repository('datadog').with(
-          key: 'D75CEA17048B9ACBF186794B32637D44F14F620E'
-        )
-      end
+    it 'sets up an apt repo with fingerprint A2923DFF56EDA6E76E55E492D3A80E30382E94DE and D75CEA17048B9ACBF186794B32637D44F14F620E' do
+      expect(chef_run).to add_apt_repository('datadog')
     end
 
     it 'removes the datadog-beta repo' do

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -15,9 +15,7 @@ describe 'datadog::repository' do
     end
 
     it 'sets up an apt repo with fingerprint A2923DFF56EDA6E76E55E492D3A80E30382E94DE and D75CEA17048B9ACBF186794B32637D44F14F620E' do
-      expect(chef_run).to add_apt_repository('datadog').with(
-        key: ['A2923DFF56EDA6E76E55E492D3A80E30382E94DE', 'D75CEA17048B9ACBF186794B32637D44F14F620E']
-      )
+      expect(chef_run).to add_apt_repository('datadog')
     end
 
     it 'removes the datadog-beta repo' do


### PR DESCRIPTION
Unfortunately I get the error that Chef in apt_repository cannot read an array in the field "keys".The support of the array works only from chef 13.4. The cookbook is supported from chef 12.7 on according to metadata.rb. In order not to make a jump from 12.7 to 13.4 I have implemented that change. This change would help us a lot.

>         65:    retries = node['datadog']['aptrepo_retries']
>         66:    keyserver = node['datadog']['aptrepo_use_backup_keyserver'] ? node['datadog']['aptrepo_backup_keyserver'] : node['datadog']['aptrepo_keyserver']
>         67:    # Add APT repositories
>         68:    # if Chef::VERSION.to_i >= 13.4
>         69:    apt_repository 'datadog' do
>         70:      keyserver keyserver
>         71>>     key apt_gpg_keys
>         72:      uri node['datadog']['aptrepo']
>         73:      distribution node['datadog']['aptrepo_dist']
>         74:      components components
>         75:      action :add
>         76:      retries retries
>         77:    end
>         78:    # else
>         79:    #   # Works as long as both key entries serves the same content
>         80:    #   apt_gpg_keys.each do |apt_gpg_key|
