### PR TITLE
Implement usage of multiple GPG keys in repofiles, get keys from keys.datadoghq.com

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -160,7 +160,7 @@ default['datadog']['aptrepo_retries'] = 4
 default['datadog']['aptrepo_use_backup_keyserver'] = false
 default['datadog']['aptrepo_keyserver'] = 'hkp://keyserver.ubuntu.com:80'
 default['datadog']['aptrepo_backup_keyserver'] = 'hkp://pool.sks-keyservers.net:80'
-default['datadog']['yumrepo_gpgkey'] = "#{yum_protocol}://yum.datadoghq.com/DATADOG_RPM_KEY.public"
+default['datadog']['yumrepo_gpgkey'] = "#{yum_protocol}://keys.datadoghq.com/DATADOG_RPM_KEY.public"
 default['datadog']['yumrepo_proxy'] = nil
 default['datadog']['yumrepo_proxy_username'] = nil
 default['datadog']['yumrepo_proxy_password'] = nil
@@ -174,9 +174,9 @@ default['datadog']['windows_agent_installer_prefix'] = nil
 # Location of additional rpm gpg keys to import. In the future the rpm packages
 # of the Agent will be signed with this key.
 # DATADOG_RPM_KEY_CURRENT always contains the key that is used to sign repodata and latest packages
-default['datadog']['yumrepo_gpgkey_new_current'] = "#{yum_protocol}://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public"
-default['datadog']['yumrepo_gpgkey_new_e09422b3'] = "#{yum_protocol}://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
-default['datadog']['yumrepo_gpgkey_new_fd4bf915'] = "#{yum_protocol}://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public"
+default['datadog']['yumrepo_gpgkey_new_current'] = "#{yum_protocol}://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public"
+default['datadog']['yumrepo_gpgkey_new_e09422b3'] = "#{yum_protocol}://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
+default['datadog']['yumrepo_gpgkey_new_fd4bf915'] = "#{yum_protocol}://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public"
 
 # Windows Agent Blacklist
 # Attribute to enforce silent failures on agent installs when attempting to install a

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -173,6 +173,8 @@ default['datadog']['windows_agent_installer_prefix'] = nil
 
 # Location of additional rpm gpg keys to import. In the future the rpm packages
 # of the Agent will be signed with this key.
+# DATADOG_RPM_KEY_CURRENT always contains the key that is used to sign repodata and latest packages
+default['datadog']['yumrepo_gpgkey_new_current'] = "#{yum_protocol}://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public"
 default['datadog']['yumrepo_gpgkey_new_e09422b3'] = "#{yum_protocol}://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
 default['datadog']['yumrepo_gpgkey_new_fd4bf915'] = "#{yum_protocol}://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public"
 

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -127,8 +127,7 @@ when 'rhel', 'fedora', 'amazon'
     # Import key if fingerprint matches
     execute "rpm-import datadog key #{rpm_gpg_key[rpm_gpg_keys_short_fingerprint]}" do
       command "rpm --import #{key_local_path}"
-      only_if { rpm_gpg_key[rpm_gpg_keys_short_fingerprint] == 'current' }
-      only_if "gpg --dry-run --quiet --with-fingerprint #{key_local_path} | grep '#{rpm_gpg_key[rpm_gpg_keys_full_fingerprint]}' || gpg --dry-run --import --import-options import-show #{key_local_path} | grep '#{gpg_key_fingerprint_without_space}'"
+      only_if "gpg --dry-run --quiet --with-fingerprint #{key_local_path} | grep '#{rpm_gpg_key[rpm_gpg_keys_full_fingerprint]}' || gpg --dry-run --import --import-options import-show #{key_local_path} | grep '#{gpg_key_fingerprint_without_space}' || [ #{rpm_gpg_key[rpm_gpg_keys_short_fingerprint]} = \"current\" ]"
       action :nothing
     end
   end
@@ -189,8 +188,7 @@ when 'suse'
     # Import key if fingerprint matches
     execute "rpm-import datadog key #{rpm_gpg_key[rpm_gpg_keys_short_fingerprint]}" do
       command "rpm --import #{new_key_local_path}"
