### PR TITLE
Don't set repo_gpgcheck=1 by default on RHEL/CentOS 8.1

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -136,8 +136,11 @@ when 'rhel', 'fedora', 'amazon'
   # Otherwise, we turn on repo_gpgcheck by default when both:
   # * We're not running on RHEL/CentOS 5 or older
   # * User has not overriden the default yumrepo
+  # * System is not RHEL/CentOS 8.1 (repo_gpgcheck doesn't work there because
+  #   of https://bugzilla.redhat.com/show_bug.cgi?id=1792506
   repo_gpgcheck = if node['datadog']['yumrepo_repo_gpgcheck'].nil?
-                    if !node['datadog']['yumrepo'].nil? || (platform_family?('rhel') && node['platform_version'].to_i < 6)
+                    if !node['datadog']['yumrepo'].nil? || (platform_family?('rhel') && node['platform_version'].to_i < 6) ||
+                        (['centos', 'redhat'].include?(node['platform']) && node['platform_version'].to_f >= 8.1 && node['platform_version'].to_f < 8.2)
                       false
                     else
                       true

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -271,6 +271,50 @@ describe 'datadog::repository' do
         ).with(repo_gpgcheck: false)
       end
     end
+
+    context 'centos 8.1, agent 6' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(
+          platform: 'centos', version: '8'
+        ) do |node|
+          node.normal['datadog'] = { 'agent_major_version' => '6' }
+          node.automatic['platform_version'] = '8.1'
+        end.converge(described_recipe)
+      end
+
+      it 'disables repo_gpgcheck because of dnf bug in RHEL 8.1' do
+        expect(chef_run).to create_yum_repository('datadog').with(
+          gpgkey: [
+            'https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public',
+            'https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
+            'https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public',
+            'https://keys.datadoghq.com/DATADOG_RPM_KEY.public',
+          ]
+        ).with(repo_gpgcheck: false)
+      end
+    end
+
+    context 'centos 8.2, agent 6' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(
+          platform: 'centos', version: '8'
+        ) do |node|
+          node.normal['datadog'] = { 'agent_major_version' => '6' }
+          node.automatic['platform_version'] = '8.2'
+        end.converge(described_recipe)
+      end
+
+      it 'enables repo_gpgcheck because of fixed dnf bug in RHEL 8.2' do
+        expect(chef_run).to create_yum_repository('datadog').with(
+          gpgkey: [
+            'https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public',
+            'https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
+            'https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public',
+            'https://keys.datadoghq.com/DATADOG_RPM_KEY.public',
+          ]
+        ).with(repo_gpgcheck: true)
+      end
+    end
   end
 
   context 'suseiods' do


### PR DESCRIPTION
Due to [a bug](https://bugzilla.redhat.com/show_bug.cgi?id=1792506) in dnf, `repo_gpgcheck` doesn't work in non-interactive shells in RHEL/CentOS 8.1. This PR implements logic that disables `repo_gpgcheck` on these platforms.