### PR TITLE
[windows] Try to start NPM only when network_enabled is true

### DIFF
--- a/recipes/system-probe.rb
+++ b/recipes/system-probe.rb
@@ -20,11 +20,11 @@
 is_windows = platform_family?('windows')
 
 # Set the correct agent startup action
-if is_windows
-  sysprobe_enabled = node['datadog']['system_probe']['network_enabled']
-else
-  sysprobe_enabled = node['datadog']['system_probe']['enabled'] || node['datadog']['system_probe']['network_enabled']
-end
+sysprobe_enabled = if is_windows
+                     node['datadog']['system_probe']['network_enabled']
+                   else
+                     node['datadog']['system_probe']['enabled'] || node['datadog']['system_probe']['network_enabled']
+                   end
 sysprobe_agent_start = sysprobe_enabled ? :start : :stop
 
 #

--- a/recipes/system-probe.rb
+++ b/recipes/system-probe.rb
@@ -20,7 +20,11 @@
 is_windows = platform_family?('windows')
 
 # Set the correct agent startup action
-sysprobe_enabled = node['datadog']['system_probe']['enabled'] || node['datadog']['system_probe']['network_enabled']
+if is_windows
+  sysprobe_enabled = node['datadog']['system_probe']['network_enabled']
+else
+  sysprobe_enabled = node['datadog']['system_probe']['enabled'] || node['datadog']['system_probe']['network_enabled']
+end
 sysprobe_agent_start = sysprobe_enabled ? :start : :stop
 
 #


### PR DESCRIPTION
### What does this PR do?

On Windows, set `sysprobe_enabled` to `true` only when `node['datadog']['system_probe']['network_enabled']` is true, to prevent operations on the `system-probe` service when it is not installed.

### Motivation

On Windows, we install NPM only when `node['datadog']['system_probe']['network_enabled']` is `true` (or with an explicit option): https://github.com/DataDog/chef-datadog/blob/main/libraries/recipe_helpers.rb#L97-L99.
With the current behavior, if `node['datadog']['system_probe']['network_enabled']` is `false` but `node['datadog']['system_probe']['enabled']` is `true`, then the chef cookbook tries to start the NPM service even though it hasn't been installed.