### PR TITLE
Fix CI failing to update RVM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,8 @@ jobs:
           command: |
                     echo "Using $RUBY_VERSION"
                     curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
-                    rvm get stable
+                    # Update RVM. Using this path instead of https://get.rvm.io because the later uses the letsencrypt cert that breaks openssl 1.0
+                    curl -sSL https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer | bash -s stable
                     rvm install $RUBY_VERSION
                     echo . $(rvm $RUBY_VERSION do rvm env --path) >> $BASH_ENV
       - run:
@@ -38,7 +39,8 @@ jobs:
           command: |
                     echo "Using $RUBY_VERSION"
                     curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
-                    rvm get stable
+                    # Update RVM. Using this path instead of https://get.rvm.io because the later uses the letsencrypt cert that breaks openssl 1.0
+                    curl -sSL https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer | bash -s stable
                     rvm install $RUBY_VERSION
                     echo . $(rvm $RUBY_VERSION do rvm env --path) >> $BASH_ENV
       - run:
@@ -71,7 +73,8 @@ jobs:
           command: |
                     echo "Using $RUBY_VERSION"
                     curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
-                    rvm get stable
+                    # Update RVM. Using this path instead of https://get.rvm.io because the later uses the letsencrypt cert that breaks openssl 1.0
+                    curl -sSL https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer | bash -s stable
                     rvm install $RUBY_VERSION
                     echo . $(rvm $RUBY_VERSION do rvm env --path) >> $BASH_ENV
       - run:


### PR DESCRIPTION
`rvm get stable` tries to get the `rvm-installer` script from https://get.rvm.io which uses the Let's Encrypt SSL cert that [breaks OpenSSL 1.0.2](https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/).

This changes the command we use to update RVM to fetch script from Github directly (note: https://get.rvm.io redirects there anyway).

See: https://github.com/rvm/rvm/issues/5133