### PR TITLE
Add local_wheel parameter to integration resource, and fixing integration resource for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ end
 - `'name'`: The name of the Agent integration to install, for example: `datadog-apache`.
 - `version`: The version of the integration to install (only required with the `:install` action).
 - `third_party`: Set to false if installing a Datadog integration, true otherwise. Available for Datadog Agents version 6.21/7.21 and higher only.
+- `local_wheel`: Optional path to the local wheel file of the Datadog integration for installation, instead of online installation.
 
 ##### Example
 

--- a/resources/integration.rb
+++ b/resources/integration.rb
@@ -74,7 +74,7 @@ end
 def agent_exe_filepath
   if platform_family?('windows')
     # This will use the definition of the Service in the machine registry
-    registry_get_values('HKLM\\SYSTEM\\CurrentControlSet\\Services\\DatadogAgent').select { |v| v[:name] == "ImagePath" }.first[:data].gsub('"', '').sub(/\.exe/i, '')
+    registry_get_values('HKLM\\SYSTEM\\CurrentControlSet\\Services\\DatadogAgent').select { |v| v[:name] == "ImagePath" }.first[:data].gsub('"', '')
   else
     '/opt/datadog-agent/bin/agent/agent'
   end

--- a/resources/integration.rb
+++ b/resources/integration.rb
@@ -40,6 +40,12 @@ action :install do
   Chef::Log.debug("Getting integration #{new_resource.property_name}")
 
   install_params = if new_resource.local_wheel
+                     unless ::File.exist?(new_resource.local_wheel)
+                      error_message = "The local_wheel value \"#{new_resource.local_wheel}\" file not found"
+                      Chef::Log.fatal(error_message)
+                      raise error_message
+                     end
+
                      # The Agent cannot perform any verification on local wheels.
                      "--local-wheel \"#{new_resource.local_wheel}\""
                    else

--- a/resources/integration.rb
+++ b/resources/integration.rb
@@ -41,12 +41,12 @@ action :install do
 
   
   install_params = if new_resource.local_wheel
-    # The Agent cannot perform any verification on local wheels.
-    "--local-wheel #{new_resource.local_wheel}"
-  else
-    # Space at the end of '--third-party ' is intentional, so that if --third-party is not specified, no additional space is added to the command line
-    "#{'--third-party ' if new_resource.third_party}#{new_resource.property_name}==#{new_resource.version}"
-  end
+                     # The Agent cannot perform any verification on local wheels.
+                     "--local-wheel #{new_resource.local_wheel}"
+                   else
+                     # Space at the end of '--third-party ' is intentional, so that if --third-party is not specified, no additional space is added to the command line
+                     "#{'--third-party ' if new_resource.third_party}#{new_resource.property_name}==#{new_resource.version}"
+                   end
 
   execute 'integration install' do
     command   "#{agent_exe_filepath} integration install #{install_params}"

--- a/resources/integration.rb
+++ b/resources/integration.rb
@@ -49,11 +49,11 @@ action :install do
   end
 
   execute 'integration install' do
-    command   "#{agent_exe_filepath} integration install #{install_params}"
+    command   "\"#{agent_exe_filepath}\" integration install #{install_params}"
     user      'dd-agent' unless platform_family?('windows')
 
     not_if {
-      output = shell_out("#{agent_exe_filepath} integration show -q #{new_resource.property_name}").stdout
+      output = shell_out("\"#{agent_exe_filepath}\" integration show -q #{new_resource.property_name}").stdout
       output.strip == new_resource.version
     }
     notifies :restart, 'service[datadog-agent]' if node['datadog']['agent_start']
@@ -69,11 +69,11 @@ action :remove do
   Chef::Log.debug("Removing integration #{new_resource.property_name}")
 
   execute 'integration remove' do
-    command   "#{agent_exe_filepath} integration remove #{new_resource.property_name}"
+    command   "\"#{agent_exe_filepath}\" integration remove #{new_resource.property_name}"
     user      'dd-agent' unless platform_family?('windows')
 
     not_if {
-      output = shell_out("#{agent_exe_filepath} integration show -q #{new_resource.property_name}").stdout
+      output = shell_out("\"#{agent_exe_filepath}\" integration show -q #{new_resource.property_name}").stdout
       output.strip.empty?
     }
     notifies :restart, 'service[datadog-agent]' if node['datadog']['agent_start']

--- a/resources/integration.rb
+++ b/resources/integration.rb
@@ -49,11 +49,11 @@ action :install do
   end
 
   execute 'integration install' do
-    command   "\"#{agent_exe_filepath}\" integration install #{install_params}"
+    command   "#{agent_exe_filepath} integration install #{install_params}"
     user      'dd-agent' unless platform_family?('windows')
 
     not_if {
-      output = shell_out("\"#{agent_exe_filepath}\" integration show -q #{new_resource.property_name}").stdout
+      output = shell_out("#{agent_exe_filepath} integration show -q #{new_resource.property_name}").stdout
       output.strip == new_resource.version
     }
     notifies :restart, 'service[datadog-agent]' if node['datadog']['agent_start']
@@ -69,11 +69,11 @@ action :remove do
   Chef::Log.debug("Removing integration #{new_resource.property_name}")
 
   execute 'integration remove' do
