### PR TITLE
Add unit types to Systemd integration

### DIFF
--- a/recipes/systemd.rb
+++ b/recipes/systemd.rb
@@ -1,48 +1,48 @@
 include_recipe '::dd-agent'
 
 # Monitor Systemd
-# It works for all unit types like target, service, socket, device, mount, automount, swap, path, timer, snapshot, slice, scope, busname
-# node.default['datadog']['systemd']['instances'] = [
-#   {
-#     'unit_names' => [
-#       'myservice1.service',
-#       'myservice2.service',
-#       'mysocket.socket',
-#       'mytimer.timer'
-#     ],
-#     'substate_status_mapping' => [
-#       'service' => [
-#         'myservice1' => {
-#           'running' => 'ok',
-#           'exited' => 'critical'
-#         },
-#         'myservice2' => {
-#           'plugged' => 'ok',
-#           'mounted' => 'ok',
-#           'running' => 'ok',
-#           'exited' => 'critical',
-#           'stopped' => 'critical'
-#         }
-#       ],
-#       'socket' => [
-#         'mysocket' => {
-#           'running' => 'ok',
-#           'exited' => 'critical'
-#         }
-#       ],
-#       'timer' => [
-#         'mytimer' => {
-#          'running' => 'ok',
-#          'exited' => 'critical'
-#         }
-#       ]
-#     ],
-#     'tags' => [
-#       'mykey1:myvalue1',
-#       'mykey2:myvalue2'
-#     ]
-#   }
-# ]
+# It works for all unit types like targets, services, sockets, devices, mounts, automounts, swaps, paths, timers, snapshots, slices, scopes, busnames
+node.default['datadog']['systemd']['instances'] = [
+  {
+    'unit_names' => [
+      'myservice1.service',
+      'myservice2.service',
+      'mysocket.socket',
+      'mytimer.timer'
+    ],
+    'substate_status_mapping' => [
+      'services' => [
+        'myservice1' => {
+          'running' => 'ok',
+          'exited' => 'critical'
+        },
+        'myservice2' => {
+          'plugged' => 'ok',
+          'mounted' => 'ok',
+          'running' => 'ok',
+          'exited' => 'critical',
+          'stopped' => 'critical'
+        }
+      ],
+      'sockets' => [
+        'mysocket' => {
+          'running' => 'ok',
+          'exited' => 'critical'
+        }
+      ],
+      'timers' => [
+        'mytimer' => {
+         'running' => 'ok',
+         'exited' => 'critical'
+        }
+      ]
+    ],
+    'tags' => [
+      'mykey1:myvalue1',
+      'mykey2:myvalue2'
+    ]
+  }
+]
 
 datadog_monitor 'systemd' do
   instances node['datadog']['systemd']['instances']

--- a/recipes/systemd.rb
+++ b/recipes/systemd.rb
@@ -1,7 +1,7 @@
 include_recipe '::dd-agent'
 
 # Monitor Systemd
-#
+# It works for all unit types like target, service, socket, device, mount, automount, swap, path, timer, snapshot, slice, scope, busname
 # node.default['datadog']['systemd']['instances'] = [
 #   {
 #     'unit_names' => [
@@ -11,7 +11,7 @@ include_recipe '::dd-agent'
 #       'mytimer.timer'
 #     ],
 #     'substate_status_mapping' => [
-#       'services' => [
+#       'service' => [
 #         'myservice1' => {
 #           'running' => 'ok',
 #           'exited' => 'critical'
@@ -24,13 +24,13 @@ include_recipe '::dd-agent'
 #           'stopped' => 'critical'
 #         }
 #       ],
-#       'sockets' => [
+#       'socket' => [
 #         'mysocket' => {
 #           'running' => 'ok',
 #           'exited' => 'critical'
 #         }
 #       ],
-#       'timers' => [
+#       'timer' => [
 #         'mytimer' => {
 #          'running' => 'ok',
 #          'exited' => 'critical'

