### PR TITLE
Remove source file and datadog-signing-keys package when removing the Agent

### DIFF
--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -7,6 +7,11 @@ class Chef
         datadog-iot-agent
       ].freeze
 
+      # This method stores a variable that is used across recipes so we needed a place to define it
+      def apt_sources_list_file
+        '/etc/apt/sources.list.d/datadog.list'
+      end
+
       def chef_version_ge?(version)
         Gem::Requirement.new(">= #{version}").satisfied_by?(Gem::Version.new(Chef::VERSION))
       end

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -7,7 +7,9 @@ class Chef
         datadog-iot-agent
       ].freeze
 
-      # This method stores a variable that is used across recipes so we needed a place to define it
+      # This method stores a variable that is used across recipes so we needed a place to define it.
+      # Global variables like this are usually set in the attributes/default.rb file for users to edit them.
+      # We don't want this variable to be changed by the user though, hence the place.
       def apt_sources_list_file
         '/etc/apt/sources.list.d/datadog.list'
       end

--- a/recipes/remove-dd-agent.rb
+++ b/recipes/remove-dd-agent.rb
@@ -28,7 +28,7 @@ when 'linux'
 
   # Then remove the installation files (depending on the OS: sources_list file, datadog-signing-keys package...)
   case node['platform_family']
-  when 'amazon', 'rhel' # 'rhel' includes redhat, centos, rocky, scientific and almalinux
+  when 'amazon', 'rhel', 'fedora' # 'rhel' includes redhat, centos, rocky, scientific and almalinux
     yum_repository 'datadog' do
       action :remove
     end

--- a/recipes/remove-dd-agent.rb
+++ b/recipes/remove-dd-agent.rb
@@ -1,3 +1,17 @@
+# Copyright:: 2011-Present, Datadog
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Run this recipe to completely remove the Datadog Agent
 
 # On Windows, this recipe works only with Chef >= 12.6
@@ -7,13 +21,18 @@ apt_sources_list_file = Chef::Datadog.apt_sources_list_file
 
 case node['os']
 when 'linux'
-  # Removing the apt sources list file and datadog-signing-keys
+  # First remove the datadog-agent package
+  package 'datadog-agent' do
+    action :purge
+  end
+
+  # Then remove the installation files (depending on the OS: sources_list file, datadog-signing-keys package...)
   case node['platform_family']
-  when 'amazon', 'redhat' # RedHat, CentOS, Rocky?, Almalinux?, Scientific Linux? AND Amazon Linux
+  when 'amazon', 'rhel' # 'rhel' includes redhat, centos, rocky, scientific and almalinux
     yum_repository 'datadog' do
       action :delete
     end
-  when 'debian' # Debian, Ubuntu
+  when 'debian' # 'debian' includes debian and ubuntu
     apt_package 'datadog-signing-keys' do
       action :purge
     end
@@ -25,10 +44,9 @@ when 'linux'
       action :remove
     end
   end
-  package 'datadog-agent' do
-    action :purge
-  end
+
 when 'windows'
+  # Remove the datadog-agent package (no need to remove other files as for Linux)
   package 'Datadog Agent' do
     action :remove
   end

--- a/recipes/remove-dd-agent.rb
+++ b/recipes/remove-dd-agent.rb
@@ -2,8 +2,29 @@
 
 # On Windows, this recipe works only with Chef >= 12.6
 
+# Importing apt_sources_list_file variable from recipe_helpers.rb
+apt_sources_list_file = Chef::Datadog.apt_sources_list_file
+
 case node['os']
 when 'linux'
+  # Removing the apt sources list file and datadog-signing-keys
+  case node['platform_family']
+  when 'amazon', 'redhat' # RedHat, CentOS, Rocky?, Almalinux?, Scientific Linux? AND Amazon Linux
+    yum_repository 'datadog' do
+      action :delete
+    end
+  when 'debian' # Debian, Ubuntu
+    apt_package 'datadog-signing-keys' do
+      action :purge
+    end
+    file apt_sources_list_file do
+      action :delete
+    end
+  when 'suse'
+    zypper_repository 'datadog' do
+      action :remove
+    end
+  end
   package 'datadog-agent' do
     action :purge
   end

