### PR TITLE
Enable yum repository repo_gpgcheck option for Red Hat platforms by default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -160,6 +160,13 @@ default['datadog']['aptrepo_retries'] = 4
 default['datadog']['aptrepo_use_backup_keyserver'] = false
 default['datadog']['aptrepo_keyserver'] = 'hkp://keyserver.ubuntu.com:80'
 default['datadog']['aptrepo_backup_keyserver'] = 'hkp://pool.sks-keyservers.net:80'
+# repo_gpgcheck on RHEL 5 requires additional packages (e.g. pygpgme) that might not
+# always be installed/available in enabled repositories
+default['datadog']['yumrepo_repo_gpgcheck'] = if platform_family?('rhel') && node['platform_version'].to_i < 6
+                                                false
+                                              else
+                                                true
+                                              end
 default['datadog']['yumrepo_gpgkey'] = "#{yum_protocol}://keys.datadoghq.com/DATADOG_RPM_KEY.public"
 default['datadog']['yumrepo_proxy'] = nil
 default['datadog']['yumrepo_proxy_username'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -160,13 +160,10 @@ default['datadog']['aptrepo_retries'] = 4
 default['datadog']['aptrepo_use_backup_keyserver'] = false
 default['datadog']['aptrepo_keyserver'] = 'hkp://keyserver.ubuntu.com:80'
 default['datadog']['aptrepo_backup_keyserver'] = 'hkp://pool.sks-keyservers.net:80'
-# repo_gpgcheck on RHEL 5 requires additional packages (e.g. pygpgme) that might not
-# always be installed/available in enabled repositories
-default['datadog']['yumrepo_repo_gpgcheck'] = if platform_family?('rhel') && node['platform_version'].to_i < 6
-                                                false
-                                              else
-                                                true
-                                              end
+# When repo_gpgcheck set to nil, it will get turned on in the code when
+# not running on RHEL/CentOS <= 5 and not providing custom yumrepo.
+# You can set it to true/false explicitly to override this behaviour.
+default['datadog']['yumrepo_repo_gpgcheck'] = nil
 default['datadog']['yumrepo_gpgkey'] = "#{yum_protocol}://keys.datadoghq.com/DATADOG_RPM_KEY.public"
 default['datadog']['yumrepo_proxy'] = nil
 default['datadog']['yumrepo_proxy_username'] = nil

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -132,7 +132,19 @@ when 'rhel', 'fedora', 'amazon'
     end
   end
 
+  # When the user has set yumrepo_repo_gpgcheck explicitly, we respect that.
+  # Otherwise, we turn on repo_gpgcheck by default when both:
+  # * We're not running on RHEL/CentOS 5 or older
+  # * User has not overriden the default yumrepo
   repo_gpgcheck = node['datadog']['yumrepo_repo_gpgcheck']
+  if repo_gpgcheck.nil?
+    if !node['datadog']['yumrepo'].nil? || (platform_family?('rhel') && node['platform_version'].to_i < 6)
+      repo_gpgcheck = false
+    else
+      repo_gpgcheck = true
+    end
+  end
+
   if !node['datadog']['yumrepo'].nil?
     baseurl = node['datadog']['yumrepo']
   else

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -132,6 +132,7 @@ when 'rhel', 'fedora', 'amazon'
     end
   end
 
+  repo_gpgcheck = node['datadog']['yumrepo_repo_gpgcheck']
   if !node['datadog']['yumrepo'].nil?
     baseurl = node['datadog']['yumrepo']
   else
@@ -142,6 +143,7 @@ when 'rhel', 'fedora', 'amazon'
       baseurl = "https://yum.datadoghq.com/stable/#{agent_major_version}/#{node['kernel']['machine']}/"
     when 5
       baseurl = "#{yum_protocol_a5}://yum.datadoghq.com/rpm/#{yum_a5_architecture_map[node['kernel']['machine']]}/"
+      repo_gpgcheck = false
     else
       Chef::Log.error("agent_major_version '#{agent_major_version}' not supported.")
     end
@@ -166,7 +168,7 @@ when 'rhel', 'fedora', 'amazon'
     proxy_password node['datadog']['yumrepo_proxy_password']
     gpgkey yumrepo_gpgkeys
     gpgcheck true
-    repo_gpgcheck node['datadog']['yumrepo_repo_gpgcheck']
+    repo_gpgcheck repo_gpgcheck
     action :create
   end
 when 'suse'
@@ -231,8 +233,8 @@ when 'suse'
     gpgautoimportkeys false
     gpgcheck false
     # zypper has no repo_gpgcheck option, but it does repodata signature checks
-    # by default which users have to actually disable system-wide, so we are
-    # fine not setting it explicitly
+    # by default (when the repomd.xml.asc file is present) which users have
+    # to actually disable system-wide, so we are fine not setting it explicitly
     action :create
   end
 end

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -136,14 +136,15 @@ when 'rhel', 'fedora', 'amazon'
   # Otherwise, we turn on repo_gpgcheck by default when both:
   # * We're not running on RHEL/CentOS 5 or older
   # * User has not overriden the default yumrepo
-  repo_gpgcheck = node['datadog']['yumrepo_repo_gpgcheck']
-  if repo_gpgcheck.nil?
-    if !node['datadog']['yumrepo'].nil? || (platform_family?('rhel') && node['platform_version'].to_i < 6)
-      repo_gpgcheck = false
-    else
-      repo_gpgcheck = true
-    end
-  end
+  repo_gpgcheck = if node['datadog']['yumrepo_repo_gpgcheck'].nil?
+                    if !node['datadog']['yumrepo'].nil? || (platform_family?('rhel') && node['platform_version'].to_i < 6)
+                      false
+                    else
+                      true
+                    end
+                  else
+                    node['datadog']['yumrepo_repo_gpgcheck']
+                  end
 
   if !node['datadog']['yumrepo'].nil?
     baseurl = node['datadog']['yumrepo']

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -166,6 +166,7 @@ when 'rhel', 'fedora', 'amazon'
     proxy_password node['datadog']['yumrepo_proxy_password']
     gpgkey yumrepo_gpgkeys
     gpgcheck true
+    repo_gpgcheck node['datadog']['yumrepo_repo_gpgcheck']
     action :create
   end
 when 'suse'
@@ -229,6 +230,9 @@ when 'suse'
     gpgkey agent_major_version < 6 ? node['datadog']['yumrepo_gpgkey'] : node['datadog']['yumrepo_gpgkey_new_current']
     gpgautoimportkeys false
     gpgcheck false
+    # zypper has no repo_gpgcheck option, but it does repodata signature checks
+    # by default which users have to actually disable system-wide, so we are
+    # fine not setting it explicitly
     action :create
   end
 end

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -119,7 +119,7 @@ describe 'datadog::repository' do
             'https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
             'https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public',
           ]
-        )
+        ).with(repo_gpgcheck: true)
       end
     end
 
@@ -193,7 +193,7 @@ describe 'datadog::repository' do
             'https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public',
             'https://keys.datadoghq.com/DATADOG_RPM_KEY.public',
           ]
-        )
+        ).with(repo_gpgcheck: true)
       end
     end
 
@@ -268,7 +268,7 @@ describe 'datadog::repository' do
             'http://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public',
             'http://keys.datadoghq.com/DATADOG_RPM_KEY.public',
           ]
-        )
+        ).with(repo_gpgcheck: false)
       end
     end
   end


### PR DESCRIPTION
I'm wondering whether we should document this - there doesn't seem to be any section in README.md that explicitly deals with gpg keys, repository URLs etc - I'm assuming because the users never really hit issues with these and so they didn't need documenting?