### PR TITLE
Support NPM installation switch

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -213,6 +213,9 @@ default['datadog']['windows_agent_use_exe'] = false
 default['datadog']['windows_ddagentuser_name'] = nil
 default['datadog']['windows_ddagentuser_password'] = nil
 
+# Since 7.27, the MSI has a switch to install NPM driver. Default to not install. Specify "true" to install.
+default['datadog']['windows_npm_install'] = nil
+
 # Chef handler version
 default['datadog']['chef_handler_version'] = nil
 

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -94,6 +94,10 @@ class Chef
         run_state_or_attribute(node, 'windows_ddagentuser_password')
       end
 
+      def npm_install(node)
+        run_state_or_attribute(node, 'windows_npm_install')
+      end
+
       def cookbook_version(run_context)
         run_context.cookbook_collection['datadog'].version
       end

--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -82,6 +82,8 @@ else
   dd_agent_installer_basename = "#{dd_agent_installer_prefix}-#{dd_agent_version}"
 end
 
+dd_agent_install_npm = Chef::Datadog.npm_install(node)
+
 temp_file_basename = ::File.join(Chef::Config[:file_cache_path], 'ddagent-cli')
 temp_fix_file = ::File.join(Chef::Config[:file_cache_path], 'fix_6_14.ps1')
 
@@ -102,6 +104,8 @@ else
   # custom credentials and use them if that's the case.
   install_options.concat(' DDAGENTUSER_NAME=%DDAGENTUSER_NAME%') if ddagentuser_name
   install_options.concat(' DDAGENTUSER_PASSWORD=%DDAGENTUSER_PASSWORD%') if ddagentuser_password
+
+  install_options.concat(" NPM=#{dd_agent_install_npm}") if dd_agent_install_npm
 end
 
 package 'Datadog Agent removal' do

--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -105,7 +105,7 @@ else
   install_options.concat(' DDAGENTUSER_NAME=%DDAGENTUSER_NAME%') if ddagentuser_name
   install_options.concat(' DDAGENTUSER_PASSWORD=%DDAGENTUSER_PASSWORD%') if ddagentuser_password
 
-  install_options.concat(" NPM=#{dd_agent_install_npm}") if dd_agent_install_npm
+  install_options.concat(" NPM=#{dd_agent_install_npm}") unless dd_agent_install_npm.nil?
 end
 
 package 'Datadog Agent removal' do


### PR DESCRIPTION

Tested by enabling the switch and running kitchen converge dd-agent-windows-2012r2-13113,
log into the VM, open C:\Users\vagrant\AppData\Local\Temp\MSI*.log and make sure NPM = true and NPM driver is installed.