### PR TITLE
Increase runner size to prevent systematic failure in agent5-rocky8 kitchen test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ jobs:
   kitchen-docker-tests:
     machine:
       image: ubuntu-2004:202201-02
+    resource_class: large
     environment:
       CHEF_LICENSE: accept # newer versions of Chef client need explicit license accept to run
       KITCHEN_LOCAL_YAML: kitchen.docker.yml


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.
-->
### What does this PR do?
Increase the runner size for kitchen-test

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
There was a systematic failure on rocky8-agent5 execution:
```
1) Service "datadog-agent" is expected to be running
Failure/Error: it { should be_running }
expected Service "datadog-agent" to be running
env PATH="/sbin:/usr/local/sbin:$PATH" /bin/sh -c systemctl\ is-active\ datadog-agent
inactive
```
This was most probably caused by supervisord still in use during restart of the Agent
```
[root@9f7651d25b01 experiment]# source /opt/datadog-agent/bin/start_agent.sh
Error: Another program is already listening on a port that one of our HTTP servers is configured to use.  Shut this program down first before starting supervisord.
```
As it seemed related to https://github.com/DataDog/dd-agent/pull/2349 where a timer had been added because of similar issue, using more powerful runner prevent failing in this case
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
Use the "runner size increase workaround" not to investigate on Agent5 issues, accepted because activity on chef-datadog repository is not too high

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
Note: Adding GitHub labels is only possible for contributors with write access.
-->
