### PR TITLE
Fix yum_package[gnupg] resource being declared more than once

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -98,15 +98,15 @@ when 'debian'
   end
 
 when 'rhel', 'fedora', 'amazon'
+  # gnupg is required to check the downloaded key's fingerprint
+  package 'gnupg' do
+    action :install
+    only_if { node['packages']['gnupg2'].nil? }
+  end
+  
   # Import new RPM key
   rpm_gpg_keys.each do |rpm_gpg_key|
     next unless node['datadog']["yumrepo_gpgkey_new_#{rpm_gpg_key[rpm_gpg_keys_short_fingerprint]}"]
-
-    # gnupg is required to check the downloaded key's fingerprint
-    package 'gnupg' do
-      action :install
-      only_if { node['packages']['gnupg2'].nil? }
-    end
 
     # Download new RPM key
     key_local_path = ::File.join(Chef::Config[:file_cache_path], rpm_gpg_key[rpm_gpg_keys_name])


### PR DESCRIPTION
On RHEL OSes, the datadog::repository recipe declared yum_package[gnupg] once for each GPG key causing deprecation warnings on Chef 12.

I was unable to get rspec to run cleanly before my change, but no new failures were reported after my change.  I was able to run the `dd-agent-centos-71-*` kitchen tests, except for `dd-agent-centos-71-1272` which fails for unrelated reasons (version dependency issues between the `apt` cookbook and Chef 12).