### PR TITLE
Use `chef_kitchen_apt_debian_8` as an image for `Debian-8.11`

### DIFF
--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -39,6 +39,9 @@ platforms:
   - name: debian-8.11
     driver_config:
       require_chef_omnibus: 14.12
+      # The Debian 8 (Jessie) GPG key expired on Sat Nov 19 2022 21:01:13 GMT+0000.
+      # This Docker image uses gpgv wrapper that ignores key expiration date but checks package signatures.
+      image: 'datadog/docker-library:chef_kitchen_apt_debian_8'
   - name: rocky-8
     driver_config:
       platform: rhel # kitchen-docker doesn't recognize rocky otherwise


### PR DESCRIPTION
The `dd-agent-handler5-debian-811` kitchen instance is failing to build. This is not about the code but about Debian 8 (Jessie) GPG keys that expired. Since they're not going to be renewed we patch the `apt` we're using [a new Docker Image](https://github.com/DataDog/docker-library/pull/88) with the same fix as [this PR](https://github.com/DataDog/datadog-agent-buildimages/pull/319).

This is basically ignoring the KEYEXPIRED errors while still verifying packages signatures.
