### PR TITLE
Pin yum cookbook in tests

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -6,3 +6,5 @@ group :integration do
   cookbook 'sudo' # Use '< 5.0.0' with Chef < 13
   cookbook 'test', path: './test/cookbooks/test' # Used to test custom resources (datadog_monitor, integration)
 end
+
+cookbook 'yum', '< 7.0.0'


### PR DESCRIPTION
### What does this PR do?

Pins the yum cookbook in `Berksfile`, to prevent kitchen tests from trying to use a `yum` cookbook version that's not compatible with the Chef version used in these tests.

### Additional notes

Updating the `Berksfile` only affects our test setup (from my tests). Updating the `metadata.rb` instead would have added that constraint to all users of the `chef-datadog` cookbook, which we don't want to do.