### PR TITLE
Fix system probe recipe on Windows

### DIFF
--- a/recipes/system-probe.rb
+++ b/recipes/system-probe.rb
@@ -72,11 +72,7 @@ template system_probe_config_file do
     runtime_security_extra_config: runtime_security_extra_config
   )
 
-  if is_windows
-    owner 'Administrators'
-    rights :full_control, 'Administrators'
-    inherits false
-  else
+  if !is_windows
     owner 'root'
     group 'dd-agent'
     mode '640'

--- a/recipes/system-probe.rb
+++ b/recipes/system-probe.rb
@@ -26,11 +26,7 @@ sysprobe_enabled = if is_windows
                    else
                      node['datadog']['system_probe']['enabled'] || node['datadog']['system_probe']['network_enabled'] || cws_enabled
                    end
-if sysprobe_enabled && node['datadog']['agent_start'] && node['datadog']['agent_enable']
-  sysprobe_agent_start = :start
-else
-  sysprobe_agent_start = :stop
-end
+sysprobe_agent_start = sysprobe_enabled && node['datadog']['agent_start'] && node['datadog']['agent_enable'] ? :start : :stop
 
 #
 # Configures system-probe agent
@@ -72,7 +68,7 @@ template system_probe_config_file do
     runtime_security_extra_config: runtime_security_extra_config
   )
 
-  if !is_windows
+  unless is_windows
     owner 'root'
     group 'dd-agent'
     mode '640'

--- a/recipes/system-probe.rb
+++ b/recipes/system-probe.rb
@@ -26,7 +26,11 @@ sysprobe_enabled = if is_windows
                    else
                      node['datadog']['system_probe']['enabled'] || node['datadog']['system_probe']['network_enabled'] || cws_enabled
                    end
-sysprobe_agent_start = sysprobe_enabled ? :start : :stop
+if sysprobe_enabled && node['datadog']['agent_start'] && node['datadog']['agent_enable']
+  sysprobe_agent_start = :start
+else
+  sysprobe_agent_start = :stop
+end
 
 #
 # Configures system-probe agent


### PR DESCRIPTION
This PR removes the permission change on Windows and synchronizes the system probe Agent start with the main Agent start.