### PR TITLE
Prevent Adding Key Every chef-client Run

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -67,7 +67,7 @@ when 'debian'
     key_short = key[-8..-1] # last 8 chars, since some versions of apt-key add dashes between key sections
     execute "apt-key import key #{key_short}" do
       command "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 #{key}"
-      not_if "apt-key list | grep #{key_short}"
+      not_if "apt-key adv --list-public-keys --with-fingerprint --with-colons | grep #{key_short} | grep pub"
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,8 +29,9 @@ RSpec.configure do |config|
     # recipes/repository.rb
     stub_command('rpm -q gpg-pubkey-e09422b3').and_return(false)
     stub_command('rpm -q gpg-pubkey-fd4bf915').and_return(false)
-    stub_command('apt-key list | grep 382E94DE').and_return(false)
+    stub_command('apt-key adv --list-public-keys --with-fingerprint --with-colons | grep 382E94DE | grep pub').and_return(false)
   end
+
 
   Ohai::Config[:log_level] = :warn
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,6 @@ RSpec.configure do |config|
     stub_command('apt-key adv --list-public-keys --with-fingerprint --with-colons | grep 382E94DE | grep pub').and_return(false)
   end
 
-
   Ohai::Config[:log_level] = :warn
 end
 


### PR DESCRIPTION
Due to #765 the possibility to use two keys < 13.4 was thankfully enabled. I figured out that the output of `apt-key` is hidden for some grep operations in newer versions, so that the `not_if statement doesn't match on Debian 10 systems (only tested with 10) and it wants to add the key from the key server every chef-client run.

Output before this change:
` * execute[apt-key import key 382E94DE] action runWarning: apt-key output should not be parsed (stdout is not a terminal)
    [execute] Warning: apt-key output should not be parsed (stdout is not a terminal)
              Executing: /tmp/apt-key-gpghome.R1PRIy6J9Z/gpg.1.sh --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE
              gpg: key D3A80E30382E94DE: "Datadog, Inc <package@datadoghq.com>" not changed
              gpg: Total number processed: 1
              gpg:              unchanged: 1
    - execute apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE`

After this change:
`execute[apt-key add /var/chef/cache/docker-repo-key-9DC858229FC7DD38854AE2D88D81803C0EBFCD88] action run (skipped due to not_if)`

The command should work for all Debian systems doesn't matter if e.g. Debian 8 9 or 10. 

`apt-key adv --list-public-keys --with-fingerprint --with-colons | grep "32637D44F14F620E" | grep pub`