### PR TITLE
Add configuration for gearmand integration

### DIFF
--- a/recipes/gearmand.rb
+++ b/recipes/gearmand.rb
@@ -1,0 +1,39 @@
+include_recipe '::dd-agent'
+
+# All attributes are optional.
+# node.default['datadog']['gearmand']['instances'] = [
+#   {
+#     # Defaults to 127.0.0.1 if not set
+#     'server' => '127.0.0.1',
+#     # Defaults to 4730 if not set
+#     'port' => '4730',
+#     'tasks' => [
+#       'TASK_1',
+#       'TASK_2',
+#     ],
+#     'tags' => [
+#       '<KEY_1>:<VALUE_1>',
+#       '<KEY_2>:<VALUE_2>'
+#     ],
+#     'service' => '<SERVICE>',
+#     # Defaults to 15 if not set
+#     'min_collection_interval' => 60,
+#     # Defaults to false if not set
+#     'empty_default_hostname' => true,
+#     'metric_patterns' => {
+#       'include' => [
+#         '<INCLUDE_REGEX>'
+#       ],
+#       'exclude' => [
+#         '<EXCLUDE_REGEX>'
+#       ]
+#     }
+#   }
+# ]
+
+datadog_monitor 'gearmand' do
+  instances node['datadog']['gearmand']['instances']
+  logs node['datadog']['gearmand']['logs']
+  action :add
+  notifies :restart, 'service[datadog-agent]' if node['datadog']['agent_start']
+end

--- a/spec/integrations/gearmand_spec.rb
+++ b/spec/integrations/gearmand_spec.rb
@@ -1,0 +1,82 @@
+describe 'datadog::gearmand' do
+  expected_yaml = <<-EOF
+  logs:
+
+  instances:
+  - server: 127.0.0.1
+    port: 4730
+    tasks:
+    - TASK_1
+    - TASK_2
+    tags:
+    - <KEY_1>:<VALUE_1>
+    - <KEY_2>:<VALUE_2>
+    service: <SERVICE>
+    min_collection_interval: 60
+    empty_default_hostname: true
+    metric_patterns:
+      include:
+      - <INCLUDE_REGEX>
+      exclude:
+      - <EXCLUDE_REGEX>
+
+  init_config:
+  # No init_config details needed
+  EOF
+
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '16.04',
+      step_into: ['datadog_monitor']
+    ) do |node|
+      node.automatic['languages'] = { 'python' => { 'version' => '2.7.2' } }
+      node.normal['datadog'] = {
+        api_key: 'someapikey',
+        gearmand: {
+          instances: [
+            {
+              server: '127.0.0.1',
+              port: '4730',
+              tasks: [
+                'TASK_1',
+                'TASK_2',
+              ],
+              tags: [
+                '<KEY_1>:<VALUE_1>',
+                '<KEY_2>:<VALUE_2>'
+              ],
+              service: '<SERVICE>',
+              # Defaults to 15 if not set
+              min_collection_interval: 60,
+              # Defaults to false if not set
+              empty_default_hostname: true,
+              metric_patterns: {
+                include: [
+                  '<INCLUDE_REGEX>'
+                ],
+                exclude: [
+                  '<EXCLUDE_REGEX>'
+                ]
+              }
+            }
+          ]
+        }
+      }
+    end.converge(described_recipe)
+  end
+
+  subject { chef_run }
+
+  it_behaves_like 'datadog-agent'
+
+  it { is_expected.to include_recipe('datadog::dd-agent') }
+
+  it { is_expected.to add_datadog_monitor('gearmand') }
+
+  it 'renders expected YAML config file' do
+    expect(chef_run).to(render_file('/etc/datadog-agent/conf.d/gearmand.d/conf.yaml').with_content { |content|
+      expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
+    })
+  end
+end

