### PR TITLE
Feature: allow muting a host during an MSI install

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,6 +29,7 @@ namespace :style do
       fail_tags: ['correctness'],
       tags: [
         '~FC121', # Disables: Cookbook depends on cookbook made obsolete by Chef 14 (chef_handler)
+        '~FC014', # Disables: Consider extracting long ruby_block to library
       ]
     }
   end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -189,6 +189,11 @@ default['datadog']['windows_blacklist_silent_fail'] = false
 # Default should suffice, but provides a knob in case instances with limited resources timeout.
 default['datadog']['windows_msi_timeout'] = 1200
 
+# Mute hosts during an MSI installation
+# To prevent no-data alerts when MSI installs take long.
+# Requires 'application_key' to be set to a valid app key.
+default['datadog']['windows_mute_hosts_during_install'] = false
+
 # Agent installer checksum
 # Expected checksum to validate correct agent installer is downloaded (Windows only)
 default['datadog']['windows_agent_checksum'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -191,7 +191,7 @@ default['datadog']['windows_msi_timeout'] = 1200
 
 # Mute hosts during an MSI installation
 # To prevent no-data alerts when MSI installs take long.
-# Requires 'application_key' to be set to a valid app key.
+# Requires setting 'application_key' to a valid app key for the Datadog REST API.
 default['datadog']['windows_mute_hosts_during_install'] = false
 
 # Agent installer checksum

--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -162,8 +162,8 @@ powershell_script 'datadog_6.14.x_fix' do
   notifies :remove, 'package[Datadog Agent removal]', :immediately
 end
 
-if node['datadog']['windows_mute_hosts_during_install'] then
-  if not Chef::Datadog.application_key(node) then
+if node['datadog']['windows_mute_hosts_during_install']
+  unless Chef::Datadog.application_key(node)
     Chef::Log.error('windows_mute_hosts_during_install requires an application_key but it is not set.')
   end
   ruby_block 'Mute host while installing' do
@@ -172,21 +172,19 @@ if node['datadog']['windows_mute_hosts_during_install'] then
       require 'uri'
       require 'json'
       hostname = node['datadog']['hostname']
-      api_key = Chef::Datadog.api_key(node)
-      app_key = Chef::Datadog.application_key(node)
       uri = URI.parse("https://api.datadoghq.com/api/v1/host/#{hostname}/mute")
       request = Net::HTTP::Post.new(uri)
-      request.content_type = "application/json"
-      request["Dd-Api-Key"] = api_key
-      request["Dd-Application-Key"] = app_key
+      request.content_type = 'application/json'
+      request['Dd-Api-Key'] = Chef::Datadog.api_key(node)
+      request['Dd-Application-Key'] = Chef::Datadog.application_key(node)
       request.body = JSON.dump({
         'message': 'Muted during install by datadog-chef cookbook',
-        'end': Time.now.getutc.to_i + (60*60), # Set to automatically unmute in 60 minutes
+        'end': Time.now.getutc.to_i + (60 * 60), # Set to automatically unmute in 60 minutes
       })
       response = Net::HTTP.start(uri.hostname, uri.port, { use_ssl: true }) do |http|
         http.request(request)
       end
-      if response.code != '200' then
+      if response.code != '200'
         Chef::Log.warn("Mute request failed with code #{response.code}: #{response.body}")
       end
     end
@@ -198,16 +196,14 @@ if node['datadog']['windows_mute_hosts_during_install'] then
       require 'uri'
       require 'json'
       hostname = node['datadog']['hostname']
-      api_key = Chef::Datadog.api_key(node)
-      app_key = Chef::Datadog.application_key(node)
       uri = URI.parse("https://api.datadoghq.com/api/v1/host/#{hostname}/unmute")
       request = Net::HTTP::Post.new(uri)
-      request["Dd-Api-Key"] = api_key
-      request["Dd-Application-Key"] = app_key
+      request['Dd-Api-Key'] = Chef::Datadog.api_key(node)
+      request['Dd-Application-Key'] = Chef::Datadog.application_key(node)
       response = Net::HTTP.start(uri.hostname, uri.port, { use_ssl: true }) do |http|
         http.request(request)
       end
-      if response.code != '200' then
+      if response.code != '200'
         Chef::Log.warn("Unmute request failed with code #{response.code}: #{response.body}")
       end
     end
@@ -234,7 +230,7 @@ windows_package 'Datadog Agent' do # ~FC009
   else
     success_codes [0, 3010]
   end
-  if node['datadog']['windows_mute_hosts_during_install'] then
+  if node['datadog']['windows_mute_hosts_during_install']
     notifies :run, 'ruby_block[Mute host while installing]', :before
     notifies :run, 'ruby_block[Unmute host after installing]', :immediately
   end

--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -158,6 +158,9 @@ powershell_script 'datadog_6.14.x_fix' do
 end
 
 if node['datadog']['windows_mute_hosts_during_install'] then
+  if not Chef::Datadog.application_key(node) then
+    Chef::Log.error('windows_mute_hosts_during_install requires an application_key but it is not set.')
+  end
   ruby_block 'Mute host while installing' do
     block do
       require 'net/http'

--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -186,7 +186,7 @@ if node['datadog']['windows_mute_hosts_during_install'] then
       response = Net::HTTP.start(uri.hostname, uri.port, { use_ssl: true }) do |http|
         http.request(request)
       end
-      if response.code != 200 then
+      if response.code != '200' then
         Chef::Log.warn("Mute request failed with code #{response.code}: #{response.body}")
       end
     end
@@ -207,7 +207,7 @@ if node['datadog']['windows_mute_hosts_during_install'] then
       response = Net::HTTP.start(uri.hostname, uri.port, { use_ssl: true }) do |http|
         http.request(request)
       end
-      if response.code != 200 then
+      if response.code != '200' then
         Chef::Log.warn("Unmute request failed with code #{response.code}: #{response.body}")
       end
     end

--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -36,6 +36,11 @@ module Windows
       resource = context.resource_collection.lookup('windows_env[DDAGENTUSER_PASSWORD]')
       resource.run_action(:delete)
     end
+
+    def unmute_host(context)
+      resource = context.resource_collection.lookup('ruby_block[Unmute host after installing]')
+      resource.run_action(:run)
+    end
   end
 end
 
@@ -207,6 +212,11 @@ if node['datadog']['windows_mute_hosts_during_install'] then
       end
     end
     action :nothing
+  end
+  Chef.event_handler do
+    on :run_failed do
+      Windows::Helper.new.unmute_host(Chef.run_context)
+    end
   end
 end
 


### PR DESCRIPTION
MSI installs can take a long time, during which the Agent is not running. On upgrades, this could trigger no-data monitors.

This PR adds a new option to mute a host while an MSI install takes place, thus preventing this issue. The host will unmute after either the install completes, the chef run fails, or after the mute expires (in 60 minutes).

This uses the [Datadog API ](https://docs.datadoghq.com/api/latest/hosts/#mute-a-host), which requires an `application_key`.