### PR TITLE
Add configuration for custom_log_collection

### DIFF
--- a/recipes/custom_log_collection.rb
+++ b/recipes/custom_log_collection.rb
@@ -1,0 +1,19 @@
+include_recipe '::dd-agent'
+
+# node.default['datadog']['custom_log_collection']['logs'] = [
+#   {
+#     'type' => 'file',
+#     'path' => '</path/to/logfile>',
+#     'source' => '<source>',
+#     'tags' => [
+#       'tag1:value1',
+#       'tag2:value2'
+#     ]
+#   }
+# ]
+
+datadog_monitor 'custom_log_collection' do
+  logs node['datadog']['custom_log_collection']['logs']
+  action :add
+  notifies :restart, 'service[datadog-agent]' if node['datadog']['agent_start']
+end

--- a/templates/default/custom_log_collection.yaml.erb
+++ b/templates/default/custom_log_collection.yaml.erb
@@ -1,0 +1,1 @@
+<%= JSON.parse(({'logs' => @logs }).to_json).to_yaml -%>


### PR DESCRIPTION
Achieved:

This Pull Request allow it to create a config file for the `custom_log_collection` DataDog integration. 

It works the same as adding a log file configuration for an integration using that community cookbook and makes it possible to use the custom_log_integration as follows:

```
node.default['datadog']['custom_log_collection']['logs'] = [
  {
    'type' => 'file',
    'path' => '</path/to/logfile>',
    'source' => '<source>',
    'tags' => [
      'tag1:value1',
      'tag2:value2'
    ]
  }
]