### PR TITLE
add support for CWS on Windows

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -107,6 +107,19 @@ suites:
         bpf_debug: true
         enable_conntrack: true
 
+- name: security-agent
+  run_list:
+    - recipe[datadog::dd-agent]
+  attributes:
+    datadog: &DATADOG
+      aptrepo: 'http://apt.datad0g.com'
+      aptrepo_dist: 'beta'
+      api_key: somenonnullapikeythats32charlong
+      application_key: alsonotnil
+      security_agent:
+        cws:
+          enabled: true
+
 - name: dd-handler
   run_list:
     - recipe[datadog::dd-handler]

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -167,7 +167,7 @@ system_probe_supported = (agent_version_greater_than_6_11 && !is_windows) || (ag
 include_recipe '::system-probe' if system_probe_managed && system_probe_supported
 
 # security-agent is a dependency of the agent on Linux or Windows
-include_recipe '::security-agent' unless is_windows
+include_recipe '::security-agent'
 
 # Installation metadata to let know the agent about installation method and its version
 include_recipe '::install_info'

--- a/recipes/system-probe.rb
+++ b/recipes/system-probe.rb
@@ -22,7 +22,7 @@ is_windows = platform_family?('windows')
 # Set the correct agent startup action
 cws_enabled = node['datadog']['security_agent']['cws']['enabled']
 sysprobe_enabled = if is_windows
-                     node['datadog']['system_probe']['network_enabled']
+                     node['datadog']['system_probe']['network_enabled'] || cws_enabled
                    else
                      node['datadog']['system_probe']['enabled'] || node['datadog']['system_probe']['network_enabled'] || node['datadog']['system_probe']['service_monitoring_enabled'] || cws_enabled
                    end
@@ -99,6 +99,5 @@ service 'datadog-agent-sysprobe' do
   else
     supports :restart => true, :status => true, :start => true, :stop => true
   end
-  supports :restart => true, :status => true, :start => true, :stop => true
   subscribes :restart, "template[#{system_probe_config_file}]", :delayed if sysprobe_enabled
 end

--- a/recipes/system-probe.rb
+++ b/recipes/system-probe.rb
@@ -20,12 +20,11 @@
 is_windows = platform_family?('windows')
 
 # Set the correct agent startup action
+npm_enabled = node['datadog']['system_probe']['network_enabled']
+usm_enabled = node['datadog']['system_probe']['service_monitoring_enabled']
 cws_enabled = node['datadog']['security_agent']['cws']['enabled']
-sysprobe_enabled = if is_windows
-                     node['datadog']['system_probe']['network_enabled'] || cws_enabled
-                   else
-                     node['datadog']['system_probe']['enabled'] || node['datadog']['system_probe']['network_enabled'] || node['datadog']['system_probe']['service_monitoring_enabled'] || cws_enabled
-                   end
+sysprobe_enabled = node['datadog']['system_probe']['enabled'] || npm_enabled || usm_enabled || cws_enabled
+
 sysprobe_agent_start = sysprobe_enabled && node['datadog']['agent_start'] && node['datadog']['agent_enable'] ? :start : :stop
 
 #

--- a/spec/security-agent_spec.rb
+++ b/spec/security-agent_spec.rb
@@ -69,4 +69,59 @@ describe 'datadog::security-agent' do
       })
     end
   end
+
+  context 'with CWS enabled on Windows' do
+    cached(:solo) do
+      ChefSpec::SoloRunner.new(
+        platform: 'windows',
+        version: '2012R2'
+      ) do |node|
+        node.name 'chef-nodename' # expected to be used as the hostname in `datadog.yaml`
+        node.normal['datadog'] = {
+          'api_key' => 'somethingnotnil',
+          'agent_major_version' => 6,
+          'security_agent' => {
+            'cws' => {
+              'enabled' => true,
+            }
+          },
+          'extra_config' => {
+            'security_agent' => {
+              'runtime_security_config' => {
+                'activity_dump' => {
+                  'enabled' => true,
+                }
+              }
+            }
+          }
+        }
+      end
+    end
+
+    cached(:chef_run) do
+      solo.converge(described_recipe) do
+        solo.resource_collection.insert(
+          Chef::Resource::Service.new('datadog-agent', solo.run_context))
+      end
+    end
+
+    it 'security-agent.yaml is created' do
+      expect(chef_run).to create_template('C:/ProgramData/Datadog/security-agent.yaml')
+    end
+
+    it 'security-agent.yaml contains expected YAML configuration' do
+      expected_yaml = <<-EOF
+      compliance_config:
+        enabled: false
+      runtime_security_config:
+        enabled: true
+        activity_dump:
+          enabled: true
+      EOF
+
+      expect(chef_run).to(render_file('C:/ProgramData/Datadog/security-agent.yaml').with_content { |content|
+        expect(YAML.safe_load(content).to_json).to be_json_eql(YAML.safe_load(expected_yaml).to_json)
+      })
+    end
+  end
 end


### PR DESCRIPTION
### What does this PR do?

This PR adds support for CWS on Windows. It also slightly cleans up the system probe recipe and adds a rspec test for this new support.

### Motivation

Windows agent builders use chef to install the agent, since we want to enable CWS there, we need this new support.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Use:
```
datadog:
  security_agent:
    cws:
      enabled: true
```
and check that CWS is actually enabled (this requires a custom agent build until 7.52 is released)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
Note: Adding GitHub labels is only possible for contributors with write access.
-->
