### PR TITLE
datadog.yaml.erb - Add agent configuration value to template

### DIFF
--- a/templates/default/datadog.yaml.erb
+++ b/templates/default/datadog.yaml.erb
@@ -94,6 +94,7 @@ agent_config = @extra_config.merge({
   log_level: node['datadog']['log_level'],
   cmd_port: node['datadog']['cmd_port'],
   GUI_port: node['datadog']['gui_port'],
+  inventories_configuration_enabled: node['datadog']['inventories_configuration_enabled'],
 
   # log agent options
   logs_enabled: node['datadog']['enable_logs_agent'],


### PR DESCRIPTION
### What does this PR do?

This pull request adds a line to the datadog.yaml.erb template that writes the 'inventories_configuration_enabled' value to the agent configuration file as detailed here [Agent Configuration](https://docs.datadoghq.com/infrastructure/list/#agent-configuration)

### Motivation

For review and troubleshooting, my company set the 'inventories_configuration_enabled' to 'true' per the documentation, but the value was never set in the datadog configuration on our nodes.  Upon review it appeared there was no corresponding template or code that applied to that attribute.

### Describe how to test/QA your changes

Using Chef Kitchen, i had local copy of our wrapper cookbook I'll call 'wrap_datadog' and my clone of Datadogs cookbook 'datadog'.  I made the documented change to my local 'datadog' cookbook.  Then in my 'wrap_datadog' cookbook, so that it used my local clone, overrode the cookbook location in my Berksfile file by adding the following line:
'cookbook "datadog", path: '/path/to/cookbook/datadog'.

i then ran kitchen converge out of the 'wrap_datadog' repo.  Once converged, i verified the attribute was written to the datadog config file.  I also verified that datadog agent config was written to the host information in the datadog console.

for verification, i removed the attribute from my 'wrap_datadog' cookbook and ran converge again.  The attribute was removed from the configuration.

