### PR TITLE
Adding support for datadog-fips-agent flavor #942

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ By default, the current major version of this cookbook installs Agent v7. The fo
 | `agent_major_version`  | Pin the major version of the Agent to 5, 6, or 7 (default).                                                                                                                         |
 | `agent_version`        | Pin a specific Agent version (recommended).                                                                                                                                         |
 | `agent_package_action` | (Linux only) Defaults to `'install'` (recommended), `'upgrade'` to get automatic Agent updates (not recommended, use the default and change the pinned `agent_version` to upgrade). |
-| `agent_flavor` | (Linux only) Defaults to `'datadog-agent'` to install the datadog-agent, can be set to `'datadog-iot-agent'` to install the IOT agent. |
+| `agent_flavor` | (Linux only) Defaults to `'datadog-agent'` to install the datadog-agent, can be set to `'datadog-iot-agent'` to install the IOT agent and `'datadog-fips-agent'` |
 
 See the sample [attributes/default.rb][1] for your cookbook version for all available attributes.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,7 +40,7 @@ default['datadog']['agent_major_version'] = nil # nil to autodetect based on 'ag
 # Example:
 # default['datadog']['agent_version'] = '7.16.0'
 default['datadog']['agent_version'] = nil # nil to install latest
-# Agent flavor to install, acceptable values are "datadog-agent", "datadog-iot-agent"
+# Agent flavor to install, acceptable values are "datadog-agent", "datadog-iot-agent", "datadog-fips-agent"
 default['datadog']['agent_flavor'] = 'datadog-agent' # "datadog-agent" to install the datadog-agent package
 default['datadog']['fips_proxy_version'] = nil
 # Datadog FIPS proxy package name:

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -18,6 +18,7 @@ class Chef
     class << self
       ACCEPTABLE_AGENT_FLAVORS = %w[
         datadog-agent
+        datadog-fips-agent
         datadog-iot-agent
       ].freeze
 


### PR DESCRIPTION
The goal of this PR is to add support for the `datadog-fips-agent` flavor #942.

This should allow the `datadog-fips-agent` to be installed in place of `datadog-agent` with relevant documentation updated.