### PR TITLE
Add ec2_prefer_imdsv2 attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -116,6 +116,9 @@ default['datadog']['env'] = nil
 # Collect EC2 tags, set to 'yes' to collect
 default['datadog']['collect_ec2_tags'] = nil
 
+# Use IMDSv2 to collect instance metadata
+default['datadog']['ec2_prefer_imdsv2'] = nil
+
 # Set this regex to exclude some Chef node tags from the host tags that the datadog handler sends to Datadog
 # https://github.com/DataDog/chef-handler-datadog/issues/85
 # This means that all the metrics and service checks coming from the

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -31,6 +31,9 @@ create_dd_check_tags: <%= node['datadog']['create_dd_check_tags'] %>
 <% if node['datadog']['collect_ec2_tags'] -%>
 collect_ec2_tags: <%= node['datadog']['collect_ec2_tags'] %>
 <% end -%>
+<% if node['datadog']['ec2_prefer_imdsv2'] -%>
+ec2_prefer_imdsv2: <%= node['datadog']['ec2_prefer_imdsv2'] %>
+<% end -%>
 
 <% if node['datadog']['web_proxy']['host'] -%>
 proxy_host: <%= node['datadog']['web_proxy']['host'] %>


### PR DESCRIPTION
This adds an attribute to allow the ec2_prefer_imdsv2 option to be set in datadog.conf.
