### PR TITLE
Add is_jmx by default to jmxfetch checks

### DIFF
--- a/recipes/confluent_platform.rb
+++ b/recipes/confluent_platform.rb
@@ -89,6 +89,7 @@ datadog_monitor 'confluent_platform' do
   init_config node['datadog']['confluent_platform']['init_config']
   instances node['datadog']['confluent_platform']['instances']
   logs node['datadog']['confluent_platform']['logs']
+  is_jmx true
   use_integration_template true
   action :add
   notifies :restart, 'service[datadog-agent]' if node['datadog']['agent_start']

--- a/recipes/hazelcast.rb
+++ b/recipes/hazelcast.rb
@@ -99,6 +99,7 @@ datadog_monitor 'hazelcast' do
   init_config node['datadog']['hazelcast']['init_config']
   instances node['datadog']['hazelcast']['instances']
   logs node['datadog']['hazelcast']['logs']
+  is_jmx true
   use_integration_template true
   action :add
   notifies :restart, 'service[datadog-agent]' if node['datadog']['agent_start']

--- a/recipes/hive.rb
+++ b/recipes/hive.rb
@@ -89,6 +89,7 @@ datadog_monitor 'hive' do
   init_config node['datadog']['hive']['init_config']
   instances node['datadog']['hive']['instances']
   logs node['datadog']['hive']['logs']
+  is_jmx true
   use_integration_template true
   action :add
   notifies :restart, 'service[datadog-agent]' if node['datadog']['agent_start']

--- a/recipes/hivemq.rb
+++ b/recipes/hivemq.rb
@@ -89,6 +89,7 @@ datadog_monitor 'hivemq' do
   init_config node['datadog']['hivemq']['init_config']
   instances node['datadog']['hivemq']['instances']
   logs node['datadog']['hivemq']['logs']
+  is_jmx true
   use_integration_template true
   action :add
   notifies :restart, 'service[datadog-agent]' if node['datadog']['agent_start']

--- a/recipes/ignite.rb
+++ b/recipes/ignite.rb
@@ -89,6 +89,7 @@ datadog_monitor 'ignite' do
   init_config node['datadog']['ignite']['init_config']
   instances node['datadog']['ignite']['instances']
   logs node['datadog']['ignite']['logs']
+  is_jmx true
   use_integration_template true
   action :add
   notifies :restart, 'service[datadog-agent]' if node['datadog']['agent_start']

--- a/recipes/jboss_wildfly.rb
+++ b/recipes/jboss_wildfly.rb
@@ -89,6 +89,7 @@ datadog_monitor 'jboss_wildfly' do
   init_config node['datadog']['jboss_wildfly']['init_config']
   instances node['datadog']['jboss_wildfly']['instances']
   logs node['datadog']['jboss_wildfly']['logs']
+  is_jmx true
   use_integration_template true
   action :add
   notifies :restart, 'service[datadog-agent]' if node['datadog']['agent_start']

--- a/resources/monitor.rb
+++ b/resources/monitor.rb
@@ -19,6 +19,7 @@ property :init_config, [Hash, nil], required: false, default: {}
 property :instances, Array, required: false, default: []
 property :version, [Integer, nil], required: false, default: nil
 property :use_integration_template, [TrueClass, FalseClass], required: false, default: false
+property :is_jmx, [TrueClass, FalseClass], required: false, default: false
 property :logs, [Array, nil], required: false, default: []
 
 action :add do
@@ -60,8 +61,13 @@ action :add do
       source "#{new_resource.name}.yaml.erb"
     end
 
+    init_config = new_resource.init_config
+    if new_resource.is_jmx
+      init_config.merge!({'is_jmx': true, 'collect_default_metrics': true })
+    end
+
     variables(
-      init_config: new_resource.init_config,
+      init_config: init_config,
       instances:   new_resource.instances,
       version:     new_resource.version,
       logs:        new_resource.logs

--- a/resources/monitor.rb
+++ b/resources/monitor.rb
@@ -64,7 +64,7 @@ action :add do
     init_config = new_resource.init_config
     if new_resource.is_jmx
       init_config ||= {}
-      init_config.merge!({'is_jmx': true, 'collect_default_metrics': true })
+      init_config.merge!({ 'is_jmx': true, 'collect_default_metrics': true })
     end
 
     variables(

--- a/resources/monitor.rb
+++ b/resources/monitor.rb
@@ -63,6 +63,7 @@ action :add do
 
     init_config = new_resource.init_config
     if new_resource.is_jmx
+      init_config ||= {}
       init_config.merge!({'is_jmx': true, 'collect_default_metrics': true })
     end
 

--- a/spec/integrations/hive_spec.rb
+++ b/spec/integrations/hive_spec.rb
@@ -1,0 +1,43 @@
+describe 'datadog::hive' do
+  expected_yaml = <<-EOF
+    logs: ~
+    init_config:
+      is_jmx: true
+      collect_default_metrics: true
+    instances:
+      - host: localhost
+  EOF
+
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
+      node.normal['datadog'] = {
+        api_key: 'someapikey',
+        hive: {
+          instances: [
+            {
+              host: 'localhost',
+            }
+          ]
+        }
+      }
+    end.converge(described_recipe)
+  end
+
+  subject { chef_run }
+
+  it_behaves_like 'datadog-agent'
+
+  it { is_expected.to include_recipe('datadog::dd-agent') }
+
+  it { is_expected.to add_datadog_monitor('hive') }
+
+  it 'renders expected YAML config file' do
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/hive.d/conf.yaml').with_content { |content|
+      expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
+    })
+  end
+end


### PR DESCRIPTION
Makes it easier to set up jmxfetch integrations, which require `is_jmx`, by setting it automatically on the integration recipes.