### PR TITLE
Use `agent version` instead of `agent status` to determine the current Agent version

### DIFF
--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -166,7 +166,7 @@ class Chef
           match_data = status.match(/^Agent (.*) - Meta: (.*) - Commit/)
 
           # Nightlies like 6.20.0-devel+git.38.cd7f989 fail to parse as Gem::Version because of the '+' sign
-          version = match_data[1] + "-" + match_data[2] if match_data
+          version = match_data[1] + '-' + match_data[2] if match_data
 
           Gem::Version.new(version) if version
         end

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -143,8 +143,11 @@ class Chef
 
       class << self
         def must_reinstall?(node)
+          puts "Im in must_reinstall rn"
           current_version = fetch_current_version
+          puts "current_version is #{current_version}"
           target_version = requested_agent_version(node)
+          puts "target_version is #{target_version}"
 
           return false unless chef_version_can_uninstall?
           return false unless current_version && target_version

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -159,6 +159,7 @@ class Chef
 
         include Chef::Mixin::ShellOut
         def agent_status
+          puts shell_out("\"#{WIN_BIN_PATH}\" version").stdout.strip
           return nil unless File.exist?(WIN_BIN_PATH)
           puts "On a pu lancer 'agent version' bro tqt"
           shell_out("\"#{WIN_BIN_PATH}\" version").stdout.strip

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -165,12 +165,13 @@ class Chef
 
         def fetch_current_version
           status = agent_status
+          print "In fetch_current_version: #{agent_status}"
           return nil if status.nil?
           match_data = status.match(/^Agent (.*) - Meta: (.*) - Commit/)
 
           # Nightlies like 6.20.0-devel+git.38.cd7f989 fail to parse as Gem::Version because of the '+' sign
           version = match_data[1] + '-' + match_data[2] if match_data
-          puts "In fetch_current_version: #{agent_status} ===> #{version}"
+          puts " ===> #{version}"
 
           Gem::Version.new(version) if version
         end

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -159,7 +159,10 @@ class Chef
 
         include Chef::Mixin::ShellOut
         def agent_status
+          puts "Trying \"#{WIN_BIN_PATH}\" version"
           puts shell_out("\"#{WIN_BIN_PATH}\" version").stdout.strip
+          puts "Trying \"#{WIN_BIN_PATH}\" status"
+          puts shell_out("\"#{WIN_BIN_PATH}\" status").stdout.strip
           return nil unless File.exist?(WIN_BIN_PATH)
           puts "On a pu lancer 'agent version' bro tqt"
           shell_out("\"#{WIN_BIN_PATH}\" version").stdout.strip

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -170,6 +170,7 @@ class Chef
 
           # Nightlies like 6.20.0-devel+git.38.cd7f989 fail to parse as Gem::Version because of the '+' sign
           version = match_data[1] + '-' + match_data[2] if match_data
+          puts "In fetch_current_version: #{agent_status} ===> #{version}"
 
           Gem::Version.new(version) if version
         end

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -160,12 +160,13 @@ class Chef
         include Chef::Mixin::ShellOut
         def agent_status
           return nil unless File.exist?(WIN_BIN_PATH)
+          puts "On a pu lancer 'agent version' bro tqt"
           shell_out("\"#{WIN_BIN_PATH}\" version").stdout.strip
         end
 
         def fetch_current_version
           status = agent_status
-          print "In fetch_current_version: #{agent_status}"
+          puts "In fetch_current_version: #{agent_status}"
           return nil if status.nil?
           match_data = status.match(/^Agent (.*) - Meta: (.*) - Commit/)
 

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -163,6 +163,7 @@ class Chef
           puts shell_out("\"#{WIN_BIN_PATH}\" version").stdout.strip
           puts "Trying \"#{WIN_BIN_PATH}\" status"
           puts shell_out("\"#{WIN_BIN_PATH}\" status").stdout.strip
+          puts shell_out("dir \"C:/Program Files/Datadog/Datadog Agent/\"").stdout.strip
           return nil unless File.exist?(WIN_BIN_PATH)
           puts "On a pu lancer 'agent version' bro tqt"
           shell_out("\"#{WIN_BIN_PATH}\" version").stdout.strip

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -157,16 +157,16 @@ class Chef
         include Chef::Mixin::ShellOut
         def agent_status
           return nil unless File.exist?(WIN_BIN_PATH)
