### PR TITLE
Fix CI again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ chef_version = ENV.fetch('CHEF_VERSION', '14.10.9')
 
 gem 'rake'
 gem 'rspec-expectations', '< 3.12.4'
-gem 'rspec', '~> 3.12.0'
 gem 'chef', "= #{chef_version}"
 gem 'cucumber-core', '~> 3.2.1'
 gem 'yaml'

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 chef_version = ENV.fetch('CHEF_VERSION', '14.10.9')
 
 gem 'rake'
+gem 'rspec', '~> 3.12.0'
 gem 'chef', "= #{chef_version}"
 gem 'cucumber-core', '~> 3.2.1'
 gem 'yaml'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 chef_version = ENV.fetch('CHEF_VERSION', '14.10.9')
 
 gem 'rake'
-gem 'rspec-expectations', '= 3.12.3'
+gem 'rspec-expectations', '< 3.12.4'
 gem 'rspec', '~> 3.12.0'
 gem 'chef', "= #{chef_version}"
 gem 'cucumber-core', '~> 3.2.1'

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 chef_version = ENV.fetch('CHEF_VERSION', '14.10.9')
 
 gem 'rake'
+gem 'rspec-expectations', '= 3.12.3'
 gem 'rspec', '~> 3.12.0'
 gem 'chef', "= #{chef_version}"
 gem 'cucumber-core', '~> 3.2.1'

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,10 @@ gem 'rbnacl', '~> 4.0.2'
 gem 'rbnacl-libsodium', '~> 1.0.16'
 gem 'bcrypt_pbkdf', '>= 1.0', '< 2.0'
 
+if RUBY_VERSION >= '3.0.0' && RUBY_VERSION < '3.1.0'
+  gem 'uri', '= 0.10.1'
+end
+
 if RUBY_VERSION < '2.4'
   gem 'json', '~> 2.4.1'
 end

--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -15,39 +15,16 @@ platforms:
   # and http://support.ntp.org/bin/view/Support/KnownOsIssues#Section_9.2.4.2.5.3.
   # - name: ubuntu-12.04
 
-  - name: ubuntu-14.04
-    driver_config:
-      require_chef_omnibus: 14.12
-  - name: centos-6.6
-    driver_config:
-      require_chef_omnibus: 14.12
-      image: 'datadog/docker-library:chef_kitchen_systemd_centos_6'
-      run_command: /root/start.sh
-    attributes:
-      datadog:
-        service_provider: Systemd
-  - name: centos-7.7
-    driver_config:
-      require_chef_omnibus: 14.12
-      image: 'datadog/docker-library:chef_kitchen_systemd_centos_7'
-      run_command: /root/start.sh
-  - name: centos-7.7
-    driver_config:
-      require_chef_omnibus: 16.5
-      image: 'datadog/docker-library:chef_kitchen_systemd_centos_7'
-      run_command: /root/start.sh
-  - name: debian-8.11
-    driver_config:
-      require_chef_omnibus: 14.12
-      # The Debian 8 (Jessie) GPG key expired on Sat Nov 19 2022 21:01:13 GMT+0000.
-      # This Docker image uses gpgv wrapper that ignores key expiration date but checks package signatures.
-      image: 'datadog/docker-library:chef_kitchen_apt_debian_8'
   - name: rocky-8
     driver_config:
       platform: rhel # kitchen-docker doesn't recognize rocky otherwise
       require_chef_omnibus: 16.17.4
       image: 'datadog/docker-library:chef_kitchen_systemd_rocky_8'
       run_command: /root/start.sh
+      # workaround https://github.com/chef/chef/issues/14034 which has been
+      # fixed, but only for fresh Chef versions (>= 18)
+      provision_command:
+        - echo "CentOS Linux release 8" > /etc/redhat-release
 
 suites:
 <%

--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -15,6 +15,33 @@ platforms:
   # and http://support.ntp.org/bin/view/Support/KnownOsIssues#Section_9.2.4.2.5.3.
   # - name: ubuntu-12.04
 
+  - name: ubuntu-14.04
+    driver_config:
+      require_chef_omnibus: 14.12
+  - name: centos-6.6
+    driver_config:
+      require_chef_omnibus: 14.12
+      image: 'datadog/docker-library:chef_kitchen_systemd_centos_6'
+      run_command: /root/start.sh
+    attributes:
+      datadog:
+        service_provider: Systemd
+  - name: centos-7.7
+    driver_config:
+      require_chef_omnibus: 14.12
+      image: 'datadog/docker-library:chef_kitchen_systemd_centos_7'
+      run_command: /root/start.sh
+  - name: centos-7.7
+    driver_config:
+      require_chef_omnibus: 16.5
+      image: 'datadog/docker-library:chef_kitchen_systemd_centos_7'
+      run_command: /root/start.sh
+  - name: debian-8.11
+    driver_config:
+      require_chef_omnibus: 14.12
+      # The Debian 8 (Jessie) GPG key expired on Sat Nov 19 2022 21:01:13 GMT+0000.
+      # This Docker image uses gpgv wrapper that ignores key expiration date but checks package signatures.
+      image: 'datadog/docker-library:chef_kitchen_apt_debian_8'
   - name: rocky-8
     driver_config:
       platform: rhel # kitchen-docker doesn't recognize rocky otherwise

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -159,6 +159,7 @@ end
 system_probe_managed = node['datadog']['system_probe']['manage_config']
 agent_version_greater_than_6_11 = agent_major_version > 5 && (agent_minor_version.nil? || agent_minor_version > 11) || agent_major_version > 6
 agent_version_greater_than_6_26 = agent_major_version > 5 && (agent_minor_version.nil? || agent_minor_version > 26)
