### PR TITLE
 Improvements for APT keys management

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -140,7 +140,7 @@ default['datadog']['handler_extra_config'] = {}
 # If you're installing a pre-release version of the Agent (beta or RC), you need to:
 # * on debian: set node['datadog']['aptrepo_dist'] to 'beta' instead of 'stable'
 # * on RHEL: set node['datadog']['yumrepo'] to 'https://yum.datadoghq.com/beta/x86_64/'
-default['datadog']['aptrepo'] = 'http://apt.datadoghq.com'
+default['datadog']['aptrepo'] = nil # uses Datadog stable repos by default
 default['datadog']['aptrepo_dist'] = 'stable'
 default['datadog']['yumrepo'] = nil # uses Datadog stable repos by default
 default['datadog']['yumrepo_suse'] = nil # uses Datadog stable repos by default
@@ -157,9 +157,6 @@ yum_protocol =
 # to pin the version you're installing with node['datadog']['agent_version']
 default['datadog']['installrepo'] = true
 default['datadog']['aptrepo_retries'] = 4
-default['datadog']['aptrepo_use_backup_keyserver'] = false
-default['datadog']['aptrepo_keyserver'] = 'hkp://keyserver.ubuntu.com:80'
-default['datadog']['aptrepo_backup_keyserver'] = 'hkp://pool.sks-keyservers.net:80'
 # When repo_gpgcheck set to nil, it will get turned on in the code when
 # not running on RHEL/CentOS <= 5 and not providing custom yumrepo.
 # You can set it to true/false explicitly to override this behaviour.

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -26,7 +26,7 @@ yum_a5_architecture_map.default = 'x86_64'
 
 agent_major_version = Chef::Datadog.agent_major_version(node)
 