--- a/recipes/remove-dd-agent.rb
+++ b/recipes/remove-dd-agent.rb
@@ -30,7 +30,7 @@ when 'linux'
   case node['platform_family']
   when 'amazon', 'rhel' # 'rhel' includes redhat, centos, rocky, scientific and almalinux
     yum_repository 'datadog' do
-      action :delete
+      action :remove
     end
   when 'debian' # 'debian' includes debian and ubuntu
     apt_package 'datadog-signing-keys' do

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -36,7 +36,8 @@ apt_gpg_keys = {
 }
 apt_trusted_d_keyring = '/etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg'
 apt_usr_share_keyring = '/usr/share/keyrings/datadog-archive-keyring.gpg'
-apt_sources_list_file = '/etc/apt/sources.list.d/datadog.list'
+# Importing apt_sources_list_file variable from recipe_helpers.rb
+apt_sources_list_file = Chef::Datadog.apt_sources_list_file
 apt_repo_uri = 'https://apt.datadoghq.com'
 
 # DATADOG_RPM_KEY_CURRENT always contains the key that is used to sign repodata and latest packages

--- a/spec/remove-dd-agent_spec.rb
+++ b/spec/remove-dd-agent_spec.rb
@@ -1,0 +1,53 @@
+# Copyright:: 2011-Present, Datadog
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+# Importing apt_sources_list_file variable from recipe_helpers.rb
+apt_sources_list_file = Chef::Datadog.apt_sources_list_file
+
+describe 'datadog::remove-dd-agent' do
+    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '20.04').converge(described_recipe) }
+
+    it 'removes the Datadog Agent package'
+        expect(chef_run).to remove_package('datadog-agent')
+    end
+
+    it 'removes apt_sources_list_file and the datadog-signing-keys package'
+        expect(chef_run).to remove_apt_package('datadog-signing-keys')
+        expect(chef_run).to delete_file(apt_sources_list_file)
+    end
+
+    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'amazon', version: '2.0').converge(described_recipe) }
+
+    it 'removes the Datadog Agent package'
+        expect(chef_run).to remove_package('datadog-agent')
+    end
+
+    it 'removes the Datadog yum repository'
+        expect(chef_run).to remove_yum_repository('datadog')
+    end
+
+    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'suse', version: '12.5').converge(described_recipe) }
+
+    it 'removes the Datadog Agent package'
+        expect(chef_run).to remove_package('datadog-agent')
+    end
+
+    it 'removes the Datadog yum repository'
+        expect(chef_run).to remove_zypper_repository('datadog')
+    end
+
+
+

--- a/spec/remove-dd-agent_spec.rb
+++ b/spec/remove-dd-agent_spec.rb
@@ -18,49 +18,49 @@ require 'spec_helper'
 apt_sources_list_file = Chef::Datadog.apt_sources_list_file
 
 describe 'datadog::remove-dd-agent' do
-    context 'when on Ubuntu' do
-        let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '20.04').converge(described_recipe) }
+  context 'when on Ubuntu' do
+    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '20.04').converge(described_recipe) }
 
-        
-        it 'purges the datadog-agent package' do
-            expect(chef_run).to purge_package('datadog-agent')
-        end
-
-        it 'removes apt_sources_list_file and purges the datadog-signing-keys package' do
-            expect(chef_run).to purge_apt_package('datadog-signing-keys')
-            expect(chef_run).to delete_file(apt_sources_list_file)
-        end
+    
+    it 'purges the datadog-agent package' do
+      expect(chef_run).to purge_package('datadog-agent')
     end
 