-      only_if { rpm_gpg_key[rpm_gpg_keys_short_fingerprint] == 'current' }
-      only_if "gpg --dry-run --quiet --with-fingerprint #{new_key_local_path} | grep '#{rpm_gpg_key[rpm_gpg_keys_full_fingerprint]}' || gpg --dry-run --import --import-options import-show #{new_key_local_path} | grep '#{gpg_key_fingerprint_without_space}'"
+      only_if "gpg --dry-run --quiet --with-fingerprint #{new_key_local_path} | grep '#{rpm_gpg_key[rpm_gpg_keys_full_fingerprint]}' || gpg --dry-run --import --import-options import-show #{new_key_local_path} | grep '#{gpg_key_fingerprint_without_space}' || [ #{rpm_gpg_key[rpm_gpg_keys_short_fingerprint]} = \"current\" ]"
       action :nothing
     end
   end

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -31,9 +31,11 @@ agent_major_version = Chef::Datadog.agent_major_version(node)
 apt_gpg_key = 'D75CEA17048B9ACBF186794B32637D44F14F620E'
 other_apt_gpg_keys = ['A2923DFF56EDA6E76E55E492D3A80E30382E94DE']
 
+# DATADOG_RPM_KEY_CURRENT always contains the key that is used to sign repodata and latest packages
 # DATADOG_RPM_KEY_E09422B3.public expires in 2022
 # DATADOG_RPM_KEY_20200908.public expires in 2024
