### PR TITLE
Add tls_ignore_warning and persist_connections parameters to rabbitmq monitor

### DIFF
--- a/templates/default/rabbitmq.yaml.erb
+++ b/templates/default/rabbitmq.yaml.erb
@@ -11,6 +11,7 @@ instances:
     rabbitmq_pass: <%= i['pass'] || 'guest' %>
     tls_verify: <%= i.key?('tls_verify') ? i['tls_verify'] : 'true' %>
     tls_ignore_warning: <%= i['tls_ignore_warning'] || 'false' %>
+    persist_connections: <%= i['persist_connections'] || 'false' %>
     # https://help.datadoghq.com/hc/en-us/articles/211590103-Tagging-RabbitMQ-queues-by-tag-family
     tag_families: <%= i['tag_families'] || 'false' %>
   <% if i.key?('max_detailed_exchanges') -%>

--- a/templates/default/rabbitmq.yaml.erb
+++ b/templates/default/rabbitmq.yaml.erb
@@ -10,6 +10,7 @@ instances:
     rabbitmq_user: <%= i['user'] || 'guest' %>
     rabbitmq_pass: <%= i['pass'] || 'guest' %>
     tls_verify: <%= i.key?('tls_verify') ? i['tls_verify'] : 'true' %>
+    tls_ignore_warning: <%= i['tls_ignore_warning'] || 'false' %>
     # https://help.datadoghq.com/hc/en-us/articles/211590103-Tagging-RabbitMQ-queues-by-tag-family
     tag_families: <%= i['tag_families'] || 'false' %>
   <% if i.key?('max_detailed_exchanges') -%>

--- a/templates/default/rabbitmq.yaml.erb
+++ b/templates/default/rabbitmq.yaml.erb
@@ -9,7 +9,7 @@ instances:
   - rabbitmq_api_url: <%= i['api_url'] %>
     rabbitmq_user: <%= i['user'] || 'guest' %>
     rabbitmq_pass: <%= i['pass'] || 'guest' %>
-    ssl_verify: <%= i.key?('ssl_verify') ? i['ssl_verify'] : 'true' %>
+    tls_verify: <%= i.key?('tls_verify') ? i['tls_verify'] : 'true' %>
     # https://help.datadoghq.com/hc/en-us/articles/211590103-Tagging-RabbitMQ-queues-by-tag-family
     tag_families: <%= i['tag_families'] || 'false' %>
   <% if i.key?('max_detailed_exchanges') -%>


### PR DESCRIPTION
I have an issue where Datadog Agent is consuming too much CPU when RabbitMQ monitor configuration doesn't have these parameters enabled.

Parameter name reference: https://github.com/DataDog/integrations-core/blob/master/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