--- a/recipes/systemd.rb
+++ b/recipes/systemd.rb
@@ -7,7 +7,8 @@ include_recipe '::dd-agent'
 #     'unit_names' => [
 #       'myservice1.service',
 #       'myservice2.service',
-#       'mysocket.socket'
+#       'mysocket.socket',
+#       'mytimer.timer'
 #     ],
 #     'substate_status_mapping' => [
 #       'services' => [
@@ -27,6 +28,12 @@ include_recipe '::dd-agent'
 #         'mysocket' => {
 #           'running' => 'ok',
 #           'exited' => 'critical'
+#         }
+#       ],
+#       'timers' => [
+#         'mytimer' => {
+#          'running' => 'ok',
+#          'exited' => 'critical'
 #         }
 #       ]
 #     ],

--- a/recipes/systemd.rb
+++ b/recipes/systemd.rb
@@ -2,47 +2,47 @@ include_recipe '::dd-agent'
 
 # Monitor Systemd
 # It works for all unit types like targets, services, sockets, devices, mounts, automounts, swaps, paths, timers, snapshots, slices, scopes, busnames
-node.default['datadog']['systemd']['instances'] = [
-  {
-    'unit_names' => [
-      'myservice1.service',
-      'myservice2.service',
-      'mysocket.socket',
-      'mytimer.timer'
-    ],
-    'substate_status_mapping' => [
-      'services' => [
-        'myservice1' => {
-          'running' => 'ok',
-          'exited' => 'critical'
-        },
-        'myservice2' => {
-          'plugged' => 'ok',
-          'mounted' => 'ok',
-          'running' => 'ok',
-          'exited' => 'critical',
-          'stopped' => 'critical'
-        }
-      ],
-      'sockets' => [
-        'mysocket' => {
-          'running' => 'ok',
-          'exited' => 'critical'
-        }
-      ],
-      'timers' => [
-        'mytimer' => {
-         'running' => 'ok',
-         'exited' => 'critical'
-        }
-      ]
-    ],
-    'tags' => [
-      'mykey1:myvalue1',
-      'mykey2:myvalue2'
-    ]
-  }
-]
+# node.default['datadog']['systemd']['instances'] = [
+#   {
+#     'unit_names' => [
+#       'myservice1.service',
+#       'myservice2.service',
+#       'mysocket.socket',
+#       'mytimer.timer'
+#     ],
+#     'substate_status_mapping' => [
+#       'services' => [
+#         'myservice1' => {
+#           'running' => 'ok',
+#           'exited' => 'critical'
+#         },
+#         'myservice2' => {
+#           'plugged' => 'ok',
+#           'mounted' => 'ok',
+#           'running' => 'ok',
+#           'exited' => 'critical',
+#           'stopped' => 'critical'
+#         }
+#       ],
+#       'sockets' => [
+#         'mysocket' => {
+#           'running' => 'ok',
+#           'exited' => 'critical'
+#         }
+#       ],
+#       'timers' => [
+#         'mytimer' => {
+#          'running' => 'ok',
+#          'exited' => 'critical'
+#         }
+#       ]
+#     ],
+#     'tags' => [
+#       'mykey1:myvalue1',
+#       'mykey2:myvalue2'
+#     ]
+#   }
+# ]
 
 datadog_monitor 'systemd' do
   instances node['datadog']['systemd']['instances']