-rpm_gpg_keys = [['DATADOG_RPM_KEY_E09422B3.public', 'e09422b3', 'A4C0 B90D 7443 CF6E 4E8A  A341 F106 8E14 E094 22B3'],
+rpm_gpg_keys = [['DATADOG_RPM_KEY_CURRENT.public', 'current', ''],
+                ['DATADOG_RPM_KEY_E09422B3.public', 'e09422b3', 'A4C0 B90D 7443 CF6E 4E8A  A341 F106 8E14 E094 22B3'],
                 ['DATADOG_RPM_KEY_20200908.public', 'fd4bf915', 'C655 9B69 0CA8 82F0 23BD  F3F6 3F4D 1729 FD4B F915']]
 
 # Local file name of the key
@@ -113,6 +115,8 @@ when 'rhel', 'fedora', 'amazon'
     remote_file "remote_file_#{rpm_gpg_key[rpm_gpg_keys_name]}" do
       path key_local_path
       source node['datadog']["yumrepo_gpgkey_new_#{rpm_gpg_key[rpm_gpg_keys_short_fingerprint]}"]
+      # note that for the "current" key, this will fine, because there's never going to be
+      # gpg-pubkey-current entry in the RPM database
       not_if "rpm -q gpg-pubkey-#{rpm_gpg_key[rpm_gpg_keys_short_fingerprint]}" # (key already imported)
       notifies :run, "execute[rpm-import datadog key #{rpm_gpg_key[rpm_gpg_keys_short_fingerprint]}]", :immediately
     end
@@ -123,6 +127,7 @@ when 'rhel', 'fedora', 'amazon'
     # Import key if fingerprint matches
     execute "rpm-import datadog key #{rpm_gpg_key[rpm_gpg_keys_short_fingerprint]}" do
       command "rpm --import #{key_local_path}"
+      only_if { rpm_gpg_key[rpm_gpg_keys_short_fingerprint] == "current" }
       only_if "gpg --dry-run --quiet --with-fingerprint #{key_local_path} | grep '#{rpm_gpg_key[rpm_gpg_keys_full_fingerprint]}' || gpg --dry-run --import --import-options import-show #{key_local_path} | grep '#{gpg_key_fingerprint_without_space}'"
       action :nothing
     end
@@ -145,13 +150,14 @@ when 'rhel', 'fedora', 'amazon'
 
   # Add YUM repository
   yumrepo_gpgkeys = []
-  if agent_major_version < 7
-    yumrepo_gpgkeys.push(node['datadog']['yumrepo_gpgkey'])
-  else
+  if agent_major_version > 5
     rpm_gpg_keys.each do |rpm_gpg_key|
       yumrepo_gpgkeys.push(node['datadog']["yumrepo_gpgkey_new_#{rpm_gpg_key[rpm_gpg_keys_short_fingerprint]}"])
     end
   end
+  # yum/dnf go through entries in the order in which they're set in the repofile;
+  # add the old key last so it doesn't get imported at all if a newer key can be used
+  yumrepo_gpgkeys.push(node['datadog']['yumrepo_gpgkey']) if agent_major_version < 7
 
   yum_repository 'datadog' do
     description 'datadog'
@@ -183,6 +189,7 @@ when 'suse'
     # Import key if fingerprint matches
     execute "rpm-import datadog key #{rpm_gpg_key[rpm_gpg_keys_short_fingerprint]}" do
       command "rpm --import #{new_key_local_path}"
+      only_if { rpm_gpg_key[rpm_gpg_keys_short_fingerprint] == "current" }
       only_if "gpg --dry-run --quiet --with-fingerprint #{new_key_local_path} | grep '#{rpm_gpg_key[rpm_gpg_keys_full_fingerprint]}' || gpg --dry-run --import --import-options import-show #{new_key_local_path} | grep '#{gpg_key_fingerprint_without_space}'"
       action :nothing
     end
@@ -221,7 +228,7 @@ when 'suse'
   zypper_repository 'datadog' do
     description 'datadog'
     baseurl baseurl
-    gpgkey agent_major_version < 7 ? node['datadog']['yumrepo_gpgkey'] : node['datadog']["yumrepo_gpgkey_new_#{rpm_gpg_keys[0][rpm_gpg_keys_short_fingerprint]}"]
+    gpgkey agent_major_version < 6 ? node['datadog']['yumrepo_gpgkey'] : node['datadog']["yumrepo_gpgkey_new_current"]
     gpgautoimportkeys false
     gpgcheck false
     action :create

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -127,7 +127,7 @@ when 'rhel', 'fedora', 'amazon'
     # Import key if fingerprint matches
     execute "rpm-import datadog key #{rpm_gpg_key[rpm_gpg_keys_short_fingerprint]}" do
       command "rpm --import #{key_local_path}"
-      only_if { rpm_gpg_key[rpm_gpg_keys_short_fingerprint] == "current" }
+      only_if { rpm_gpg_key[rpm_gpg_keys_short_fingerprint] == 'current' }
       only_if "gpg --dry-run --quiet --with-fingerprint #{key_local_path} | grep '#{rpm_gpg_key[rpm_gpg_keys_full_fingerprint]}' || gpg --dry-run --import --import-options import-show #{key_local_path} | grep '#{gpg_key_fingerprint_without_space}'"
       action :nothing
     end
@@ -189,7 +189,7 @@ when 'suse'
     # Import key if fingerprint matches
     execute "rpm-import datadog key #{rpm_gpg_key[rpm_gpg_keys_short_fingerprint]}" do
       command "rpm --import #{new_key_local_path}"
-      only_if { rpm_gpg_key[rpm_gpg_keys_short_fingerprint] == "current" }
+      only_if { rpm_gpg_key[rpm_gpg_keys_short_fingerprint] == 'current' }
       only_if "gpg --dry-run --quiet --with-fingerprint #{new_key_local_path} | grep '#{rpm_gpg_key[rpm_gpg_keys_full_fingerprint]}' || gpg --dry-run --import --import-options import-show #{new_key_local_path} | grep '#{gpg_key_fingerprint_without_space}'"
       action :nothing
     end
@@ -228,7 +228,7 @@ when 'suse'
   zypper_repository 'datadog' do
     description 'datadog'
     baseurl baseurl
-    gpgkey agent_major_version < 6 ? node['datadog']['yumrepo_gpgkey'] : node['datadog']["yumrepo_gpgkey_new_current"]
+    gpgkey agent_major_version < 6 ? node['datadog']['yumrepo_gpgkey'] : node['datadog']['yumrepo_gpgkey_new_current']
     gpgautoimportkeys false
     gpgcheck false
     action :create

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -33,10 +33,10 @@ other_apt_gpg_keys = ['A2923DFF56EDA6E76E55E492D3A80E30382E94DE']
 
 # DATADOG_RPM_KEY_CURRENT always contains the key that is used to sign repodata and latest packages
 # DATADOG_RPM_KEY_E09422B3.public expires in 2022
-# DATADOG_RPM_KEY_20200908.public expires in 2024
+# DATADOG_RPM_KEY_FD4BF915.public expires in 2024
 rpm_gpg_keys = [['DATADOG_RPM_KEY_CURRENT.public', 'current', ''],
                 ['DATADOG_RPM_KEY_E09422B3.public', 'e09422b3', 'A4C0 B90D 7443 CF6E 4E8A  A341 F106 8E14 E094 22B3'],
-                ['DATADOG_RPM_KEY_20200908.public', 'fd4bf915', 'C655 9B69 0CA8 82F0 23BD  F3F6 3F4D 1729 FD4B F915']]
+                ['DATADOG_RPM_KEY_FD4BF915.public', 'fd4bf915', 'C655 9B69 0CA8 82F0 23BD  F3F6 3F4D 1729 FD4B F915']]
 
 # Local file name of the key
 rpm_gpg_keys_name = 0

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -88,7 +88,7 @@ describe 'datadog::repository' do
       # Key FD4BF915 (2020-09-08)
       it 'sets the yumrepo_gpgkey_new attribute fd4bf915' do
         expect(chef_run.node['datadog']['yumrepo_gpgkey_new_fd4bf915']).to match(
-          /DATADOG_RPM_KEY_20200908.public/
+          /DATADOG_RPM_KEY_FD4BF915.public/
         )
       end
 