-          shell_out("\"#{WIN_BIN_PATH}\" status").stdout.strip
+          shell_out("\"#{WIN_BIN_PATH}\" version").stdout.strip
         end
 
         def fetch_current_version
           status = agent_status
           return nil if status.nil?
-          match_data = status.match(/^Agent \(v(.*)\)/)
+          match_data = status.match(/^Agent (.*) - Meta: (.*) - Commit/)
 
           # Nightlies like 6.20.0-devel+git.38.cd7f989 fail to parse as Gem::Version because of the '+' sign
-          version = match_data[1].tr('+', '-') if match_data
+          version = match_data[1] + "-" + match_data[2] if match_data
 
           Gem::Version.new(version) if version
         end

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -143,11 +143,8 @@ class Chef
 
       class << self
         def must_reinstall?(node)
-          puts "Im in must_reinstall rn"
           current_version = fetch_current_version
-          puts "current_version is #{current_version}"
           target_version = requested_agent_version(node)
-          puts "target_version is #{target_version}"
 
           return false unless chef_version_can_uninstall?
           return false unless current_version && target_version
@@ -159,13 +156,7 @@ class Chef
 
         include Chef::Mixin::ShellOut
         def agent_get_version
-          puts "Trying \"#{WIN_BIN_PATH}\" version"
-          puts shell_out("\"#{WIN_BIN_PATH}\" version").stdout.strip
-          puts "Trying \"#{WIN_BIN_PATH}\" status"
-          puts shell_out("\"#{WIN_BIN_PATH}\" status").stdout.strip
-          puts shell_out("dir \"C:/Program Files/Datadog/Datadog Agent/\"").stdout.strip
           return nil unless File.exist?(WIN_BIN_PATH)
-          puts "On a pu lancer 'agent version' bro tqt"
           shell_out("\"#{WIN_BIN_PATH}\" version").stdout.strip
         end
 
@@ -179,7 +170,6 @@ class Chef
           # If the Meta tag is catched, we'll add it to the version to specify the nightly version we're using
           # Nightlies like 6.20.0-devel+git.38.cd7f989 fail to parse as Gem::Version because of the '+' sign so let's use '-'
           version = version + '-' + nightly_version if nightly_version
-
 
           Gem::Version.new(version) if version
         end

--- a/spec/recipe_helpers_spec.rb
+++ b/spec/recipe_helpers_spec.rb
@@ -37,15 +37,13 @@ describe Chef::Datadog::WindowsInstallHelpers do
     context 'when the agent is installed' do
       before do
         allow(Chef::Datadog::WindowsInstallHelpers)
-          .to receive(:agent_status)
-          .and_return(agent_status_string)
+          .to receive(:agent_get_version)
+          .and_return(agent_version_string)
       end
 
-      let(:agent_status_string) do
+      let(:agent_version_string) do
         %(
-.....
-Agent (v6.20.0)
-....
+Agent 6.20.0 - Commit: 3c29612 - Serialization version: v5.0.22 - Go version: go1.17.11
         )
       end
 
@@ -70,11 +68,9 @@ Agent (v6.20.0)
       end
 
       context 'when the current agent version is a nightly' do
-        let(:agent_status) do
+        let(:agent_get_version) do
           %(
-.....
-Agent (v6.20.0-devel+git.38.cd7f989)
-....
+Agent 6.20.0-devel - Meta: git.38.cd7f989 - Commit: cd7f98964 - Serialization version: v5.0.22 - Go version: go1.17.11
           )
         end
 


### PR DESCRIPTION
[Here](https://github.com/DataDog/chef-datadog/blob/60c36631449341281c3af2ecdab3685cfcb73734/libraries/recipe_helpers.rb#L157-L172) we call `agent status`, which does an http request to the running Agent.

If the Agent is misbehaving, `agent status` might take a long time to return. 

This PR replaces this with `agent version` which returns immediately.