### PR TITLE
Ignore error `Unable to validate API Key` in agent info output

### DIFF
--- a/test/integration/dd-agent-handler5/serverspec_datadog/dd-agent_spec.rb
+++ b/test/integration/dd-agent-handler5/serverspec_datadog/dd-agent_spec.rb
@@ -24,7 +24,7 @@ end
 
 # On Linux kernel >= 5.5, Agent 5 disk check fails because of old psutil version, which doesn't have fix
 # https://github.com/giampaolo/psutil/commit/2e0952e939d6ab517449314876d8d3488ba5b98b
-describe command('/etc/init.d/datadog-agent info | grep -v "API Key is invalid" | grep -v "not sure how to interpret line"'), :if => os[:family] != 'windows' do
+describe command('/etc/init.d/datadog-agent info | grep -v "API Key is invalid" | grep -v "not sure how to interpret line" | egrep -v "Unable to validate API Key. Please try again later"'), :if => os[:family] != 'windows' do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should contain 'OK' }
   its(:stdout) { should_not contain 'ERROR' }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.
-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fixing CI failure appering in https://github.com/DataDog/chef-datadog/pull/959, https://github.com/DataDog/chef-datadog/pull/958, etc.
```
       Failures:
       
         1) Command "/etc/init.d/datadog-agent info | grep -v "API Key is invalid" | grep -v "not sure how to interpret line"" stdout is expected not to contain "ERROR"
            Failure/Error: its(:stdout) { should_not contain 'ERROR' }
              expected "====================\nCollector (v 5.32.9)\n====================\n\n  Status date: 2025-10-03 14:38:...bytes\n  Stats: 0 payloads, 0 stats buckets, 0 bytes\n  Services: 0 payloads, 0 services, 0 bytes\n" not to contain "ERROR"
              
            # /tmp/verifier/suites/serverspec_datadog/dd-agent_spec.rb:30:in `block (2 levels) in <top (required)>'
       
       Finished in 1.05 seconds (files took 0.26317 seconds to load)
       13 examples, 1 failure
```

Most likely root cause is API response error code change from 403 to 401 handled [here](https://github.com/DataDog/dd-agent/blob/master/checks/check_status.py#L146-L154)(?). Elsewhere in test output we see these lines 

```
# last successful run
       Running handlers:
       [2025-04-17T22:02:32+00:00] WARN: Could not determine whether chef run metrics were successfully submitted to Datadog. Error:
       Response Content-Type is not application/json but is text/html: <!DOCTYPE html>\..         <h2>403 - Forbidden!</h2>\n        <ul>\n                   <li id='live_status' class='hid....y>\n</html>
# failed run
       Running handlers:
       [2025-10-03T15:12:43+00:00] WARN: Could not determine whether chef run metrics were successfully submitted to Datadog. Error:
       Response Content-Type is not application/json but is text/plain: Invalid API Key
       [2025-10-03T15:12:43+00:00] WARN: Could not determine whether Chef event was successfully submitted to Datadog: . Error:
       Response Content-Type is not application/json but is text/plain: Invalid API Key
       [2025-10-03T15:12:43+00:00] WARN: Could not submit ["env:_default"] tags for dd-agent-gpgcheck-older-centos-77 to Datadog: ["401", {"errors"=>["Unauthorized"]}]
```

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
Note: Adding GitHub labels is only possible for contributors with write access.
-->