--- a/spec/integrations/systemd_spec.rb
+++ b/spec/integrations/systemd_spec.rb
@@ -48,7 +48,7 @@ describe 'datadog::systemd' do
                 'mytimer.timer'
               ],
               substate_status_mapping: [
-                service: [
+                services: [
                   myservice1: {
                     running: 'ok',
                     exited: 'critical'
@@ -61,13 +61,13 @@ describe 'datadog::systemd' do
                     stopped: 'critical'
                   }
                 ],
-                socket: [
+                sockets: [
                   mysocket: {
                     running: 'ok',
                     exited: 'critical'
                   }
                 ],
-                timer: [
+                timers: [
                   mytimer: {
                     running: 'ok',
                     exited: 'critical'

--- a/spec/integrations/systemd_spec.rb
+++ b/spec/integrations/systemd_spec.rb
@@ -15,6 +15,9 @@ describe 'datadog::systemd' do
           mysocket.socket:
             exited: critical
             running: ok
+          mytimer.timer:
+            exited: critical
+            running: ok
         tags:
           - 'mykey1:myvalue1'
           - 'mykey2:myvalue2'
@@ -22,6 +25,7 @@ describe 'datadog::systemd' do
           - myservice1.service
           - myservice2.service
           - mysocket.socket
+          - mytimer.timer
     logs: ~
   EOF
 
@@ -40,7 +44,8 @@ describe 'datadog::systemd' do
               unit_names: [
                 'myservice1.service',
                 'myservice2.service',
-                'mysocket.socket'
+                'mysocket.socket',
+                'mytimer.timer'
               ],
               substate_status_mapping: [
                 services: [
@@ -58,6 +63,12 @@ describe 'datadog::systemd' do
                 ],
                 sockets: [
                   mysocket: {
+                    running: 'ok',
+                    exited: 'critical'
+                  }
+                ],
+                timers: [
+                  mytimer: {
                     running: 'ok',
                     exited: 'critical'
                   }

--- a/spec/integrations/systemd_spec.rb
+++ b/spec/integrations/systemd_spec.rb
@@ -48,7 +48,7 @@ describe 'datadog::systemd' do
                 'mytimer.timer'
               ],
               substate_status_mapping: [
-                services: [
+                service: [
                   myservice1: {
                     running: 'ok',
                     exited: 'critical'
@@ -61,13 +61,13 @@ describe 'datadog::systemd' do
                     stopped: 'critical'
                   }
                 ],
-                sockets: [
+                socket: [
                   mysocket: {
                     running: 'ok',
                     exited: 'critical'
                   }
                 ],
-                timers: [
+                timer: [
                   mytimer: {
                     running: 'ok',
                     exited: 'critical'

--- a/templates/default/systemd.yaml.erb
+++ b/templates/default/systemd.yaml.erb
@@ -29,6 +29,16 @@ instances:
             <% end -%>
           <% end -%>
         <% end -%>
+        <% if s.key?('timers') -%>
+          <% s['timers'].each do |k| -%>
+            <% k.keys.each do |j| -%>
+      <%= j %>.timer:
+              <% k[j].each do |l,v| %>
+        <%= l %>: <%= v %>
+              <% end -%>
+            <% end -%>
+          <% end -%>
+        <% end -%>
       <% end -%>
     <% end -%>
     <% if i.key?('tags') -%>

--- a/templates/default/systemd.yaml.erb
+++ b/templates/default/systemd.yaml.erb
@@ -9,32 +9,14 @@ instances:
     <% if i.key?('substate_status_mapping') -%>
     substate_status_mapping:
       <% i['substate_status_mapping'].each do |s| -%>
-        <% if s.key?('services') -%>
-          <% s['services'].each do |k| -%>
-            <% k.keys.each do |j| -%>
-      <%= j %>.service:
-              <% k[j].each do |l,v| %>
+        <% %w(services sockets timers).each do |unit_type| -%>
+          <% if s.key?(unit_type)-%>
+            <% s[unit_type].each do |k| -%>
+              <% k.keys.each do |j| -%>
+      <%= j %>.<%= unit_type %>:
+                <% k[j].each do |l,v| %>
         <%= l %>: <%= v %>
-              <% end -%>
-            <% end -%>
-          <% end -%>
-        <% end -%>
-        <% if s.key?('sockets') -%>
-          <% s['sockets'].each do |k| -%>
-            <% k.keys.each do |j| -%>
-      <%= j %>.socket:
-              <% k[j].each do |l,v| %>
-        <%= l %>: <%= v %>
-              <% end -%>
-            <% end -%>
-          <% end -%>
-        <% end -%>
-        <% if s.key?('timers') -%>
-          <% s['timers'].each do |k| -%>
-            <% k.keys.each do |j| -%>
-      <%= j %>.timer:
-              <% k[j].each do |l,v| %>
-        <%= l %>: <%= v %>
+                <% end -%>
               <% end -%>
             <% end -%>
           <% end -%>

--- a/templates/default/systemd.yaml.erb
+++ b/templates/default/systemd.yaml.erb
@@ -1,4 +1,4 @@
-<%= JSON.parse(({'logs' => @logs }).to_json).to_yaml %>
+<%= JSON.parse(({'logs' => @logs }).to_json).to_yaml -%>
 
 instances:
   <% @instances.each do |i| -%>
@@ -9,7 +9,7 @@ instances:
     <% if i.key?('substate_status_mapping') -%>
     substate_status_mapping:
       <% i['substate_status_mapping'].each do |s| -%>
-        <% %w(services sockets timers).each do |unit_type| -%>
+        <% %w(target service socket device mount automount swap path timer snapshot slice scope busname).each do |unit_type| -%>
           <% if s.key?(unit_type)-%>
             <% s[unit_type].each do |k| -%>
               <% k.keys.each do |j| -%>

--- a/templates/default/systemd.yaml.erb
+++ b/templates/default/systemd.yaml.erb
@@ -9,11 +9,11 @@ instances:
     <% if i.key?('substate_status_mapping') -%>
     substate_status_mapping:
       <% i['substate_status_mapping'].each do |s| -%>
-        <% %w(target service socket device mount automount swap path timer snapshot slice scope busname).each do |unit_type| -%>
+        <% %w(targets services sockets devices mounts automounts swaps paths timers snapshots slices scopes busnames).each do |unit_type| -%>
           <% if s.key?(unit_type)-%>
             <% s[unit_type].each do |k| -%>
               <% k.keys.each do |j| -%>
-      <%= j %>.<%= unit_type %>:
+      <%= j %>.<%= unit_type.chomp('s') %>:
                 <% k[j].each do |l,v| %>
         <%= l %>: <%= v %>
                 <% end -%>

--- a/test/integration/datadog_systemd/serverspec/systemd_spec.rb
+++ b/test/integration/datadog_systemd/serverspec/systemd_spec.rb
@@ -20,7 +20,8 @@ describe file(AGENT_CONFIG) do
           'unit_names' => [
             'myservice1.service',
             'myservice2.service',
-            'mysocket.socket'
+            'mysocket.socket',
+            'mytimer.timer'
           ]
         }
       ],


### PR DESCRIPTION
Initially the Pull Request was created to add the functionality to timer units only. I realized it's the best to add the possibility to add the functionality for all Systemd unit types. 

From my point of view it makes the most sense to let the user select the unit type instead of handing over every string added to node attributes in `systemd.rb`. Therefore an array with all unit types checks if the unit type has been added to node attributes inside the recipe as part of a loop. For a smaller code the decision has been chosen to remove the `s` from the unit type keys inside the hash. It could be a little bit confusing for the end user but in the end it's ways better to have an efficient code in place. 

Node attributes changed from:
```
node.default['datadog']['systemd']['instances'] = [
[...]
    'substate_status_mapping' => [
      'services' => [
        'myservice1' => {
          'running' => 'ok',
          'exited' => 'critical'
        },
[..]
```
to:
```
node.default['datadog']['systemd']['instances'] = [
[...]
    'substate_status_mapping' => [
      'service' => [
        'myservice1' => {
          'running' => 'ok',
          'exited' => 'critical'
        },
[..]
```
Means e.g. the unit type is not called `services` anymore but `service`. 

The array distinguishing between unit types:
```
%w(target service socket device mount automount swap path timer snapshot slice scope busname)
```

UPDATE:
The decision has been chosen to keep the plural version, so the first example has to be used.