### PR TITLE
Add datadog_monitor option to override the config file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,19 +320,21 @@ datadog_monitor 'name' do
   instances                         Array # default value: []
   logs                              Array # default value: []
   use_integration_template          true, false # default value: false
+  config_name                       String # default value: 'conf'
   action                            Symbol # defaults to :add
 end
 ```
 
 #### Properties
 
-| Property                   | Description                                                                                                                                                                                                                                                                                    |
-|----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `'name'`                   | The name of the Agent integration to configure and enable.                                                                                                                                                                                                                                     |
-| `instances`                | The fields used to fill values under the `instances` section in the integration configuration file.                                                                                                                                                                                            |
-| `init_config`              | The fields used to fill values under the the `init_config` section in the integration configuration file.                                                                                                                                                                                      |
-| `logs`                     | The fields used to fill values under the the `logs` section in the integration configuration file.                                                                                                                                                                                             |
+| Property                   | Description                                                                                                                                                                                                                                                                                   |
+|----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `'name'`                   | The name of the Agent integration to configure and enable.                                                                                                                                                                                                                                    |
+| `instances`                | The fields used to fill values under the `instances` section in the integration configuration file.                                                                                                                                                                                           |
+| `init_config`              | The fields used to fill values under the the `init_config` section in the integration configuration file.                                                                                                                                                                                     |
+| `logs`                     | The fields used to fill values under the the `logs` section in the integration configuration file.                                                                                                                                                                                            |
 | `use_integration_template` | Set to `true` (recommended) to use the default template, which writes the values of `instances`, `init_config`, and `logs` in the YAML under their respective keys. This defaults to `false` for backward compatibility, but may default to `true` in a future major version of the cookbook. |
+| `config_name`              | The filename used when creating an integrations configuration file. Overriding this property allows the creation of multiple configuration files for a single integration.  This defaults to `conf`, which creates a configuration file named `conf.yaml`.                                    |
 
 #### Example
 

--- a/resources/monitor.rb
+++ b/resources/monitor.rb
@@ -35,6 +35,7 @@ property :version, [Integer, nil], required: false, default: nil
 property :use_integration_template, [TrueClass, FalseClass], required: false, default: false
 property :is_jmx, [TrueClass, FalseClass], required: false, default: false
 property :logs, [Array, nil], required: false, default: []
+property :config_name, [String, nil], required: false, default: 'conf'
 
 action :add do
   Chef::Log.debug("Adding monitoring for #{new_resource.name}")
@@ -49,7 +50,7 @@ action :add do
         mode '755'
       end
     end
-    yaml_file = ::File.join(yaml_dir, "#{new_resource.name}.d", 'conf.yaml')
+    yaml_file = ::File.join(yaml_dir, "#{new_resource.name}.d", "#{new_resource.config_name}.yaml")
   else
     yaml_file = ::File.join(yaml_dir, "#{new_resource.name}.yaml")
   end
@@ -101,7 +102,7 @@ end
 
 action :remove do
   yaml_file = if Chef::Datadog.agent_major_version(node) != 5
-                ::File.join(yaml_dir, "#{new_resource.name}.d", 'conf.yaml')
+                ::File.join(yaml_dir, "#{new_resource.name}.d", "#{new_resource.config_name}.yaml")
               else
                 ::File.join(yaml_dir, "#{new_resource.name}.yaml")
               end

--- a/spec/dd-agent_spec.rb
+++ b/spec/dd-agent_spec.rb
@@ -1506,6 +1506,7 @@ describe 'test::monitor_add' do
     end
     it 'creates the config file at A7\'s path' do
       expect(chef_run).to render_file('/etc/datadog-agent/conf.d/potato.d/conf.yaml')
+      expect(chef_run).to render_file('/etc/datadog-agent/conf.d/potato.d/potato-one.yaml')
     end
   end
 end
@@ -1541,6 +1542,7 @@ describe 'test::monitor_remove' do
     end
     it 'creates the config file at A7\'s path' do
       expect(chef_run).to delete_file('/etc/datadog-agent/conf.d/potato.d/conf.yaml')
+      expect(chef_run).to delete_file('/etc/datadog-agent/conf.d/potato.d/potato-one.yaml')
     end
   end
 end

--- a/test/cookbooks/test/recipes/monitor_add.rb
+++ b/test/cookbooks/test/recipes/monitor_add.rb
@@ -15,3 +15,8 @@
 datadog_monitor 'potato' do
   action :add
 end
+
+datadog_monitor 'potato' do
+  action :add
+  config_name 'potato-one'
+end

--- a/test/cookbooks/test/recipes/monitor_remove.rb
+++ b/test/cookbooks/test/recipes/monitor_remove.rb
@@ -15,3 +15,8 @@
 datadog_monitor 'potato' do
   action :remove
 end
+
+datadog_monitor 'potato' do
+  action :remove
+  config_name 'potato-one'
+end


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.
-->
### What does this PR do?

Allows users consuming the datadog_monitor resource to select a config file name instead of just the default of conf.yaml. The default still exists but by adding this option others can call the datadog_monitor function multiple times and not override existing files.

### Motivation

This allows people to use the integration multiple times and place different config files in the same integration directory.  The use case would be many different cookbooks adding a single check they care about without doing messy attribute overrides. The use case would be the following, Cookbook A & Cookbook B are both maintained by different teams but can be used on the same host.  In the previous way of doing this you would have to add attributes in different cookbooks which can cause weird issues around attribute inheritance / ordering.  By adding this teams can more easily just create different config files that are owned by the respective cookbooks and do not step on each other. 

Cookbook A: 

```ruby
# Cookbook A

datadog_monitor 'process' do
  action :add
   <Existing configuration for the monitor>
  config_name 'datadog-agent'
end

# Cookbook B

datadog_monitor 'process' do
  action :add
   <Existing configuration for the monitor>
  config_name 'ssh'
end
```

### Additional Notes


### Possible Drawbacks / Trade-offs

I don't see too many Drawbacks, by default the existing behavior exists.  The only drawback I can think of is this does add some complexity since there can be multiple files to manage however if you manage the with this resource then the delete function has the same logic. 

### Describe how to test/QA your changes

I am not entire sure what other tests should be added which is why I made this a Draft.  The testing should be light, essentially create an integration (logs might be the easiest since it doesn't require an integration to run) and just validate that the new file is generated.  The default case should already be tested. 

### Reviewer's Checklist

- [x] Add additional tests to validate the new behavior. 
