### PR TITLE
Ignore apt update failures to keep running if some sources are offline

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -63,7 +63,9 @@ when 'debian'
     }
   end
 
-  apt_update 'update'
+  apt_update 'update' do
+    ignore_failure true
+  end
 
   package 'install-apt-transport-https' do
     package_name 'apt-transport-https'


### PR DESCRIPTION
Prior to commit 1b0eaedb8cac2ab67ffe6fbc885858b3e71eeace we were using `include_recipe 'apt'` which made `apt-get update` ignore failures. This is good because we don't want to fail the run if e.g. just one of the sources is not available ATM.