### PR TITLE
Specify release but not epoch for RPM packages on Chef < 14

### DIFF
--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -22,11 +22,15 @@ class Chef
           dd_agent_version = dd_agent_version[platform_family]
         end
         if !dd_agent_version.nil? && dd_agent_version.match(/^[0-9]+\.[0-9]+\.[0-9]+((?:~|-)[^0-9\s-]+[^-\s]*)?$/)
-          # For RHEL-based distros, we can only add epoch and release when running Chef >= 14, as Chef < 14
-          # has different yum logic that doesn't know how to work with epoch and/or release
+          # For RHEL-based distros:
+          # - we can only add epoch and release when running Chef >= 14, as Chef < 14
+          # has different yum logic that doesn't know how to work with epoch and release
+          # - for Chef < 14, we only add release
           if %w[debian suse].include?(node['platform_family']) ||
              (%w[amazon fedora rhel].include?(node['platform_family']) && chef_version_ge?(14))
             dd_agent_version = '1:' + dd_agent_version + '-1'
+          elsif %w[amazon fedora rhel].include?(node['platform_family'])
+            dd_agent_version += '-1'
           end
         end
         dd_agent_version

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -1449,7 +1449,7 @@ describe 'datadog::dd-agent' do
       if Chef::Datadog.chef_version_ge? 14
         expect(chef_run).to install_dnf_package('datadog-agent').with_version('1:6.16.0-1')
       else
-        expect(chef_run).to install_dnf_package('datadog-agent').with_version('6.16.0')
+        expect(chef_run).to install_dnf_package('datadog-agent').with_version('6.16.0-1')
       end
     end
   end


### PR DESCRIPTION
### What does this PR do?

In https://github.com/DataDog/chef-datadog/pull/856, we reverted the logic introduced in https://github.com/DataDog/chef-datadog/pull/839 when Chef < 14 is used, as the `yum` logic in Chef < 14 doesn't support the use of epochs.

However, before https://github.com/DataDog/chef-datadog/pull/839, the release was added in all cases to the package version. In https://github.com/DataDog/chef-datadog/pull/856 we forgot to restore that, which this PR does. 