### PR TITLE
Add multiple apt keys in a way that's compatible with chef < 13.4

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -3,6 +3,6 @@ source 'https://supermarket.chef.io'
 metadata
 
 group :integration do
-  cookbook 'sudo'
+  cookbook 'sudo' # Use '< 5.0.0' with Chef < 13
   cookbook 'test', path: './test/cookbooks/test' # Used to test custom resources (datadog_monitor, integration)
 end

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -28,7 +28,8 @@ agent_major_version = Chef::Datadog.agent_major_version(node)
 
 # A2923DFF56EDA6E76E55E492D3A80E30382E94DE expires in 2022
 # D75CEA17048B9ACBF186794B32637D44F14F620E expires in 2032
-apt_gpg_keys = ['A2923DFF56EDA6E76E55E492D3A80E30382E94DE', 'D75CEA17048B9ACBF186794B32637D44F14F620E']
+apt_gpg_key = 'D75CEA17048B9ACBF186794B32637D44F14F620E'
+other_apt_gpg_keys = ['A2923DFF56EDA6E76E55E492D3A80E30382E94DE']
 
 # DATADOG_RPM_KEY_E09422B3.public expires in 2022
 # DATADOG_RPM_KEY_20200908.public expires in 2024
@@ -67,12 +68,20 @@ when 'debian'
   # Add APT repositories
   apt_repository 'datadog' do
     keyserver keyserver
-    key apt_gpg_keys
+    key apt_gpg_key
     uri node['datadog']['aptrepo']
     distribution node['datadog']['aptrepo_dist']
     components components
     action :add
     retries retries
+  end
+
+  other_apt_gpg_keys.each do |key|
+    key_short = key[-8..-1] # last 8 chars, since some versions of apt-key list add dashes in between key parts
+    execute "apt-key import key #{key_short}" do
+      command "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 #{key}"
+      not_if "apt-key list | grep #{key_short}"
+    end
   end
 
   # Previous versions of the cookbook could create these repo files, make sure we remove it now

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -64,7 +64,7 @@ when 'debian'
   end
 
   other_apt_gpg_keys.each do |key|
-    key_short = key[-8..-1] # last 8 chars, since some versions of apt-key list add dashes in between key parts
+    key_short = key[-8..-1] # last 8 chars, since some versions of apt-key add dashes between key sections
     execute "apt-key import key #{key_short}" do
       command "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 #{key}"
       not_if "apt-key list | grep #{key_short}"

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -16,8 +16,9 @@ describe 'datadog::repository' do
 
     it 'sets up an apt repo with fingerprint A2923DFF56EDA6E76E55E492D3A80E30382E94DE and D75CEA17048B9ACBF186794B32637D44F14F620E' do
       expect(chef_run).to add_apt_repository('datadog').with(
-        key: ['A2923DFF56EDA6E76E55E492D3A80E30382E94DE', 'D75CEA17048B9ACBF186794B32637D44F14F620E']
+        key: ['D75CEA17048B9ACBF186794B32637D44F14F620E']
       )
+      expect(chef_run).to run_execute('apt-key import key 382E94DE')
     end
 
     it 'removes the datadog-beta repo' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,7 @@ RSpec.configure do |config|
     # recipes/repository.rb
     stub_command('rpm -q gpg-pubkey-e09422b3').and_return(false)
     stub_command('rpm -q gpg-pubkey-fd4bf915').and_return(false)
+    stub_command('apt-key list | grep 382E94DE').and_return(false)
   end
 
   Ohai::Config[:log_level] = :warn


### PR DESCRIPTION
Chef older than 13.4 doesn't support passing an array in the `key` field of `apt_repository`. Add a single key there an manually execute `apt-key` to add any additional keys.