### PR TITLE
Don't use epoch/release for yum package version on Chef < 14

### DIFF
--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -7,7 +7,7 @@ class Chef
         datadog-iot-agent
       ].freeze
 
-      def chef_version_ge? version
+      def chef_version_ge?(version)
         Gem::Requirement.new(">= #{version}").satisfied_by?(Gem::Version.new(Chef::VERSION))
       end
 
@@ -25,7 +25,7 @@ class Chef
           # For RHEL-based distros, we can only add epoch and release when running Chef >= 14, as Chef < 14
           # has different yum logic that doesn't know how to work with epoch and/or release
           if %w[debian suse].include?(node['platform_family']) ||
-              (%w[amazon fedora rhel].include?(node['platform_family']) && chef_version_ge?(14))
+             (%w[amazon fedora rhel].include?(node['platform_family']) && chef_version_ge?(14))
             dd_agent_version = '1:' + dd_agent_version + '-1'
           end
         end

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -1446,7 +1446,11 @@ describe 'datadog::dd-agent' do
       end.converge described_recipe
     end
     it 'installs the full version' do
-      expect(chef_run).to install_dnf_package('datadog-agent').with_version('1:6.16.0-1')
+      if Chef::Datadog.chef_version_ge? 14
+        expect(chef_run).to install_dnf_package('datadog-agent').with_version('1:6.16.0-1')
+      else
+        expect(chef_run).to install_dnf_package('datadog-agent').with_version('6.16.0')
+      end
     end
   end
 end


### PR DESCRIPTION
The yum logic has been rewritten in Chef 14 and using epoch/release is correct (and necessary), however on Chef < 14 not using epoch/release is correct (and necessary).