### PR TITLE
chore(recipe/consul): enable integration_template usage

### DIFF
--- a/recipes/consul.rb
+++ b/recipes/consul.rb
@@ -45,6 +45,7 @@ include_recipe '::dd-agent'
 datadog_monitor 'consul' do
   instances node['datadog']['consul']['instances']
   logs node['datadog']['consul']['logs']
+  use_integration_template true
   action :add
   notifies :restart, 'service[datadog-agent]' if node['datadog']['agent_start']
 end


### PR DESCRIPTION
### What does this PR do?

Enable integration template usage for consul monitoring.

### Motivation

Currently, there is no way to add custom attributes due to hard-coded values in `consul.yaml.erb`. For example, it makes impossible to use `use_prometheus_endpoint` as suggested in [consul integration example](https://app.datadoghq.com/integrations?integrationId=consul).

### Additional Notes

Solves https://github.com/DataDog/chef-datadog/issues/849

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
Note: Adding GitHub labels is only possible for contributors with write access.
-->
