### PR TITLE
Don't use `chef_handler` cookbook for Chef >= 14

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -22,6 +22,10 @@ issues_url       'https://github.com/DataDog/chef-datadog/issues'
   supports os
 end
 
-depends    'chef_handler', '>= 1.2'
+if Chef::VERSION < Gem::Version.new(14)
+  # The chef_handler cookbook is shipped as part of Chef >= 14,
+  # so from Chef >= 14 chef_handler cookbook is deprecated.
+  depends    'chef_handler', '>= 1.2'
+end
 depends    'apt' # Use '< 6.0.0' with Chef < 12.9
 depends    'yum', '>= 3.0' # Use '< 5.0' with Chef < 12.14

--- a/metadata.rb
+++ b/metadata.rb
@@ -25,7 +25,7 @@ end
 if Chef::VERSION < Gem::Version.new(14)
   # The chef_handler cookbook is shipped as part of Chef >= 14,
   # so from Chef >= 14 chef_handler cookbook is deprecated.
-  depends    'chef_handler', '>= 1.2'
+  depends 'chef_handler', '>= 1.2'
 end
 depends    'apt' # Use '< 6.0.0' with Chef < 12.9
 depends    'yum', '>= 3.0' # Use '< 5.0' with Chef < 12.14

--- a/recipes/_install-windows.rb
+++ b/recipes/_install-windows.rb
@@ -17,7 +17,9 @@
 # limitations under the License.
 #
 
-include_recipe 'chef_handler'
+if Chef::VERSION < Gem::Version.new(14)
+  include_recipe 'chef_handler'
+end
 
 dd_agent_flavor = Chef::Datadog.agent_flavor(node)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR removes usage of `chef_handler` cookbook for Chef >= 14.

### Motivation

This was reported in issue #872 .

As it's stated on https://supermarket.chef.io/cookbooks/chef_handler:

```
The chef_handler resource from this cookbook is now shipping as part of Chef 14.
With the inclusion of this resource into Chef itself we are now deprecating this cookbook.
It will continue to function for Chef 13 users, but will not be updated.
```

So we don't need to use it anymore as it's part of Chef from version 14.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
Note: Adding GitHub labels is only possible for contributors with write access.
-->