-    command   "\"#{agent_exe_filepath}\" integration remove #{new_resource.property_name}"
+    command   "#{agent_exe_filepath} integration remove #{new_resource.property_name}"
     user      'dd-agent' unless platform_family?('windows')
 
     not_if {
-      output = shell_out("\"#{agent_exe_filepath}\" integration show -q #{new_resource.property_name}").stdout
+      output = shell_out("#{agent_exe_filepath} integration show -q #{new_resource.property_name}").stdout
       output.strip.empty?
     }
     notifies :restart, 'service[datadog-agent]' if node['datadog']['agent_start']
@@ -82,8 +82,8 @@ end
 
 def agent_exe_filepath
   if platform_family?('windows')
-    # This will use the definition of the Service in the machine registry
-    registry_get_values('HKLM\\SYSTEM\\CurrentControlSet\\Services\\DatadogAgent').select { |v| v[:name] == 'ImagePath' }.first[:data].gsub('"','')
+    # This will use the definition of the Service in the machine registry, which is wrapped in quotes for the space in path issue.
+    registry_get_values('HKLM\\SYSTEM\\CurrentControlSet\\Services\\DatadogAgent').select { |v| v[:name] == 'ImagePath' }.first[:data]
   else
     '/opt/datadog-agent/bin/agent/agent'
   end

--- a/resources/integration.rb
+++ b/resources/integration.rb
@@ -40,11 +40,11 @@ action :install do
 
   execute 'integration install' do
     # Space at the end of '--third-party ' is intentional, so that if --third-party is not specified, no additional space is added to the command line
-    command   "\"#{agent_exe_filepath}\" integration install #{'--third-party ' if new_resource.third_party}#{new_resource.property_name}==#{new_resource.version}"
+    command   "#{agent_exe_filepath} integration install #{'--third-party ' if new_resource.third_party}#{new_resource.property_name}==#{new_resource.version}"
     user      'dd-agent' unless platform_family?('windows')
 
     not_if {
-      output = shell_out("\"#{agent_exe_filepath}\" integration show -q #{new_resource.property_name}").stdout
+      output = shell_out("#{agent_exe_filepath} integration show -q #{new_resource.property_name}").stdout
       output.strip == new_resource.version
     }
     notifies :restart, 'service[datadog-agent]' if node['datadog']['agent_start']
@@ -60,7 +60,7 @@ action :remove do
   Chef::Log.debug("Removing integration #{new_resource.property_name}")
 
   execute 'integration remove' do
