### PR TITLE
Enable suse in install-fips-proxy-linux recipe

### DIFF
--- a/recipes/_install-fips-proxy-linux.rb
+++ b/recipes/_install-fips-proxy-linux.rb
@@ -65,15 +65,12 @@ when 'rhel', 'fedora', 'amazon'
     end
   end
 when 'suse'
-  raise 'SuSE currently unsupported for the datadog FIPS proxy.'
-
-  ## Uncomment code below once SuSE support is added for FIPS proxy
-  # zypper_package dd_fips_proxy_package_name do # ~FC009
-  #   version dd_fips_proxy_version
-  #   retries package_retries unless package_retries.nil?
-  #   retry_delay package_retry_delay unless package_retry_delay.nil?
-  #   action package_action # default is :install
-  #   # allow_downgrade is only suported for zypper_package since Chef Client 13.6
-  #   allow_downgrade node['datadog']['fips_proxy_allow_downgrade'] if respond_to?(:allow_downgrade)
-  # end
+  zypper_package dd_fips_proxy_package_name do # ~FC009
+    version dd_fips_proxy_version
+    retries package_retries unless package_retries.nil?
+    retry_delay package_retry_delay unless package_retry_delay.nil?
+    action package_action # default is :install
+    # allow_downgrade is only suported for zypper_package since Chef Client 13.6
+    allow_downgrade node['datadog']['fips_proxy_allow_downgrade'] if respond_to?(:allow_downgrade)
+  end
 end


### PR DESCRIPTION
This PR enables SuSE in the install recipe for the FIPS Proxy. This is needed for FIPS Proxy kitchen tests are we now support SuSE

Tested on the [FIPS Proxy repo](https://github.com/DataDog/fips-proxy/commit/1e0ce435de2bf8d28048c25e4e5623b1d37bc1d3) and it works as expected.