### PR TITLE
Remove deprecated config `skip_event`

### DIFF
--- a/recipes/http_check.rb
+++ b/recipes/http_check.rb
@@ -11,7 +11,6 @@ include_recipe 'datadog::dd-agent'
 #       'content_match' => 'string to match',
 #       'include_content' => true,
 #       'collect_response_time' => true,
-#       'skip_event' => true,
 #       'tags' => [
 #        'myApp',
 #        'serviceName'


### PR DESCRIPTION
`skip-event` has been removed as of [HTTP Check release 2.0.0](https://github.com/DataDog/integrations-core/blob/f8b9b133af66d26599d623367eccff6fdb3e56af/http_check/CHANGELOG.md#200--2018-03-23).