-    context 'when on Amazon Linux' do
-        let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'amazon', version: '2').converge(described_recipe) }
+    it 'removes apt_sources_list_file and purges the datadog-signing-keys package' do
+      expect(chef_run).to purge_apt_package('datadog-signing-keys')
+      expect(chef_run).to delete_file(apt_sources_list_file)
+    end
+  end
 
-        it 'purges the datadog-agent package' do
-            expect(chef_run).to purge_package('datadog-agent')
-        end
+  context 'when on Amazon Linux' do
+    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'amazon', version: '2').converge(described_recipe) }
 
-        it 'removes the datadog yum repository' do
-            expect(chef_run).to remove_yum_repository('datadog')
-        end
+    it 'purges the datadog-agent package' do
+      expect(chef_run).to purge_package('datadog-agent')
     end
 
-    context 'when on Suse' do
-        let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'suse', version: '12.5').converge(described_recipe) }
+    it 'removes the datadog yum repository' do
+      expect(chef_run).to remove_yum_repository('datadog')
+    end
+  end
 
-        it 'purges the datadog-agent package' do
-            expect(chef_run).to purge_package('datadog-agent')
-        end
+  context 'when on Suse' do
+    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'suse', version: '12.5').converge(described_recipe) }
 
-        it 'removes the datadog zypper repository' do
-            expect(chef_run).to remove_zypper_repository('datadog')
-        end
+    it 'purges the datadog-agent package' do
+      expect(chef_run).to purge_package('datadog-agent')
     end
 
-    context 'when on Windows' do
-        let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'windows', version: '2016').converge(described_recipe) }
-
-        it 'removes the Datadog Agent package' do
-            expect(chef_run).to remove_package('Datadog Agent')
-        end
+    it 'removes the datadog zypper repository' do
+      expect(chef_run).to remove_zypper_repository('datadog')
     end
+  end
+
+  context 'when on Windows' do
+    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'windows', version: '2016').converge(described_recipe) }
+
+    it 'removes the Datadog Agent package' do
+      expect(chef_run).to remove_package('Datadog Agent')
+    end
+  end
 end

--- a/spec/remove-dd-agent_spec.rb
+++ b/spec/remove-dd-agent_spec.rb
@@ -29,23 +29,23 @@ describe 'datadog::remove-dd-agent' do
         expect(chef_run).to delete_file(apt_sources_list_file)
     end
 
-    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'amazon', version: '2.0').converge(described_recipe) }
+    # let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'amazon', version: '2.0').converge(described_recipe) }
 
-    it 'removes the Datadog Agent package'
-        expect(chef_run).to remove_package('datadog-agent')
-    end
+    # it 'removes the Datadog Agent package'
+    #     expect(chef_run).to remove_package('datadog-agent')
+    # end
 
-    it 'removes the Datadog yum repository'
-        expect(chef_run).to remove_yum_repository('datadog')
-    end
+    # it 'removes the Datadog yum repository'
+    #     expect(chef_run).to remove_yum_repository('datadog')
+    # end
 
-    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'suse', version: '12.5').converge(described_recipe) }
+    # let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'suse', version: '12.5').converge(described_recipe) }
 
-    it 'removes the Datadog Agent package'
-        expect(chef_run).to remove_package('datadog-agent')
-    end
+    # it 'removes the Datadog Agent package'
+    #     expect(chef_run).to remove_package('datadog-agent')
+    # end
 
-    it 'removes the Datadog yum repository'
-        expect(chef_run).to remove_zypper_repository('datadog')
-    end
+    # it 'removes the Datadog yum repository'
+    #     expect(chef_run).to remove_zypper_repository('datadog')
+    # end
 end

--- a/spec/remove-dd-agent_spec.rb
+++ b/spec/remove-dd-agent_spec.rb
@@ -21,7 +21,6 @@ describe 'datadog::remove-dd-agent' do
   context 'when on Ubuntu' do
     let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '20.04').converge(described_recipe) }
 