-# DATADOG_APT_KEY_CURRENT always contains the key that is used to sing repodata and latest packages
+# DATADOG_APT_KEY_CURRENT always contains the key that is used to sign repodata and latest packages
 # A2923DFF56EDA6E76E55E492D3A80E30382E94DE expires in 2022
 # D75CEA17048B9ACBF186794B32637D44F14F620E expires in 2032
 apt_gpg_keys = {

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -95,7 +95,9 @@ when 'debian'
     # Import the APT key
     execute "import apt datadog key #{key_fingerprint}" do
       command "/bin/cat #{key_local_path} | gpg --import --batch --no-default-keyring --keyring #{apt_usr_share_keyring}"
-      not_if "/bin/cat #{key_local_path} | gpg --dry-run --import --batch --no-default-keyring --keyring #{apt_usr_share_keyring} 2>&1 | grep 'unchanged: 1'"
+      # the second part extracts the fingerprint of the key from output like "fpr::::A2923DFF56EDA6E76E55E492D3A80E30382E94DE:"
+      not_if "/usr/bin/gpg --no-default-keyring --keyring #{apt_usr_share_keyring} --list-keys --with-fingerprint --with-colons | grep \
+             $(cat #{key_local_path} | gpg --with-colons --with-fingerprint 2>/dev/null | grep 'fpr:' | sed 's|^fpr||' | tr -d ':')"
       action :nothing
     end
   end

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -26,10 +26,18 @@ yum_a5_architecture_map.default = 'x86_64'
 
 agent_major_version = Chef::Datadog.agent_major_version(node)
 
+# DATADOG_APT_KEY_CURRENT always contains the key that is used to sing repodata and latest packages
 # A2923DFF56EDA6E76E55E492D3A80E30382E94DE expires in 2022
 # D75CEA17048B9ACBF186794B32637D44F14F620E expires in 2032
-apt_gpg_key = 'D75CEA17048B9ACBF186794B32637D44F14F620E'
-other_apt_gpg_keys = ['A2923DFF56EDA6E76E55E492D3A80E30382E94DE']
+apt_gpg_keys = {
+  'DATADOG_APT_KEY_CURRENT.public'           => 'https://keys.datadoghq.com/DATADOG_APT_KEY_CURRENT.public',
+  'D75CEA17048B9ACBF186794B32637D44F14F620E' => 'https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public',
+  'A2923DFF56EDA6E76E55E492D3A80E30382E94DE' => 'https://keys.datadoghq.com/DATADOG_APT_KEY_382E94DE.public',
+}
+apt_trusted_d_keyring = '/etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg'
+apt_usr_share_keyring = '/usr/share/keyrings/datadog-archive-keyring.gpg'
+apt_sources_list_file = '/etc/apt/sources.list.d/datadog.list'
+apt_repo_uri = 'https://apt.datadoghq.com'
 
 # DATADOG_RPM_KEY_CURRENT always contains the key that is used to sign repodata and latest packages
 # DATADOG_RPM_KEY_E09422B3.public expires in 2022
@@ -47,11 +55,51 @@ rpm_gpg_keys_full_fingerprint = 2
 
 case node['platform_family']
 when 'debian'
+  log 'apt deprecated parameters warning' do
+    level :warn
+    message 'Attributes "aptrepo_use_backup_keyserver", "aptrepo_keyserver" and "aptrepo_backup_keyserver" are deprecated since version 4.11.0'
+    only_if {
+      !node['datadog']['aptrepo_use_backup_keyserver'].nil? || !node['datadog']['aptrepo_keyserver'].nil? || !node['datadog']['aptrepo_backup_keyserver'].nil?
+    }
+  end
+
   apt_update 'update'
 
   package 'install-apt-transport-https' do
     package_name 'apt-transport-https'
     action :install
+  end
+
+  file apt_usr_share_keyring do
+    action :create_if_missing
+    content ''
+    mode '0644'
+  end
+
+  apt_gpg_keys.each do |key_fingerprint, key_url|
+    # Download the APT key
+    key_local_path = ::File.join(Chef::Config[:file_cache_path], key_fingerprint)
+    # By default, remote_file will use `If-Modified-Since` header to see if the file
+    # was modified remotely, so this works fine for the "current" key
+    remote_file "remote_file_#{key_fingerprint}" do
+      path key_local_path
+      source key_url
+      notifies :run, "execute[import apt datadog key #{key_fingerprint}]", :immediately
+    end
+
+    # Import the APT key
+    execute "import apt datadog key #{key_fingerprint}" do
+      command "/bin/cat #{key_local_path} | gpg --import --batch --no-default-keyring --keyring #{apt_usr_share_keyring}"
+      not_if "/bin/cat #{key_local_path} | gpg --dry-run --import --batch --no-default-keyring --keyring #{apt_usr_share_keyring} 2>&1 | grep 'unchanged: 1'"
+      action :nothing
+    end
+  end
+
+  remote_file apt_trusted_d_keyring do
+    action :create
+    mode '0644'
+    source "file://#{apt_usr_share_keyring}"
+    only_if { (platform?('ubuntu') && node['platform_version'].to_i < 16) || (platform?('debian') && node['platform_version'].to_i < 9) }
   end
 
   case agent_major_version
@@ -65,25 +113,30 @@ when 'debian'
     Chef::Log.error("agent_major_version '#{agent_major_version}' not supported.")
   end
 
-  other_apt_gpg_keys.each do |key|
-    key_short = key[-8..-1] # last 8 chars, since some versions of apt-key add dashes between key sections
-    execute "apt-key import key #{key_short}" do
-      command "apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 #{key}"
-      not_if "apt-key adv --list-public-keys --with-fingerprint --with-colons | grep #{key_short} | grep pub"
-    end
+  retries = node['datadog']['aptrepo_retries']
+
+  # Add APT repositories
+  # Chef's apt_repository resource doesn't allow specifying the signed-by option and we can't pass
+  # it in uri, as that would make it fail parsing, hence we use the file and apt_update resources.
+  apt_update 'datadog' do
+    retries retries
+    ignore_failure true # this is exactly what apt_repository does
+    action :nothing
   end
 
-  retries = node['datadog']['aptrepo_retries']
-  keyserver = node['datadog']['aptrepo_use_backup_keyserver'] ? node['datadog']['aptrepo_backup_keyserver'] : node['datadog']['aptrepo_keyserver']
-  # Add APT repositories
-  apt_repository 'datadog' do
-    keyserver keyserver
-    key apt_gpg_key
-    uri node['datadog']['aptrepo']
-    distribution node['datadog']['aptrepo_dist']
-    components components
-    action :add
-    retries retries
+  deb_repo_with_options = if node['datadog']['aptrepo'].nil?
+                            "[signed-by=#{apt_usr_share_keyring}] #{apt_repo_uri}"
+                          else
+                            node['datadog']['aptrepo']
+                          end
+
+  file apt_sources_list_file do
+    action :create
+    owner 'root'
+    group 'root'
+    mode '0644'
+    content "deb #{deb_repo_with_options} #{node['datadog']['aptrepo_dist']} #{components.compact.join(' ')}"
+    notifies :update, 'apt_update[datadog]', :immediately
   end
 
   # Previous versions of the cookbook could create these repo files, make sure we remove it now

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -70,6 +70,11 @@ when 'debian'
     action :install
   end
 
+  package 'install-gnupg' do
+    package_name 'gnupg'
+    action :install
+  end
+
   file apt_usr_share_keyring do
     action :create_if_missing
     content ''


### PR DESCRIPTION
* By default, get keys from keys.datadoghq.com, not Ubuntu keyserver
* Always add the DATADOG_APT_KEY_CURRENT.public key (contains key used to sign current repodata)
* Add 'signed-by' option to all sources list lines
* On Debian >= 9 and Ubuntu >= 16, only add keys to /usr/share/keyrings/datadog-archive-keyring.gpg
* On older systems, also add the same keyring to /etc/apt/trusted.gpg.d