### PR TITLE
Enforce calls of agent version without color output

### DIFF
--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -168,7 +168,7 @@ class Chef
         include Chef::Mixin::ShellOut
         def agent_get_version
           return nil unless File.exist?(WIN_BIN_PATH)
-          shell_out("\"#{WIN_BIN_PATH}\" version").stdout.strip
+          shell_out("\"#{WIN_BIN_PATH}\" version -n").stdout.strip
         end
 
         def fetch_current_version


### PR DESCRIPTION
### What does this PR do?

Ensures that `agent version` is called with the `-n` option, which removes color output.

Some versions of the Agent have color output by default, which breaks the parsing done in `fetch_current_version`.