### PR TITLE
Removed chef_handler cookbook as its EOL

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -22,6 +22,5 @@ issues_url       'https://github.com/DataDog/chef-datadog/issues'
   supports os
 end
 
-depends    'chef_handler', '>= 1.2'
 depends    'apt' # Use '< 6.0.0' with Chef < 12.9
 depends    'yum', '>= 3.0' # Use '< 5.0' with Chef < 12.14

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'package@datadoghq.com'
 license          'Apache-2.0'
 description      'Installs/Configures datadog components'
 version          '4.14.0'
-chef_version     '>= 12.7'
+chef_version     '>= 14.0'
 source_url       'https://github.com/DataDog/chef-datadog'
 issues_url       'https://github.com/DataDog/chef-datadog/issues'
 


### PR DESCRIPTION
See https://github.com/chef-boneyard/chef_handler#deprecation:

> The chef_handler resource from this cookbook is now shipping as part of Chef 14. With the inclusion of this resource into Chef itself we are now deprecating this cookbook. It will continue to function for Chef 13 users, but will not be updated.

Including this cookbook is breaking our CI running with the `deprecations_as_errors` flag set to `true`, and raises:

```
       Chef::Exceptions::DeprecatedFeatureError
       ----------------------------------------
       Deprecation CHEF-33 from /tmp/kitchen/cache/cookbooks/chef_handler/resources/default.rb
       
         The  resource in the chef_handler cookbook should declare `unified_mode true`
       
       Please see https://docs.chef.io/deprecations_unified_mode/ for further details and information on how to correct this problem. (raising error due to treat_deprecation_warnings_as_errors being set)
       
       System Info:
       ------------
       chef_version=17.10.3
       platform=ubuntu
       platform_version=20.04
       ruby=ruby 3.0.3p157 (2021-11-24 revision 3fb7d2cadc) [x86_64-linux]
       program_name=/opt/chef/bin/chef-client
       executable=/opt/chef/bin/chef-client
```