-    command   "\"#{agent_exe_filepath}\" integration remove #{new_resource.property_name}"
+    command   "#{agent_exe_filepath} integration remove #{new_resource.property_name}"
     user      'dd-agent' unless platform_family?('windows')
 
     not_if {
@@ -74,7 +74,7 @@ end
 def agent_exe_filepath
   if platform_family?('windows')
     # This will use the definition of the Service in the machine registry
-    registry_get_values('HKLM\\SYSTEM\\CurrentControlSet\\Services\\DatadogAgent').select { |v| v[:name] == 'ImagePath' }.first[:data].gsub('"', '')
+    registry_get_values('HKLM\\SYSTEM\\CurrentControlSet\\Services\\DatadogAgent').select { |v| v[:name] == 'ImagePath' }.first[:data]
   else
     '/opt/datadog-agent/bin/agent/agent'
   end

--- a/resources/integration.rb
+++ b/resources/integration.rb
@@ -44,7 +44,7 @@ action :install do
     user      'dd-agent' unless platform_family?('windows')
 
     not_if {
-      output = shell_out("#{agent_exe_filepath} integration show -q #{new_resource.property_name}").stdout
+      output = shell_out("\"#{agent_exe_filepath}\" integration show -q #{new_resource.property_name}").stdout 
       output.strip == new_resource.version
     }
     notifies :restart, 'service[datadog-agent]' if node['datadog']['agent_start']
@@ -73,9 +73,8 @@ end
 
 def agent_exe_filepath
   if platform_family?('windows')
-    # The Windows Agent will always be setup in this path if the _install-windows.rb
-    # has been used to install it.
-    "C:\\Program\ Files\\Datadog\\Datadog\ Agent\\embedded\\agent.exe"
+    # This will use the definition of the Service in the machine registry
+    registry_get_values('HKLM\\SYSTEM\\CurrentControlSet\\Services\\DatadogAgent').select { |v| v[:name] == "ImagePath" }.first[:data].gsub('"', '').sub(/\.exe/i, '')
   else
     '/opt/datadog-agent/bin/agent/agent'
   end

--- a/resources/integration.rb
+++ b/resources/integration.rb
@@ -29,6 +29,7 @@ default_action :install
 property :property_name, String, name_property: true
 property :version, String, required: true
 property :third_party, [true, false], required: false, default: false
+property :local_wheel, String, required: false
 
 action :install do
   if Chef::Datadog.agent_major_version(node) == 5
@@ -38,9 +39,17 @@ action :install do
 
   Chef::Log.debug("Getting integration #{new_resource.property_name}")
 
-  execute 'integration install' do
+  
+  install_params = if new_resource.local_wheel
+    # The Agent cannot perform any verification on local wheels.
+    "--local-wheel #{new_resource.local_wheel}"
+  else
     # Space at the end of '--third-party ' is intentional, so that if --third-party is not specified, no additional space is added to the command line
-    command   "#{agent_exe_filepath} integration install #{'--third-party ' if new_resource.third_party}#{new_resource.property_name}==#{new_resource.version}"
+    "#{'--third-party ' if new_resource.third_party}#{new_resource.property_name}==#{new_resource.version}"
+  end
+
+  execute 'integration install' do
+    command   "#{agent_exe_filepath} integration install #{install_params}"
     user      'dd-agent' unless platform_family?('windows')
 
     not_if {

--- a/resources/integration.rb
+++ b/resources/integration.rb
@@ -83,7 +83,7 @@ end
 def agent_exe_filepath
   if platform_family?('windows')
     # This will use the definition of the Service in the machine registry
-    registry_get_values('HKLM\\SYSTEM\\CurrentControlSet\\Services\\DatadogAgent').select { |v| v[:name] == 'ImagePath' }.first[:data]
+    registry_get_values('HKLM\\SYSTEM\\CurrentControlSet\\Services\\DatadogAgent').select { |v| v[:name] == 'ImagePath' }.first[:data].gsub('"','')
   else
     '/opt/datadog-agent/bin/agent/agent'
   end

--- a/resources/integration.rb
+++ b/resources/integration.rb
@@ -39,7 +39,6 @@ action :install do
 
   Chef::Log.debug("Getting integration #{new_resource.property_name}")
 
-
   install_params = if new_resource.local_wheel
                      # The Agent cannot perform any verification on local wheels.
                      "--local-wheel #{new_resource.local_wheel}"

--- a/resources/integration.rb
+++ b/resources/integration.rb
@@ -41,9 +41,9 @@ action :install do
 
   install_params = if new_resource.local_wheel
                      unless ::File.exist?(new_resource.local_wheel)
-                      error_message = "The local_wheel value \"#{new_resource.local_wheel}\" file not found"
-                      Chef::Log.fatal(error_message)
-                      raise error_message
+                       error_message = "The local_wheel value \"#{new_resource.local_wheel}\" file not found"
+                       Chef::Log.fatal(error_message)
+                       raise error_message
                      end
 
                      # The Agent cannot perform any verification on local wheels.

--- a/resources/integration.rb
+++ b/resources/integration.rb
@@ -41,7 +41,7 @@ action :install do
 
   install_params = if new_resource.local_wheel
                      # The Agent cannot perform any verification on local wheels.
-                     "--local-wheel #{new_resource.local_wheel}"
+                     "--local-wheel \"#{new_resource.local_wheel}\""
                    else
                      # Space at the end of '--third-party ' is intentional, so that if --third-party is not specified, no additional space is added to the command line
                      "#{'--third-party ' if new_resource.third_party}#{new_resource.property_name}==#{new_resource.version}"

--- a/resources/integration.rb
+++ b/resources/integration.rb
@@ -44,7 +44,7 @@ action :install do
     user      'dd-agent' unless platform_family?('windows')
 
     not_if {
-      output = shell_out("\"#{agent_exe_filepath}\" integration show -q #{new_resource.property_name}").stdout 
+      output = shell_out("\"#{agent_exe_filepath}\" integration show -q #{new_resource.property_name}").stdout
       output.strip == new_resource.version
     }
     notifies :restart, 'service[datadog-agent]' if node['datadog']['agent_start']
@@ -74,7 +74,7 @@ end
 def agent_exe_filepath
   if platform_family?('windows')
     # This will use the definition of the Service in the machine registry
-    registry_get_values('HKLM\\SYSTEM\\CurrentControlSet\\Services\\DatadogAgent').select { |v| v[:name] == "ImagePath" }.first[:data].gsub('"', '')
+    registry_get_values('HKLM\\SYSTEM\\CurrentControlSet\\Services\\DatadogAgent').select { |v| v[:name] == 'ImagePath' }.first[:data].gsub('"', '')
   else
     '/opt/datadog-agent/bin/agent/agent'
   end

--- a/resources/integration.rb
+++ b/resources/integration.rb
@@ -39,7 +39,7 @@ action :install do
 
   Chef::Log.debug("Getting integration #{new_resource.property_name}")
 
-  
+
   install_params = if new_resource.local_wheel
                      # The Agent cannot perform any verification on local wheels.
                      "--local-wheel #{new_resource.local_wheel}"

--- a/spec/integrations/integration_spec.rb
+++ b/spec/integrations/integration_spec.rb
@@ -76,7 +76,7 @@ describe 'datadog_integration' do
   context 'with local wheel file integration that is not installed' do
     before do
       allow(File).to receive(:exist?).and_call_original
-      allow(File).to receive(:exist?).with("/path/to/foo-bar.whl").and_return(true)
+      allow(File).to receive(:exist?).with('/path/to/foo-bar.whl').and_return(true)
     end
     stubs_for_resource('execute[integration install]') do |resource|
       allow(resource).to receive_shell_out('/opt/datadog-agent/bin/agent/agent integration show -q foo-bar')
@@ -93,7 +93,7 @@ describe 'datadog_integration' do
   context 'with local wheel file integration that is already installed' do
     before do
       allow(File).to receive(:exist?).and_call_original
-      allow(File).to receive(:exist?).with("/path/to/foo-bar.whl").and_return(true)
+      allow(File).to receive(:exist?).with('/path/to/foo-bar.whl').and_return(true)
     end
     stubs_for_resource('execute[integration install]') do |resource|
       allow(resource).to receive_shell_out('/opt/datadog-agent/bin/agent/agent integration show -q foo-bar')
@@ -111,7 +111,7 @@ describe 'datadog_integration' do
   context 'with local wheel file integration that is installed with an older version' do
     before do
       allow(File).to receive(:exist?).and_call_original
-      allow(File).to receive(:exist?).with("/path/to/foo-bar.whl").and_return(true)
+      allow(File).to receive(:exist?).with('/path/to/foo-bar.whl').and_return(true)
     end
     stubs_for_resource('execute[integration install]') do |resource|
       allow(resource).to receive_shell_out('/opt/datadog-agent/bin/agent/agent integration show -q foo-bar')

--- a/spec/integrations/integration_spec.rb
+++ b/spec/integrations/integration_spec.rb
@@ -72,4 +72,46 @@ describe 'datadog_integration' do
     end
     it { is_expected.to run_execute('integration install').with(command: '"/opt/datadog-agent/bin/agent/agent" integration install --third-party foo-bar==1.0.0') }
   end
+
+  context 'with local wheel file integration that is not installed' do
+    stubs_for_resource('execute[integration install]') do |resource|
+      allow(resource).to receive_shell_out('/opt/datadog-agent/bin/agent/agent integration show -q foo-bar')
+    end
+    recipe do
+      datadog_integration 'foo-bar' do
+        version '1.0.0'
+        local_wheel '/path/to/foo-bar.whl'
+      end
+    end
+    it { is_expected.to run_execute('integration install').with(command: '"/opt/datadog-agent/bin/agent/agent" integration install --local-wheel /path/to/foo-bar.whl') }
+  end
+
+  context 'with local wheel file integration that is already installed' do
+    stubs_for_resource('execute[integration install]') do |resource|
+      allow(resource).to receive_shell_out('/opt/datadog-agent/bin/agent/agent integration show -q foo-bar')
+        .and_return(Mock::ShellCommandResult.new('1.0.0'))
+    end
+    recipe do
+      datadog_integration 'foo-bar' do
+        version '1.0.0'
+        local_wheel '/path/to/foo-bar.whl'
+      end
+    end
+    it { is_expected.not_to run_execute('integration install') }
+  end
+
+  context 'with local wheel file integration that is installed with an older version' do
+    stubs_for_resource('execute[integration install]') do |resource|
+      allow(resource).to receive_shell_out('/opt/datadog-agent/bin/agent/agent integration show -q foo-bar')
+        .and_return(Mock::ShellCommandResult.new('0.9.0'))
+    end
+    recipe do
+      datadog_integration 'foo-bar' do
+        version '1.0.0'
+        local_wheel '/path/to/foo-bar.whl'
+      end
+    end
+    it { is_expected.to run_execute('integration install').with(command: '"/opt/datadog-agent/bin/agent/agent" integration install --local-wheel /path/to/foo-bar.whl') }
+  end
+
 end

--- a/spec/integrations/integration_spec.rb
+++ b/spec/integrations/integration_spec.rb
@@ -91,6 +91,10 @@ describe 'datadog_integration' do
   end
 
   context 'with local wheel file integration that is already installed' do
+    before do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with("/path/to/foo-bar.whl").and_return(true)
+    end
     stubs_for_resource('execute[integration install]') do |resource|
       allow(resource).to receive_shell_out('/opt/datadog-agent/bin/agent/agent integration show -q foo-bar')
         .and_return(Mock::ShellCommandResult.new('1.0.0'))

--- a/spec/integrations/integration_spec.rb
+++ b/spec/integrations/integration_spec.rb
@@ -29,7 +29,7 @@ describe 'datadog_integration' do
         version '1.0.0'
       end
     end
-    it { is_expected.to run_execute('integration install').with(command: '"/opt/datadog-agent/bin/agent/agent" integration install datadog-foobar==1.0.0') }
+    it { is_expected.to run_execute('integration install').with(command: '/opt/datadog-agent/bin/agent/agent integration install datadog-foobar==1.0.0') }
   end
 
   context 'with third party integration that is not installed' do
@@ -42,7 +42,7 @@ describe 'datadog_integration' do
         third_party true
       end
     end
-    it { is_expected.to run_execute('integration install').with(command: '"/opt/datadog-agent/bin/agent/agent" integration install --third-party foo-bar==1.0.0') }
+    it { is_expected.to run_execute('integration install').with(command: '/opt/datadog-agent/bin/agent/agent integration install --third-party foo-bar==1.0.0') }
   end
 
   context 'with third party integration that is already installed' do
@@ -70,7 +70,7 @@ describe 'datadog_integration' do
         third_party true
       end
     end
-    it { is_expected.to run_execute('integration install').with(command: '"/opt/datadog-agent/bin/agent/agent" integration install --third-party foo-bar==1.0.0') }
+    it { is_expected.to run_execute('integration install').with(command: '/opt/datadog-agent/bin/agent/agent integration install --third-party foo-bar==1.0.0') }
   end
 
   context 'with local wheel file integration that is not installed' do
@@ -83,7 +83,7 @@ describe 'datadog_integration' do
         local_wheel '/path/to/foo-bar.whl'
       end
     end
-    it { is_expected.to run_execute('integration install').with(command: '"/opt/datadog-agent/bin/agent/agent" integration install --local-wheel /path/to/foo-bar.whl') }
+    it { is_expected.to run_execute('integration install').with(command: '/opt/datadog-agent/bin/agent/agent integration install --local-wheel /path/to/foo-bar.whl') }
   end
 
   context 'with local wheel file integration that is already installed' do
@@ -111,7 +111,7 @@ describe 'datadog_integration' do
         local_wheel '/path/to/foo-bar.whl'
       end
     end
-    it { is_expected.to run_execute('integration install').with(command: '"/opt/datadog-agent/bin/agent/agent" integration install --local-wheel /path/to/foo-bar.whl') }
+    it { is_expected.to run_execute('integration install').with(command: '/opt/datadog-agent/bin/agent/agent integration install --local-wheel /path/to/foo-bar.whl') }
   end
 
 end

--- a/spec/integrations/integration_spec.rb
+++ b/spec/integrations/integration_spec.rb
@@ -76,6 +76,8 @@ describe 'datadog_integration' do
   context 'with local wheel file integration that is not installed' do
     stubs_for_resource('execute[integration install]') do |resource|
       allow(resource).to receive_shell_out('/opt/datadog-agent/bin/agent/agent integration show -q foo-bar')
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with("/path/to/foo-bar.whl").and_return(true)
     end
     recipe do
       datadog_integration 'foo-bar' do
@@ -104,6 +106,8 @@ describe 'datadog_integration' do
     stubs_for_resource('execute[integration install]') do |resource|
       allow(resource).to receive_shell_out('/opt/datadog-agent/bin/agent/agent integration show -q foo-bar')
         .and_return(Mock::ShellCommandResult.new('0.9.0'))
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with("/path/to/foo-bar.whl").and_return(true)
     end
     recipe do
       datadog_integration 'foo-bar' do

--- a/spec/integrations/integration_spec.rb
+++ b/spec/integrations/integration_spec.rb
@@ -74,10 +74,12 @@ describe 'datadog_integration' do
   end
 
   context 'with local wheel file integration that is not installed' do
-    stubs_for_resource('execute[integration install]') do |resource|
-      allow(resource).to receive_shell_out('/opt/datadog-agent/bin/agent/agent integration show -q foo-bar')
+    before do
       allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?).with("/path/to/foo-bar.whl").and_return(true)
+    end
+    stubs_for_resource('execute[integration install]') do |resource|
+      allow(resource).to receive_shell_out('/opt/datadog-agent/bin/agent/agent integration show -q foo-bar')
     end
     recipe do
       datadog_integration 'foo-bar' do
@@ -103,11 +105,13 @@ describe 'datadog_integration' do
   end
 
   context 'with local wheel file integration that is installed with an older version' do
+    before do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with("/path/to/foo-bar.whl").and_return(true)
+    end
     stubs_for_resource('execute[integration install]') do |resource|
       allow(resource).to receive_shell_out('/opt/datadog-agent/bin/agent/agent integration show -q foo-bar')
         .and_return(Mock::ShellCommandResult.new('0.9.0'))
-      allow(File).to receive(:exist?).and_call_original
-      allow(File).to receive(:exist?).with("/path/to/foo-bar.whl").and_return(true)
     end
     recipe do
       datadog_integration 'foo-bar' do

--- a/spec/integrations/integration_spec.rb
+++ b/spec/integrations/integration_spec.rb
@@ -113,5 +113,4 @@ describe 'datadog_integration' do
     end
     it { is_expected.to run_execute('integration install').with(command: '/opt/datadog-agent/bin/agent/agent integration install --local-wheel /path/to/foo-bar.whl') }
   end
-
 end

--- a/spec/integrations/integration_spec.rb
+++ b/spec/integrations/integration_spec.rb
@@ -83,7 +83,7 @@ describe 'datadog_integration' do
         local_wheel '/path/to/foo-bar.whl'
       end
     end
-    it { is_expected.to run_execute('integration install').with(command: '/opt/datadog-agent/bin/agent/agent integration install --local-wheel /path/to/foo-bar.whl') }
+    it { is_expected.to run_execute('integration install').with(command: '/opt/datadog-agent/bin/agent/agent integration install --local-wheel "/path/to/foo-bar.whl"') }
   end
 
   context 'with local wheel file integration that is already installed' do
@@ -111,6 +111,6 @@ describe 'datadog_integration' do
         local_wheel '/path/to/foo-bar.whl'
       end
     end
-    it { is_expected.to run_execute('integration install').with(command: '/opt/datadog-agent/bin/agent/agent integration install --local-wheel /path/to/foo-bar.whl') }
+    it { is_expected.to run_execute('integration install').with(command: '/opt/datadog-agent/bin/agent/agent integration install --local-wheel "/path/to/foo-bar.whl"') }
   end
 end


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.
-->
### What does this PR do?
The Integration resource uses a hardcoded and outdated (since Agent v6!) path for the executable.

This PR updates the `agent_exe_filepath` variable for Windows execution to get the Datadog Agent path from the Registry definition of the `DatadogAgent` service. This should work across all Datadog Agent versions.

This PR also adds a `local_wheel` parameter to add the capability to use a wheel file to install the package locally.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Testing a chef workbook installation for the [RapDev Marketplace Integration for Microsoft 365](https://docs.datadoghq.com/integrations/rapdev-o365/) on a Windows host failed.

There is also a desire to install integrations from offline sources, so adding the native `--local-wheel` parameter for installation was added.

### Additional Notes
Tested via a CINC solo run on a Windows development VM.

### Possible Drawbacks / Trade-offs
Regarding `local_wheel`, the agent has no method to perform verification, however the resource will still query if the version specified is installed before attempting installation.

Regarding the Windows executable path, there are still hard-coded references to `C:\Program Files\` throughout the cookbook, but I wanted to keep this PR simple.

A note that the existing hard-coded references break any behavior for machines that have installations that used the PROJECTLOCATION MSI parameter and/or the `APPLICATIONDATADIRECTORY` MSI parameter (`InstallPath` and `ConfigRoot` keys respectively in `HKLM:\SOFTWARE\Datadog\Datadog Agent`)

I would advise to fetch the existing installation parameters from the registry for future updates for maximum compatibility, or at the very least only use the existing environment variables for `ProgramFiles` and `ProgramData`.

Hard-coded `Program Files`
```
chef-datadog • libraries\recipe_helpers.rb:
  188      module WindowsInstallHelpers
  189:       WIN_BIN_PATH = 'C:/Program Files/Datadog/Datadog Agent/bin/agent'.freeze
  190  

chef-datadog • spec\recipe_helpers_spec.rb:
  41            .to receive(:exist?)
  42:           .with('C:/Program Files/Datadog/Datadog Agent/bin/agent')
  43            .and_return(false)
```

### Describe how to test/QA your changes

Since the CircleCI automated tests only Linux, for Windows hosts, I can only recommend testing a recipe defining to install an integration on a Windows host.

For marketplace integrations:
```ruby
  rd_O365_Ver = '3.0.1'

  datadog_integration 'datadog-o365' do
    version rd_O365_Ver
    third_party true
  end
```

For offline wheel files:
```ruby
  # Intentionally skipping some variable definitions
  ...
  rd_O365_Ver = '3.0.1'
  rd_O365_Whl_File = "datadog_o365-#{rd_O365_Ver}-py2.py3-none-any.whl"
  rd_O365_Whl_Path = "#{::File.join(Chef::Config[:file_cache_path], "#{rd_O365_Whl_File}")}"

  remote_file 'rapdev-o365-integration-whl' do
    source rd_O365_Source
    path rd_O365_Whl_Path
    action :create
  end

  datadog_integration 'datadog-o365' do
    version rd_O365_Ver
    local_wheel rd_O365_Whl_Path
  end
```

## Current behavior on Windows host:
### Error output on current resource definition:
```ruby
...
  * datadog_integration[datadog-o365] action install[2026-05-27T16:41:46-04:00] INFO: Processing datadog_integration[datadog-o365] action install (datadog_install::setup_datadog_integration line 23)

    * execute[integration install] action run[2026-05-27T16:41:46-04:00] INFO: Processing execute[integration install] action run (datadog_install::setup_datadog_integration line 41)

      [execute] The system cannot find the path specified.

      ================================================================================
      Error executing action `run` on resource 'execute[integration install]'
      ================================================================================

      Mixlib::ShellOut::ShellCommandFailed
      ------------------------------------
      Expected process to exit with [0], but received '1'
      ---- Begin output of "C:\Program Files\Datadog\Datadog Agent\embedded\agent.exe" integration install --third-party datadog-o365==3.0.1 ----
      STDOUT:
      STDERR: The system cannot find the path specified.
      ---- End output of "C:\Program Files\Datadog\Datadog Agent\embedded\agent.exe" integration install --third-party datadog-o365==3.0.1 ----
      Ran "C:\Program Files\Datadog\Datadog Agent\embedded\agent.exe" integration install --third-party datadog-o365==3.0.1 returned 1

      Cookbook Trace: (most recent call first)
      ----------------------------------------
      c:/users/user/desktop/chef/local-mode-cache/cache/cookbooks/datadog/resources/integration.rb:41:in `block in class_from_file'

      Resource Declaration:
      ---------------------
      # In c:/users/user/desktop/chef/local-mode-cache/cache/cookbooks/datadog/resources/integration.rb

       41:   execute 'integration install' do
       42:     # Space at the end of '--third-party ' is intentional, so that if --third-party is not specified, no additional space is added to the command line
       43:     command   "\"#{agent_exe_filepath}\" integration install #{'--third-party ' if new_resource.third_party}#{new_resource.property_name}==#{new_resource.version}"
       44:     user      'dd-agent' unless platform_family?('windows')
       45:
       46:     not_if {
       47:       output = shell_out("\"#{agent_exe_filepath}\" integration show -q #{new_resource.property_name}").stdout
       48:       output.strip == new_resource.version
       49:     }
       50:     notifies :restart, 'service[datadog-agent]' if node['datadog']['agent_start']
       51:   end
       52: end

      Compiled Resource:
      ------------------
      # Declared in c:/users/user/desktop/chef/local-mode-cache/cache/cookbooks/datadog/resources/integration.rb:41:in `block in class_from_file'

      execute("integration install") do
        action [:run]
        default_guard_interpreter :execute
        command "\"C:\\Program Files\\Datadog\\Datadog Agent\\embedded\\agent.exe\" integration install --third-party datadog-o365==3.0.1"
        declared_type :execute
        cookbook_name "datadog_install"
        recipe_name "setup_datadog_integration"
        not_if { #code block }
      end

      System Info:
      ------------
      chef_version=18.6.2
      platform=windows
      platform_version=10.0.22621
      ruby=ruby 3.1.6p260 (2024-05-29 revision a777087be6) [x64-mingw-ucrt]
      program_name=C:/cinc-project/cinc-workstation/bin/cinc-solo
      executable=C:/cinc-project/cinc-workstation/bin/cinc-solo


    ================================================================================
    Error executing action `install` on resource 'datadog_integration[datadog-o365]'
    ================================================================================

    Mixlib::ShellOut::ShellCommandFailed
    ------------------------------------
    execute[integration install] (datadog_install::setup_datadog_integration line 41) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
    ---- Begin output of "C:\Program Files\Datadog\Datadog Agent\embedded\agent.exe" integration install --third-party datadog-o365==3.0.1 ----
    STDOUT:
    STDERR: The system cannot find the path specified.
    ---- End output of "C:\Program Files\Datadog\Datadog Agent\embedded\agent.exe" integration install --third-party datadog-o365==3.0.1 ----
    Ran "C:\Program Files\Datadog\Datadog Agent\embedded\agent.exe" integration install --third-party datadog-o365==3.0.1 returned 1

    Cookbook Trace: (most recent call first)
    ----------------------------------------
    c:/users/user/desktop/chef/local-mode-cache/cache/cookbooks/datadog/resources/integration.rb:41:in `block in class_from_file'

    Resource Declaration:
    ---------------------
    # In c:/users/user/desktop/chef/local-mode-cache/cache/cookbooks/datadog_install/recipes/setup_datadog_integration.rb

     23:   datadog_integration 'datadog-o365' do
     24:     version "3.0.1"
     25:     third_party true
     26:   end
     27:

    Compiled Resource:
    ------------------
    # Declared in c:/users/user/desktop/chef/local-mode-cache/cache/cookbooks/datadog_install/recipes/setup_datadog_integration.rb:23:in `from_file'

    datadog_integration("datadog-o365") do
      action [:install]
      default_guard_interpreter :default
      declared_type :datadog_integration
      cookbook_name "datadog_install"
      recipe_name "setup_datadog_integration"
      version "3.0.1"
      third_party true
      property_name "datadog-o365"
    end

    System Info:
    ------------
    chef_version=18.6.2
    platform=windows
    platform_version=10.0.22621
    ruby=ruby 3.1.6p260 (2024-05-29 revision a777087be6) [x64-mingw-ucrt]
    program_name=C:/cinc-project/cinc-workstation/bin/cinc-solo
    executable=C:/cinc-project/cinc-workstation/bin/cinc-solo
```

## PR change behavior on Windows host:
### Successful `install` output when not installed for online installation:
```ruby
...
Recipe: datadog_install::setup_datadog_integration
  * chef_gem[berkshelf] action nothing[2026-05-27T16:45:35-04:00] INFO: Processing chef_gem[berkshelf] action nothing (datadog_install::setup_datadog_integration line 15)
 (skipped due to action :nothing)
  * datadog_integration[datadog-o365] action install[2026-05-27T16:45:35-04:00] INFO: Processing datadog_integration[datadog-o365] action install (datadog_install::setup_datadog_integration line 23)

    * execute[integration install] action run[2026-05-27T16:45:35-04:00] INFO: Processing execute[integration install] action run (datadog_install::setup_datadog_integration line 41)

      [execute] C:/Program Files/Datadog/Datadog Agent/embedded3/Lib/site-packages/datadog_checks/downloader/data/repo/targets/simple/datadog-o365/datadog_o365-3.0.1-py2.py3-none-any.whl
                Processing .\Program Files\Datadog\Datadog Agent\embedded3\Lib\site-packages\datadog_checks\downloader\data\repo\targets\simple\datadog-o365\datadog_o365-3.0.1-py2.py3-none-any.whl
                Installing collected packages: datadog-o365
                Successfully installed datadog-o365-3.0.1
                Successfully copied configuration file conf.yaml.example
                Successfully installed datadog-o365 3.0.1
[2026-05-27T16:45:40-04:00] INFO: execute[integration install] ran successfully
      - execute "C:\Program Files\Datadog\Datadog Agent\bin\agent.exe" integration install --third-party datadog-o365==3.0.1

[2026-05-27T16:45:40-04:00] INFO: execute[integration install] sending restart action to windows_service[datadog-agent] (delayed)
Recipe: datadog::dd-agent
  * windows_service[datadog-agent] action restart[2026-05-27T16:45:40-04:00] INFO: Processing windows_service[datadog-agent] action restart (datadog::dd-agent line 141)
[2026-05-27T16:45:43-04:00] INFO: windows_service[datadog-agent] restarted

    - restart service windows_service[datadog-agent]
...
``` 
### Successful `not_if` output when already installed for online installation:
```ruby
...
Recipe: datadog_install::setup_datadog_integration
  * chef_gem[berkshelf] action nothing[2026-05-27T16:46:09-04:00] INFO: Processing chef_gem[berkshelf] action nothing (datadog_install::setup_datadog_integration line 15)
 (skipped due to action :nothing)
  * datadog_integration[datadog-o365] action install[2026-05-27T16:46:09-04:00] INFO: Processing datadog_integration[datadog-o365] action install (datadog_install::setup_datadog_integration line 23)

    * execute[integration install] action run[2026-05-27T16:46:09-04:00] INFO: Processing execute[integration install] action run (datadog_install::setup_datadog_integration line 41)
 (skipped due to not_if)
     (up to date)
...
```

### Successful `install` output when not installed for `local_wheel` installation:
```ruby
PS C:\Users\User\Desktop\chef> & "$Env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" integration remove datadog-o365
Found existing installation: datadog-o365 3.0.1
Uninstalling datadog-o365-3.0.1:
  Successfully uninstalled datadog-o365-3.0.1
PS C:\Users\User\Desktop\chef> cinc-solo --config solo.rb --json-attributes dna.json | Select-string -Pattern 'integration install' -Context 10

  Recipe: datadog::install_info
    * template[C:\ProgramData/Datadog/install_info] action create[2026-05-28T09:58:27-04:00] INFO: Processing template[C:\ProgramData/Datadog/install_info] action create (datadog::install_info line 34)
   (up to date)
  Recipe: datadog_install::setup_datadog_integration
    * chef_gem[berkshelf] action nothing[2026-05-28T09:58:27-04:00] INFO: Processing chef_gem[berkshelf] action nothing (datadog_install::setup_datadog_integration line 16)
   (skipped due to action :nothing)
    * remote_file[rapdev-o365-integration-whl] action create[2026-05-28T09:58:27-04:00] INFO: Processing remote_file[rapdev-o365-integration-whl] action create (datadog_install::setup_datadog_integration line 24)
   (up to date)
    * datadog_integration[datadog-o365] action install[2026-05-28T09:58:28-04:00] INFO: Processing datadog_integration[datadog-o365] action install (datadog_install::setup_datadog_integration line 35)

>     * execute[integration install] action run[2026-05-28T09:58:28-04:00] INFO: Processing execute[integration install] action run (datadog_install::setup_datadog_integration line 51)

        [execute] For your security, only use this to install wheels containing an Agent integration and coming from a known source. The Agent cannot perform any verification on local wheels.
                  Processing .\users\user\desktop\chef\local-mode-cache\cache\datadog_o365-3.0.1-py2.py3-none-any.whl
                  Installing collected packages: datadog-o365
                  Successfully installed datadog-o365-3.0.1
                  Successfully copied configuration file conf.yaml.example
                  Successfully completed the installation of datadog-o365
> [2026-05-28T09:58:30-04:00] INFO: execute[integration install] ran successfully
>       - execute "C:\Program Files\Datadog\Datadog Agent\bin\agent.exe" integration install --local-wheel "c:\users\user\desktop\chef\local-mode-cache\cache/datadog_o365-3.0.1-py2.py3-none-any.whl"

> [2026-05-28T09:58:30-04:00] INFO: execute[integration install] sending restart action to windows_service[datadog-agent] (delayed)
  Recipe: datadog::dd-agent
    * windows_service[datadog-agent] action restart[2026-05-28T09:58:30-04:00] INFO: Processing windows_service[datadog-agent] action restart (datadog::dd-agent line 141)
  [2026-05-28T09:58:33-04:00] INFO: windows_service[datadog-agent] restarted

      - restart service windows_service[datadog-agent]
  [2026-05-28T09:58:33-04:00] INFO: Cinc Client Run complete in 10.6659256 seconds

  Running handlers:
  [2026-05-28T09:58:33-04:00] INFO: Running report handlers
  Running handlers complete
```

### Successful `not_if` output when already installed for `local_wheel` installation:
```ruby
PS C:\Users\User\Desktop\chef> cinc-solo --config solo.rb --json-attributes dna.json | Select-string -Pattern 'integration install' -Context 10

  Recipe: datadog::install_info
    * template[C:\ProgramData/Datadog/install_info] action create[2026-05-28T09:58:58-04:00] INFO: Processing template[C:\ProgramData/Datadog/install_info] action create (datadog::install_info line 34)
   (up to date)
  Recipe: datadog_install::setup_datadog_integration
    * chef_gem[berkshelf] action nothing[2026-05-28T09:58:58-04:00] INFO: Processing chef_gem[berkshelf] action nothing (datadog_install::setup_datadog_integration line 16)
   (skipped due to action :nothing)
    * remote_file[rapdev-o365-integration-whl] action create[2026-05-28T09:58:58-04:00] INFO: Processing remote_file[rapdev-o365-integration-whl] action create (datadog_install::setup_datadog_integration line 24)
   (up to date)
    * datadog_integration[datadog-o365] action install[2026-05-28T09:58:58-04:00] INFO: Processing datadog_integration[datadog-o365] action install (datadog_install::setup_datadog_integration line 35)

>     * execute[integration install] action run[2026-05-28T09:58:58-04:00] INFO: Processing execute[integration install] action run (datadog_install::setup_datadog_integration line 51)
   (skipped due to not_if)
       (up to date)
  [2026-05-28T09:58:59-04:00] INFO: Cinc Client Run complete in 5.1517284 seconds

  Running handlers:
  [2026-05-28T09:58:59-04:00] INFO: Running report handlers
  Running handlers complete
  [2026-05-28T09:58:59-04:00] INFO: Report handlers complete
  Infra Phase complete, 0/18 resources updated in 09 seconds
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

<!--
### Reviewer's Checklist

* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
Note: Adding GitHub labels is only possible for contributors with write access.
-->