@@ -97,11 +97,11 @@ describe 'datadog::repository' do
       end
 
       it 'downloads the new RPM key fd4bf915' do
-        expect(chef_run).to create_remote_file('remote_file_DATADOG_RPM_KEY_20200908.public').with(path: ::File.join(Chef::Config[:file_cache_path], 'DATADOG_RPM_KEY_20200908.public'))
+        expect(chef_run).to create_remote_file('remote_file_DATADOG_RPM_KEY_FD4BF915.public').with(path: ::File.join(Chef::Config[:file_cache_path], 'DATADOG_RPM_KEY_FD4BF915.public'))
       end
 
       it 'notifies the GPG key install if a new one is downloaded fd4bf915' do
-        keyfile_r = chef_run.remote_file('remote_file_DATADOG_RPM_KEY_20200908.public')
+        keyfile_r = chef_run.remote_file('remote_file_DATADOG_RPM_KEY_FD4BF915.public')
         expect(keyfile_r).to notify('execute[rpm-import datadog key fd4bf915]')
           .to(:run).immediately
       end
@@ -112,12 +112,12 @@ describe 'datadog::repository' do
       end
 
       # prefer HTTPS on boxes that support TLS1.2
-      it 'sets up a yum repo E09422B3 and 20200908' do
+      it 'sets up a yum repo E09422B3 and FD4BF915' do
         expect(chef_run).to create_yum_repository('datadog').with(
           gpgkey: [
-            'https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public',
-            'https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
-            'https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public',
+            'https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public',
+            'https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
+            'https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public',
           ]
         )
       end
@@ -161,7 +161,7 @@ describe 'datadog::repository' do
       # Key FD4BF915 (2020-09-08)
       it 'sets the yumrepo_gpgkey_new attribute fd4bf915' do
         expect(chef_run.node['datadog']['yumrepo_gpgkey_new_fd4bf915']).to match(
-          /DATADOG_RPM_KEY_20200908.public/
+          /DATADOG_RPM_KEY_FD4BF915.public/
         )
       end
 
@@ -170,11 +170,11 @@ describe 'datadog::repository' do
       end
 
       it 'downloads the new RPM key fd4bf915' do
-        expect(chef_run).to create_remote_file('remote_file_DATADOG_RPM_KEY_20200908.public').with(path: ::File.join(Chef::Config[:file_cache_path], 'DATADOG_RPM_KEY_20200908.public'))
+        expect(chef_run).to create_remote_file('remote_file_DATADOG_RPM_KEY_FD4BF915.public').with(path: ::File.join(Chef::Config[:file_cache_path], 'DATADOG_RPM_KEY_FD4BF915.public'))
       end
 
       it 'notifies the GPG key install if a new one is downloaded fd4bf915' do
-        keyfile_r = chef_run.remote_file('remote_file_DATADOG_RPM_KEY_20200908.public')
+        keyfile_r = chef_run.remote_file('remote_file_DATADOG_RPM_KEY_FD4BF915.public')
         expect(keyfile_r).to notify('execute[rpm-import datadog key fd4bf915]')
           .to(:run).immediately
       end
@@ -188,10 +188,10 @@ describe 'datadog::repository' do
       it 'sets up a yum repo' do
         expect(chef_run).to create_yum_repository('datadog').with(
           gpgkey: [
-            'https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public',
-            'https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
-            'https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public',
-            'https://yum.datadoghq.com/DATADOG_RPM_KEY.public',
+            'https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public',
+            'https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
+            'https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public',
+            'https://keys.datadoghq.com/DATADOG_RPM_KEY.public',
           ]
         )
       end
@@ -235,7 +235,7 @@ describe 'datadog::repository' do
       # Key FD4BF915 (2020-09-08)
       it 'sets the yumrepo_gpgkey_new attribute fd4bf915' do
         expect(chef_run.node['datadog']['yumrepo_gpgkey_new_fd4bf915']).to match(
-          /DATADOG_RPM_KEY_20200908.public/
+          /DATADOG_RPM_KEY_FD4BF915.public/
         )
       end
 
