### PR TITLE
Specify package epoch on RH-like platforms to ensure proper upgrade path

### DIFF
--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -18,10 +18,8 @@ class Chef
           dd_agent_version = dd_agent_version[platform_family]
         end
         if !dd_agent_version.nil? && dd_agent_version.match(/^[0-9]+\.[0-9]+\.[0-9]+((?:~|-)[^0-9\s-]+[^-\s]*)?$/)
-          if node['platform_family'] == 'suse' || node['platform_family'] == 'debian'
+          if %w(debian amazon fedora rhel suse).include?(node['platform_family'])
             dd_agent_version = '1:' + dd_agent_version + '-1'
-          elsif node['platform_family'] == 'rhel' || node['platform_family'] == 'fedora' || node['platform_family'] == 'amazon'
-            dd_agent_version += '-1'
           end
         end
         dd_agent_version

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -18,7 +18,7 @@ class Chef
           dd_agent_version = dd_agent_version[platform_family]
         end
         if !dd_agent_version.nil? && dd_agent_version.match(/^[0-9]+\.[0-9]+\.[0-9]+((?:~|-)[^0-9\s-]+[^-\s]*)?$/)
-          if %w(debian amazon fedora rhel suse).include?(node['platform_family'])
+          if %w[debian amazon fedora rhel suse].include?(node['platform_family'])
             dd_agent_version = '1:' + dd_agent_version + '-1'
           end
         end

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -1446,7 +1446,7 @@ describe 'datadog::dd-agent' do
       end.converge described_recipe
     end
     it 'installs the full version' do
-      expect(chef_run).to install_dnf_package('datadog-agent').with_version('6.16.0-1')
+      expect(chef_run).to install_dnf_package('datadog-agent').with_version('1:6.16.0-1')
     end
   end
 end


### PR DESCRIPTION
Right now, upgrades on some RH-like platforms don't work properly if `agent_version` is specified in `X.Y.Z` format.

When this format is used, the version gets expanded to `X.Y.Z-1`.

For example:
* We have version 1:7.32.3-1` installed
* We specify `agent_version => 7.32.4`
* Using the current code, yum is told to install `7.32.4-1` (the `-1` is appended)
* Yum considers `7.32.4 < 1:7.32.3-1`, because epoch `0` is implied unless given explicitly. Hence running `yum install datadog-agent-7.32.4-1` exits with `datadog-agent has installed version 1:7.32.3-1.x86_64, which is newer than available version 7.32.4-1` and doesn't install anything.

This PR ensures that we specify the correct epoch when `agent_version` is specified in the `X.Y.Z` format and thus the upgrade correctly happens.

This seems to only happen on Yum (so affects CentOS 6/7 and Amazonlinux 2). DNF appears to be smart enough to first check the repodata, understand that `7.32.4-1` has epoch `1` and correctly does the upgrade. However, there is no harm in specifying the epoch explicitly with DNF.