+agent_version_greater_than_6_49 = agent_major_version > 5 && (agent_minor_version.nil? || agent_minor_version > 49)
 
 # System probe requires at least agent 6.12 on Linux or 6.27 on Windows, before that it was called the network-tracer or unsupported.
 system_probe_supported = (agent_version_greater_than_6_11 && !is_windows) || (agent_version_greater_than_6_26 && is_windows)
@@ -166,8 +167,11 @@ system_probe_supported = (agent_version_greater_than_6_11 && !is_windows) || (ag
 # system-probe is a dependency of the agent on Linux or Windows
 include_recipe '::system-probe' if system_probe_managed && system_probe_supported
 
+# Security Agent requires at least agent 6.27 on Linux or 6.50 on Windows, before that it was unsupported.
+security_agent_supported = (agent_version_greater_than_6_26 && !is_windows) || (agent_version_greater_than_6_49 && is_windows)
+
 # security-agent is a dependency of the agent on Linux or Windows
-include_recipe '::security-agent'
+include_recipe '::security-agent' && security_agent_supported
 
 # Installation metadata to let know the agent about installation method and its version
 include_recipe '::install_info'

--- a/recipes/dd-agent.rb
+++ b/recipes/dd-agent.rb
@@ -168,10 +168,11 @@ system_probe_supported = (agent_version_greater_than_6_11 && !is_windows) || (ag
 include_recipe '::system-probe' if system_probe_managed && system_probe_supported
 
 # Security Agent requires at least agent 6.27 on Linux or 6.50 on Windows, before that it was unsupported.
+security_agent_managed = node['datadog']['security_agent']['cws']['enabled'] || (!is_windows && node['datadog']['security_agent']['cspm']['enabled'])
 security_agent_supported = (agent_version_greater_than_6_26 && !is_windows) || (agent_version_greater_than_6_49 && is_windows)
 
 # security-agent is a dependency of the agent on Linux or Windows
-include_recipe '::security-agent' && security_agent_supported
+include_recipe '::security-agent' if security_agent_managed && security_agent_supported
 
 # Installation metadata to let know the agent about installation method and its version
 include_recipe '::install_info'

--- a/recipes/security-agent.rb
+++ b/recipes/security-agent.rb
@@ -30,7 +30,6 @@ security_agent_config_file =
   else
     '/etc/datadog-agent/security-agent.yaml'
   end
-security_agent_config_file_exists = ::File.exist?(security_agent_config_file)
 
 template security_agent_config_file do
   runtime_security_extra_config = {}

--- a/recipes/security-agent.rb
+++ b/recipes/security-agent.rb
@@ -20,8 +20,7 @@
 is_windows = platform_family?('windows')
 
 # Set the correct agent startup action
-security_agent_enabled = node['datadog']['security_agent']['cws']['enabled'] || (!is_windows && node['datadog']['security_agent']['cspm']['enabled'])
-security_agent_start = security_agent_enabled && node['datadog']['agent_start'] && node['datadog']['agent_enable'] ? :start : :stop
+security_agent_start = node['datadog']['agent_start'] && node['datadog']['agent_enable'] ? :start : :stop
 
 #
 # Configures security-agent agent
@@ -64,10 +63,7 @@ template security_agent_config_file do
     mode '640'
   end
 
-  notifies :restart, 'service[datadog-agent-security]', :delayed if security_agent_enabled
-
-  # Security agent is not enabled and the file doesn't exists, don't create it
-  not_if { !security_agent_enabled && !security_agent_config_file_exists }
+  notifies :restart, 'service[datadog-agent-security]', :delayed
 end
 
 # Common configuration
@@ -86,5 +82,5 @@ service 'datadog-agent-security' do
   else
     supports :restart => true, :status => true, :start => true, :stop => true
   end
-  subscribes :restart, "template[#{security_agent_config_file}]", :delayed if security_agent_enabled
+  subscribes :restart, "template[#{security_agent_config_file}]", :delayed
 end


### PR DESCRIPTION
### What does this PR do?

* Pins `rspec-expectations` and `uri` gems to fix compatibility with various legacy versions of Ruby/Chefspec.
* Makes the Rocky image pretend to be CentOS. A recent change to `https://omnitruck.chef.io/install.sh` (which is downloaded by kitchen before running the actual test) made Rocky to be recognized as `rocky`, not `el`. The script later tries to download file `https://omnitruck.chef.io/stable/chef/metadata?v=16.17.4&p=rocky&pv=8&m=x86_64` (`rocky` is the platform passed to it) - these metadata files don't exist for Rocky for old Chef versions, even though this has been fix for newer versions of Chef as per https://github.com/chef/omnitruck/issues/600
* Fixes the conditions on when we include the security-agent recipe