### PR TITLE
Add support for enabling Database Monitoring tool

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -329,6 +329,7 @@ suites:
       mysql:
         instances:
           - server: 1.1.1.1
+            dbm: true
             port: 3307
             user: my_username
             pass: my_password

--- a/templates/default/mysql.yaml.erb
+++ b/templates/default/mysql.yaml.erb
@@ -6,6 +6,9 @@ instances:
     <% if i.key?('port') -%>
     port: <%= i['port'] %>
     <% end -%>
+    <% if i.key?('dbm') -%>
+    dbm: <%= i['dbm'] %>
+    <% end -%>
     user: <%= i['user'] %>
     pass: <%= i['pass'] %>
     <% if i.key?('sock') -%>

--- a/test/integration/datadog_mysql/serverspec/mysql_spec.rb
+++ b/test/integration/datadog_mysql/serverspec/mysql_spec.rb
@@ -24,6 +24,7 @@ describe file(AGENT_CONFIG) do
       'instances' => [
         {
           'server' => '1.1.1.1',
+          'dbm' => true,
           'port' => 3307,
           'user' => 'my_username',
           'pass' => 'my_password',


### PR DESCRIPTION
This will enable database monitoring tool on self hosted instances of
MySQL by passing the `dbm` flag.

Ref: https://docs.datadoghq.com/database_monitoring/setup_mysql/selfhosted/?tab=mysql56#metric-collection