-
     it 'purges the datadog-agent package' do
       expect(chef_run).to purge_package('datadog-agent')
     end

--- a/spec/remove-dd-agent_spec.rb
+++ b/spec/remove-dd-agent_spec.rb
@@ -21,7 +21,7 @@ describe 'datadog::remove-dd-agent' do
   context 'when on Ubuntu' do
     let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '20.04').converge(described_recipe) }
 
-    
+
     it 'purges the datadog-agent package' do
       expect(chef_run).to purge_package('datadog-agent')
     end

--- a/spec/remove-dd-agent_spec.rb
+++ b/spec/remove-dd-agent_spec.rb
@@ -48,6 +48,4 @@ describe 'datadog::remove-dd-agent' do
     it 'removes the Datadog yum repository'
         expect(chef_run).to remove_zypper_repository('datadog')
     end
-
-
-
+end

--- a/spec/remove-dd-agent_spec.rb
+++ b/spec/remove-dd-agent_spec.rb
@@ -18,34 +18,49 @@ require 'spec_helper'
 apt_sources_list_file = Chef::Datadog.apt_sources_list_file
 
 describe 'datadog::remove-dd-agent' do
-    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '20.04').converge(described_recipe) }
+    context 'when on Ubuntu' do
+        let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '20.04').converge(described_recipe) }
 
-    it 'removes the Datadog Agent package'
-        expect(chef_run).to remove_package('datadog-agent')
+        
+        it 'purges the datadog-agent package' do
+            expect(chef_run).to purge_package('datadog-agent')
+        end
+
+        it 'removes apt_sources_list_file and purges the datadog-signing-keys package' do
+            expect(chef_run).to purge_apt_package('datadog-signing-keys')
+            expect(chef_run).to delete_file(apt_sources_list_file)
+        end
     end
 
-    it 'removes apt_sources_list_file and the datadog-signing-keys package'
-        expect(chef_run).to remove_apt_package('datadog-signing-keys')
-        expect(chef_run).to delete_file(apt_sources_list_file)
+    context 'when on Amazon Linux' do
+        let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'amazon', version: '2').converge(described_recipe) }
+
+        it 'purges the datadog-agent package' do
+            expect(chef_run).to purge_package('datadog-agent')
+        end
+
+        it 'removes the datadog yum repository' do
+            expect(chef_run).to remove_yum_repository('datadog')
+        end
     end
 
-    # let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'amazon', version: '2.0').converge(described_recipe) }
+    context 'when on Suse' do
+        let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'suse', version: '12.5').converge(described_recipe) }
 
-    # it 'removes the Datadog Agent package'
-    #     expect(chef_run).to remove_package('datadog-agent')
-    # end
+        it 'purges the datadog-agent package' do
+            expect(chef_run).to purge_package('datadog-agent')
+        end
 
-    # it 'removes the Datadog yum repository'
-    #     expect(chef_run).to remove_yum_repository('datadog')
-    # end
+        it 'removes the datadog zypper repository' do
+            expect(chef_run).to remove_zypper_repository('datadog')
+        end
+    end
 
-    # let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'suse', version: '12.5').converge(described_recipe) }
+    context 'when on Windows' do
+        let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'windows', version: '2016').converge(described_recipe) }
 
-    # it 'removes the Datadog Agent package'
-    #     expect(chef_run).to remove_package('datadog-agent')
-    # end
-
-    # it 'removes the Datadog yum repository'
-    #     expect(chef_run).to remove_zypper_repository('datadog')
-    # end
+        it 'removes the Datadog Agent package' do
+            expect(chef_run).to remove_package('Datadog Agent')
+        end
+    end
 end


### PR DESCRIPTION
This PR fixes  #847 .

This PR also adds some tests to check that once deleting the Agent, the source file and the `datadog-signing-keys` package are also removed from the host. 