### PR TITLE
Document how to uninstall the Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,10 @@ The following example downgrades to Agent v6. The same applies if you are downgr
   )
 ```
 
+### Uninstall
+
+To uninstall the Agent, remove the `dd-agent` recipe and add the `remove-dd-agent` recipe with no attributes.
+
 ## Recipes
 
 Access the [Datadog Chef recipes on GitHub][7].

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -217,6 +217,8 @@ default['datadog']['windows_ddagentuser_name'] = nil
 default['datadog']['windows_ddagentuser_password'] = nil
 
 # Since 7.27, the MSI has a switch to install NPM driver. Default to not install. Specify "true" to install.
+# Note: If the Agent is already installed before setting this to true, this will have no effect until the Agent
+# is either upgraded or uninstalled and installed again. Use the `remove-dd-agent` recipe to uninstall the Agent.
 default['datadog']['windows_npm_install'] = nil
 
 # Chef handler version


### PR DESCRIPTION
Uninstalling is currently needed as a workaround to enable NPM on Windows if the host already had the Agent installed.