@@ -244,11 +244,11 @@ describe 'datadog::repository' do
       end
 
       it 'downloads the new RPM key fd4bf915' do
-        expect(chef_run).to create_remote_file('remote_file_DATADOG_RPM_KEY_20200908.public').with(path: ::File.join(Chef::Config[:file_cache_path], 'DATADOG_RPM_KEY_20200908.public'))
+        expect(chef_run).to create_remote_file('remote_file_DATADOG_RPM_KEY_FD4BF915.public').with(path: ::File.join(Chef::Config[:file_cache_path], 'DATADOG_RPM_KEY_FD4BF915.public'))
       end
 
       it 'notifies the GPG key install if a new one is downloaded fd4bf915' do
-        keyfile_r = chef_run.remote_file('remote_file_DATADOG_RPM_KEY_20200908.public')
+        keyfile_r = chef_run.remote_file('remote_file_DATADOG_RPM_KEY_FD4BF915.public')
         expect(keyfile_r).to notify('execute[rpm-import datadog key fd4bf915]')
           .to(:run).immediately
       end
@@ -263,10 +263,10 @@ describe 'datadog::repository' do
       it 'sets up a yum repo' do
         expect(chef_run).to create_yum_repository('datadog').with(
           gpgkey: [
-            'http://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public',
-            'http://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
-            'http://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public',
-            'http://yum.datadoghq.com/DATADOG_RPM_KEY.public',
+            'http://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public',
+            'http://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
+            'http://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public',
+            'http://keys.datadoghq.com/DATADOG_RPM_KEY.public',
           ]
         )
       end
@@ -312,16 +312,16 @@ describe 'datadog::repository' do
       # Key FD4BF915 (2020-09-08)
       it 'sets the yumrepo_gpgkey_new attribute fd4bf915' do
         expect(chef_run.node['datadog']['yumrepo_gpgkey_new_fd4bf915']).to match(
-          /DATADOG_RPM_KEY_20200908.public/
+          /DATADOG_RPM_KEY_FD4BF915.public/
         )
       end
 
       it 'downloads the new RPM key fd4bf915' do
-        expect(chef_run).to create_remote_file('remote_file_DATADOG_RPM_KEY_20200908.public').with(path: ::File.join(Chef::Config[:file_cache_path], 'DATADOG_RPM_KEY_20200908.public'))
+        expect(chef_run).to create_remote_file('remote_file_DATADOG_RPM_KEY_FD4BF915.public').with(path: ::File.join(Chef::Config[:file_cache_path], 'DATADOG_RPM_KEY_FD4BF915.public'))
       end
 
       it 'notifies the GPG key install if a new one is downloaded fd4bf915' do
-        keyfile_r = chef_run.remote_file('remote_file_DATADOG_RPM_KEY_20200908.public')
+        keyfile_r = chef_run.remote_file('remote_file_DATADOG_RPM_KEY_FD4BF915.public')
         expect(keyfile_r).to notify('execute[rpm-import datadog key fd4bf915]')
           .to(:run).immediately
       end
@@ -348,7 +348,7 @@ describe 'datadog::repository' do
 
       it 'sets up a yum repo' do
         expect(chef_run).to create_zypper_repository('datadog').with(
-          gpgkey: 'https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public'
+          gpgkey: 'https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public'
         )
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,8 +27,10 @@ RSpec.configure do |config|
     stub_command('apt-cache policy datadog-agent-base | grep "Installed: (none)"').and_return(false)
 
     # recipes/repository.rb
+    stub_command('rpm -q gpg-pubkey-current').and_return(false)
     stub_command('rpm -q gpg-pubkey-e09422b3').and_return(false)
     stub_command('rpm -q gpg-pubkey-fd4bf915').and_return(false)
+    stub_command('rpm -q gpg-pubkey-4172a230').and_return(false)
     stub_command('apt-key adv --list-public-keys --with-fingerprint --with-colons | grep 382E94DE | grep pub').and_return(false)
   end
 


### PR DESCRIPTION
This PR adds multiple entries to the repofiles' gpgkey entry in order for both yum/dnf and rpm to have access to all necessary keys. The special DATADOG_RPM_KEY_CURRENT.public entry will always contain the key that is used to sign current metadata as well as newly released packages. zypper repofile is updated as well, but contains only the `CURRENT` key entry, as Chef doesn't allow multiple keys for zypper repofiles.