### PR TITLE
Update datadog agent 6 yaml to include dogstatsd_port by default

### DIFF
--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -1066,6 +1066,7 @@ describe 'datadog::dd-agent' do
             log_file: "/var/log/datadog/agent.log"
             log_level: "INFO"
             dogstatsd_non_local_traffic: false
+            dogstatsd_port: 8125
             apm_config:
               apm_non_local_traffic: false
             process_config:
@@ -1126,6 +1127,7 @@ describe 'datadog::dd-agent' do
             hostname: "chef-nodename"
             log_level: "INFO"
             dogstatsd_non_local_traffic: false
+            dogstatsd_port: 8125
             apm_config:
               apm_non_local_traffic: false
             process_config:
@@ -1187,6 +1189,7 @@ describe 'datadog::dd-agent' do
             log_file: "/var/log/datadog/agent.log"
             log_level: "INFO"
             dogstatsd_non_local_traffic: false
+            dogstatsd_port: 8125
             apm_config:
               apm_non_local_traffic: false
             process_config:
@@ -1244,6 +1247,7 @@ describe 'datadog::dd-agent' do
           log_file: "/var/log/datadog/agent.log"
           log_level: "INFO"
           dogstatsd_non_local_traffic: false
+          dogstatsd_port: 8125
           apm_config:
             apm_non_local_traffic: false
           process_config:

--- a/templates/default/datadog.yaml.erb
+++ b/templates/default/datadog.yaml.erb
@@ -89,6 +89,7 @@ agent_config = @extra_config.merge({
   histogram_aggregates: string_list_to_array(node['datadog']['histogram_aggregates']),
   histogram_percentiles: string_list_to_array(node['datadog']['histogram_percentiles']),
   use_dogstatsd: node['datadog']['dogstatsd'],
+  dogstatsd_port: node['datadog']['dogstatsd_port'],
   statsd_metric_namespace: node['datadog']['statsd_metric_namespace'],
   log_level: node['datadog']['log_level'],
   cmd_port: node['datadog']['cmd_port'],


### PR DESCRIPTION
This change allows the dogstatsd_port attribute to be respected [similar to version 5](https://github.com/DataDog/chef-datadog/blob/main/templates/default/datadog.conf.erb#L110) without having to use the extra_config attribute. This allows the [existing attribute to be respected
](https://github.com/DataDog/chef-datadog/blob/main/attributes/default.rb#L280)



Currently with agent 6 the only way to override this is to set the following
```
default['datadog']['extra_config']['dogstatsd_port'] = 8125
```