--- a/templates/default/gearmand.yaml.erb
+++ b/templates/default/gearmand.yaml.erb
@@ -1,0 +1,62 @@
+<%= JSON.parse(({'logs' => @logs }).to_json).to_yaml -%>
+
+instances:
+<% @instances.each do |i| %>
+  <% if i['server'] -%>
+    <% ip = i['server'] %>
+  <% else %>
+    <% ip = '127.0.0.1' %>
+  <% end -%>
+- server: <%= ip %>
+  <% if i['port'] -%>
+    <% port = i['port'] %>
+  <% else %>
+    <% port = '4730' %>
+  <% end -%>
+  port: <%= port %>
+  <% if i['tasks'] %>
+  tasks:
+    <% i['tasks'].each do |task| -%>
+  - <%= task %>
+    <% end %>
+  <% end %>
+  <% if i['tags'] %>
+  tags:
+    <% i['tags'].each do |tag| -%>
+  - <%= tag %>
+    <% end %>
+  <% end %>
+  <% if i['service'] %>
+  service: <%= i['service'] %>
+  <% end %>
+  <% if i['min_collection_interval'] %>
+    <% seconds = i['min_collection_interval'] %>
+  <% else %>
+    <% seconds = 15 %>
+  <% end %>
+  min_collection_interval: <%= seconds %>
+  <% if i['empty_default_hostname'] %>
+     <% boolean = i['empty_default_hostname'] %>
+  <% else %>
+     <% boolean = false %>
+  <% end %>
+  empty_default_hostname: <%= boolean %>
+  <% if i['metric_patterns'] %>
+  metric_patterns:
+    <% if i['metric_patterns'].include?('include') %>
+    include:
+      <% i['metric_patterns']['include'].each do |regex| %>
+    - <%= regex %>
+      <% end %>
+    <% end %>
+    <% if i['metric_patterns'].include?('exclude') %>
+    exclude:
+      <% i['metric_patterns']['exclude'].each do |regex| %>
+    - <%= regex %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end -%>
+
+init_config:
+# No init_config details needed

--- a/test/integration/datadog_gearmand/serverspec/gearmand_spec.rb
+++ b/test/integration/datadog_gearmand/serverspec/gearmand_spec.rb
@@ -1,0 +1,51 @@
+# Encoding: utf-8
+
+require 'spec_helper'
+
+AGENT_CONFIG = File.join(@agent_config_dir, 'conf.d/gearmand.d/conf.yaml')
+
+describe service(@agent_service_name) do
+  it { should be_running }
+end
+
+describe file(AGENT_CONFIG) do
+  it { should be_a_file }
+
+  it 'is valid yaml matching input values' do
+    generated = YAML.load_file(AGENT_CONFIG)
+
+    expected = {
+      'instances' => [
+        {
+          'server' => '127.0.0.1',
+          'port' => '4730',
+          'tasks' => [
+            'TASK_1',
+            'TASK_2',
+          ],
+          'tags' => [
+            '<KEY_1>:<VALUE_1>',
+            '<KEY_2>:<VALUE_2>'
+          ],
+          'service' => '<SERVICE>',
+          # Defaults to 15 if not set
+          'min_collection_interval' => 60,
+          # Defaults to false if not set
+          'empty_default_hostname' => true,
+          'metric_patterns' => {
+            'include' => [
+              '<INCLUDE_REGEX>'
+            ],
+            'exclude' => [
+              '<EXCLUDE_REGEX>'
+            ]
+          }
+        }
+      ],
+      'logs' => nil,
+      'init_config' => nil
+    }
+
+    expect(generated.to_json).to be_json_eql expected.to_json
+  end
+end


### PR DESCRIPTION
Achieved:

This PR enables the opportunity to handle the `gearmand` integration via Chef. It's possible to define every parameter described within the integration documentation example file. 

Because all parameters for the `gearmand` integration are optional, the possibility of optional node attributes has been enabled within the configuration deployment, too. Means, if a parameter is not defined, it will be written with default parameters. Well known that the example config file doesn't need that, because these parameters are set by default behind the scenes, the behavior has been set anyway in case of visibility. So the user has the chance to see what he does.

If the user would only add the following to his recipe `node.default['datadog']['gearmand']['instances'] = [{}]`,  the basic standard config would be written as well. If only a view parameters will not be set but others, too - the default settings will be written in case of visibility as well. 

From my point of view this is the most valuable way to handle optional arguments of the DataDog config file via configuration deployment.